### PR TITLE
Fixed "Null Pointer Exception" for dependency without version

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -108,13 +108,18 @@ class DependencyUpdates {
    * Returns the version that is used for the given dependency. Resolves dynamic versions (e.g. '1.+') to actual version numbers
    */
   private def resolveActualDependencyVersion(Dependency dependency) {
+
+    if (!dependency.version) {
+      return ""
+    }
+
     def version = dependency.version
     boolean mightBeDynamicVersion = version.endsWith('+') || version.endsWith(']') || version.endsWith(')') || version.startsWith('latest.')
     if (!mightBeDynamicVersion){
       project.logger.info("Dependency {} does not use a dynamic version", dependency)
       return version
     }
-    
+
     def actualVersion = resolveWithAllRepositories{
       project.configurations.detachedConfiguration(dependency).resolvedConfiguration.lenientConfiguration
       .getFirstLevelModuleDependencies(SATISFIES_ALL).find()?.moduleVersion ?: version


### PR DESCRIPTION
Fixed "Null Pointer Exception" for dependencies without version, eg.

```
compile group: 'org.hibernate', name: 'hibernate-validator'
compile("org.springframework.boot:spring-boot-starter-actuator")
```
