### PR TITLE
Use Bintray's JCenter repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ this plugin provides a task to determine which dependencies have updates.
 
 ## Usage
 
-This plugin is available from a Maven repository hosted on GitHub. You can add it to your build script using
+This plugin is available from Bintray's JCenter repository. You can add it to your build script using
 the following configuration:
 
 ```groovy
@@ -13,12 +13,11 @@ apply plugin: 'versions'
 
 buildscript {
   repositories {
-    maven { url "https://github.com/ben-manes/gradle-versions-plugin/raw/mvnrepo" }
-    mavenCentral()
+    jcenter()
   }
   
   dependencies {
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.5-beta-1'
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.4'
   }
 }
 ```


### PR DESCRIPTION
All public releases are available from https://bintray.com/ben-manes/maven/com.github.ben-manes:gradle-versions-plugin which is linked to JCenter. Thus is easier to remember to use Gradle's `jcenter()` repo block; also friendlier to organizations that only allow access to jcenter and/or maven central.

I've seen that all available versions (0.1 up to 0.4) are also available at maven central; so I guess is a toss between `jcenter()` and `mavenCentral()` but the former is faster :wink:
