### PR TITLE
Have 'dependencyUpdates' task force evaluation of all childprojects

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -44,6 +44,8 @@ class DependencyUpdatesTask extends DefaultTask {
 
   @TaskAction
   def dependencyUpdates() {
+    project.evaluationDependsOnChildren()
+
     def evaluator = new DependencyUpdates(project, revisionLevel(), outputFormatterProp(), outputDirectory())
     DependencyUpdatesReporter reporter = evaluator.run()
     reporter?.write()


### PR DESCRIPTION
Hi,
I'm using gradle with the incubating 'configureOnDemand' option on, to achieve a speedup on the bigger projects.

Right now your plugin collects all dependencies from all projects in the current build and evaluates them with all repositories found anywhere. (Which I took to mean, the plugin should be applied to the root project only, otherwise stuff would be done redundantly)

WIth 'configureOnDemand' which is slated to become default, only needed projects are evaluated, meaning dependencies from children can only be read if they, by chance, were already configured.
This is the case for "gradle dependencyUpdates", but not for example for "gradle :dependencyUpdates"

The Gradle-Api allows calls to evaluationDependsOn...() inside task actions, which would make your plugin future proof.

Ramon