### PR TITLE
Fix for Gradle 1.12

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -53,7 +53,7 @@ class DependencyUpdates {
     Map<Project, Set<Configuration>> projectConfigs = project.allprojects.collectEntries { proj ->
       [proj, proj.configurations.plus(proj.buildscript.configurations) as Set]
     }
-    Set<DependencyStatus> status = projectConfigs.collectMany { proj, configurations ->
+    Set<DependencyStatus> status = projectConfigs.collect { proj, configurations ->
       Resolver resolver = new Resolver(proj, resolutionStrategy)
       return configurations.collectMany { config ->
         try {
@@ -64,7 +64,7 @@ class DependencyUpdates {
           return []
         }
       }
-    } as Set
+    }.flatten() as Set
 
     VersionMapping versions = new VersionMapping(project, status)
     Set<UnresolvedDependency> unresolved =

--- a/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -73,6 +73,6 @@ public class DifferentGradleVersionsSpec extends Specification {
     srdErrWriter.toString().empty
 
     where:
-    gradleVersion << ['2.0', '3.3']
+    gradleVersion << ['1.12', '2.0', '3.3']
   }
 }


### PR DESCRIPTION
The plugin does not run with Gradle 1.12 anymore. It also fails for earlier versions, but let's take one step at a time.