### PR TITLE
Test against the most recent releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ buildscript {
 }
 ```
 
-The current version is known to work with Gradle versions up to 4.0-rc1.
+The current version is known to work with Gradle versions up to 4.2-rc-2.
 
 ## Tasks
 

--- a/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -80,7 +80,9 @@ public class DifferentGradleVersionsSpec extends Specification {
       '3.3',
       '3.4',
       '3.5',
-      '4.0-rc-1'
+      '4.0',
+      '4.1',
+      '4.2-rc-2'
     ]
   }
 }


### PR DESCRIPTION
Make sure that the plug-in works with Gradle 4.1 and 4.2 (RC)