### PR TITLE
Basic implementation of Gradle update checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 In the spirit of the [Maven Versions Plugin](http://www.mojohaus.org/versions-maven-plugin/),
 this plugin provides a task to determine which dependencies have updates.
+Additionally, the plugin checks for updates to Gradle itself.
 
 You may also wish to explore additional functionality provided by,
  - [gradle-use-latest-versions](https://github.com/patrikerdes/gradle-use-latest-versions-plugin)
@@ -47,7 +48,12 @@ The current version is known to work with Gradle versions up to 4.6.
 
 Displays a report of the project dependencies that are up-to-date, exceed the latest version found,
 have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
-logged at the `info` level.
+logged at the `info` level.  
+Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels.
+The plaintext report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds).
+The xml and json reports include information about all three release channels, whether a release is considered an update
+with respect to the running (executing) gradle instance, whether an update check on on a release channel has failed, as
+well as a reason field explaining failures or missing information.
 
 #### Revisions
 
@@ -118,6 +124,9 @@ This displays a report to the console, e.g.
 : Project Dependency Updates (report to plain text file)
 ------------------------------------------------------------
 
+Gradle updates:
+- Gradle: [4.6 -> 4.7 -> 4.8-rc-2]
+
 The following dependencies are using the latest integration version:
  - backport-util-concurrent:backport-util-concurrent:3.1
  - backport-util-concurrent:backport-util-concurrent-java12:3.1
@@ -154,6 +163,32 @@ Json report
       }
     ],
     "count": 2
+  },
+  "gradle": {
+    "current": {
+      "version": "4.7",
+      "reason": "",
+      "isUpdateAvailable": true,
+      "isFailure": false
+    },
+    "nightly": {
+      "version": "4.9-20180526235939+0000",
+      "reason": "",
+      "isUpdateAvailable": true,
+      "isFailure": false
+    },
+    "releaseCandidate": {
+      "version": "4.8-rc-2",
+      "reason": "",
+      "isUpdateAvailable": true,
+      "isFailure": false
+    },
+    "running": {
+      "version": "4.6",
+      "reason": "",
+      "isUpdateAvailable": false,
+      "isFailure": false
+    }
   },
   "exceeded": {
     "dependencies": [
@@ -302,6 +337,32 @@ XML report
       </unresolvedDependency>
     </dependencies>
   </unresolved>
+  <gradle>
+    <running>
+      <version>4.6</version>
+      <isUpdateAvailable>false</isUpdateAvailable>
+      <isFailure>false</isFailure>
+      <reason></reason>
+    </running>
+    <current>
+      <version>4.7</version>
+      <isUpdateAvailable>true</isUpdateAvailable>
+      <isFailure>false</isFailure>
+      <reason></reason>
+    </current>
+    <releaseCandidate>
+      <version>4.8-rc-2</version>
+      <isUpdateAvailable>true</isUpdateAvailable>
+      <isFailure>false</isFailure>
+      <reason></reason>
+    </releaseCandidate>
+    <nightly>
+      <version>4.9-20180526235939+0000</version>
+      <isUpdateAvailable>true</isUpdateAvailable>
+      <isFailure>false</isFailure>
+      <reason></reason>
+    </nightly>
+  </gradle>
 </response>
 ```
 

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/result/Result.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/result/Result.groovy
@@ -1,5 +1,6 @@
 package com.github.benmanes.gradle.versions.reporter.result
 
+import com.github.benmanes.gradle.versions.updates.gradle.GradleUpdateResults
 import groovy.transform.TupleConstructor
 
 /**
@@ -28,4 +29,8 @@ class Result {
    * The unresolvable dependencies
    */
   DependenciesGroup<DependencyUnresolved> unresolved
+  /**
+   * Gradle release channels and respective update availability
+   */
+  GradleUpdateResults gradle
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.benmanes.gradle.versions.updates
 
+import com.github.benmanes.gradle.versions.updates.gradle.GradleUpdateChecker
 import groovy.transform.TupleConstructor
 import groovy.transform.TypeChecked
 import org.gradle.api.Project
@@ -79,9 +80,12 @@ class DependencyUpdates {
     Map<Map<String, String>, String> downgradeVersions = toMap(versions.downgrade)
     Map<Map<String, String>, String> upgradeVersions = toMap(versions.upgrade)
 
+    // Check for Gradle updates.
+    GradleUpdateChecker gradleUpdateChecker = new GradleUpdateChecker()
+
     return new DependencyUpdatesReporter(project, revision, outputFormatter, outputDir, reportfileName,
       currentVersions, latestVersions, upToDateVersions, downgradeVersions, upgradeVersions,
-      unresolved, projectUrls)
+      unresolved, projectUrls, gradleUpdateChecker)
   }
 
   private static Map<Map<String, String>, String> toMap(Set<Coordinate> coordinates) {

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleReleaseChannel.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleReleaseChannel.groovy
@@ -1,0 +1,16 @@
+package com.github.benmanes.gradle.versions.updates.gradle
+
+/**
+ * Enum class that represents the available Gradle release channels and their ids in the api url
+ */
+enum GradleReleaseChannel {
+  CURRENT('current'),
+  RELEASE_CANDIDATE('release-candidate'),
+  NIGHTLY('nightly')
+
+  final String id
+  private GradleReleaseChannel(String id) {
+    this.id = id
+  }
+
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateChecker.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateChecker.groovy
@@ -1,0 +1,104 @@
+package com.github.benmanes.gradle.versions.updates.gradle
+
+import groovy.json.JsonException
+import groovy.json.JsonSlurper
+import groovy.transform.PackageScope
+import org.gradle.util.GradleVersion
+
+/**
+ * Facade class that provides information about the running gradle version and the latest versions of the different
+ * gradle release channels. The information is queried from the official gradle api via HTTPS during object construction.
+ *
+ * @see GradleReleaseChannel
+ */
+class GradleUpdateChecker {
+
+  private static final String API_BASE_URL = 'https://services.gradle.org/versions/'
+
+  private final Map<GradleReleaseChannel, ReleaseStatus> cacheMap = new EnumMap<>(GradleReleaseChannel.class)
+
+  GradleUpdateChecker() {
+    GradleReleaseChannel.values().each {
+      try {
+        def versionObject = new JsonSlurper().parse(new URL(API_BASE_URL + it.id))
+        if (versionObject.version) {
+          cacheMap.put(it, new ReleaseStatus.Available(GradleVersion.version(versionObject.version as String)))
+        } else {
+          cacheMap.put(it, new ReleaseStatus.Unavailable())
+        }
+      } catch (JsonException e) {
+        // JsonSlurper throws JsonException for all types of parsing failures (including I/O exceptions).
+        cacheMap.put(it, new ReleaseStatus.Failure(e.getMessage()))
+      }
+    }
+  }
+
+  /**
+   * @return An instance of
+   * {@link com.github.benmanes.gradle.versions.updates.gradle.GradleUpdateChecker.ReleaseStatus.Available} containing a
+   * {@link GradleVersion} representing the version of the running gradle instance
+   */
+  static ReleaseStatus.Available getRunningGradleVersion() {
+    return new ReleaseStatus.Available(GradleVersion.current())
+  }
+
+  /**
+   * @return An instance of {@link ReleaseStatus} explaining the update check for the latest version on the 'current'
+   * gradle release channel.
+   */
+  ReleaseStatus getCurrentGradleVersion() {
+    return cacheMap.get(GradleReleaseChannel.CURRENT)
+  }
+
+  /**
+   * @return An instance of {@link ReleaseStatus} explaining the update check for the latest version on the
+   * 'release-candidate' gradle release channel.
+   */
+  ReleaseStatus getReleaseCandidateGradleVersion() {
+    return cacheMap.get(GradleReleaseChannel.RELEASE_CANDIDATE)
+  }
+
+  /**
+   * @return An instance of {@link ReleaseStatus} explaining the update check for the latest version on the 'nightly'
+   * gradle release channel.
+   */
+  ReleaseStatus getNightlyGradleVersion() {
+    return cacheMap.get(GradleReleaseChannel.NIGHTLY)
+  }
+
+  /**
+   * Abstract class representing the possible states of a release channel after an update check.
+   */
+  @PackageScope
+  static abstract class ReleaseStatus {
+    /**
+     * Class representing an available release. Holds the release version in the form of a {@link GradleVersion}.
+     */
+    @PackageScope
+    static class Available extends ReleaseStatus {
+      final GradleVersion gradleVersion
+      private Available(GradleVersion gradleVersion) {
+        this.gradleVersion = gradleVersion
+      }
+    }
+
+    /**
+     * Class representing a release channel without any releases. This may be the case with pre-release channels after
+     * an update has been released to general availability.
+     */
+    @PackageScope
+    static class Unavailable extends ReleaseStatus {}
+
+    /**
+     * Class representing a failure during update checking.
+     */
+    @PackageScope
+    static class Failure extends ReleaseStatus {
+      final String reason
+      private Failure(reason) {
+        this.reason = reason
+      }
+    }
+  }
+
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResult.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResult.groovy
@@ -1,0 +1,67 @@
+package com.github.benmanes.gradle.versions.updates.gradle
+
+import org.gradle.util.GradleVersion
+
+/**
+ * Holder class for gradle update results of a specific release channel (or the running version).
+ * Used for reporting & serialization to JSON/XML
+ */
+class GradleUpdateResult implements Comparable<GradleUpdateResult> {
+
+  /**
+   * Comparator that compares two instances of {@link GradleUpdateResult} by comparing the {@link GradleVersion} they
+   * represent
+   */
+  private static final Comparator<GradleUpdateResult> comparator = Comparator.comparing { gradleUpdateResult -> GradleVersion.version(gradleUpdateResult.version) }
+
+  /**
+   * The version available on the release channel represented by this object.
+   */
+  final String version
+  /**
+   * Indicates whether the {@link #version} is an update with respect to the currently running gradle version.
+   */
+  final boolean isUpdateAvailable
+  /**
+   * Indicates whether the check for Gradle updates on this release channel failed.
+   */
+  final boolean isFailure
+  /**
+   * An explanatory field on how to interpret the results. Useful when {@link #version} is not set to a valid value.
+   */
+  final String reason
+
+  GradleUpdateResult(GradleUpdateChecker.ReleaseStatus.Available running, GradleUpdateChecker.ReleaseStatus release) {
+    if (release instanceof GradleUpdateChecker.ReleaseStatus.Available) {
+      this.version = release.gradleVersion.version
+      this.isUpdateAvailable = release.gradleVersion > running.gradleVersion
+      this.isFailure = false
+      this.reason = "" // empty string so the field is serialized
+    } else if (release instanceof GradleUpdateChecker.ReleaseStatus.Unavailable) {
+      this.version = "" // empty string so the field is serialized
+      this.isUpdateAvailable = false
+      this.isFailure = false
+      this.reason = "update check succeeded: no release available"
+    } else if (release instanceof GradleUpdateChecker.ReleaseStatus.Failure) {
+      this.version = "" // empty string so the field is serialized
+      this.isUpdateAvailable = false
+      this.isFailure = true
+      this.reason = release.reason
+    } else {
+      throw new IllegalStateException("ReleaseStatus subtype [" + release.class + "] not yet implemented")
+    }
+  }
+
+  /**
+   * Compares two instances of {@link GradleUpdateResult}.
+   * @throws IllegalArgumentException when one of the {@link GradleUpdateResult}s does not represent a valid
+   * {@link GradleVersion}. This may be the case when a {@link GradleUpdateResult} represents a failure.
+   * @param o
+   * @return an integer as specified by {@link Comparable#compareTo(java.lang.Object)}
+   */
+  @Override
+  int compareTo(GradleUpdateResult o) {
+    return comparator.compare(this, o)
+  }
+
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResults.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResults.groovy
@@ -1,0 +1,17 @@
+package com.github.benmanes.gradle.versions.updates.gradle
+
+import groovy.transform.TupleConstructor
+
+/**
+ * Wrapper holder class for gradle update results of all release channel (including the running version).
+ * Used for reporting & serialization to JSON/XML
+ */
+@TupleConstructor
+class GradleUpdateResults {
+
+  GradleUpdateResult running
+  GradleUpdateResult current
+  GradleUpdateResult releaseCandidate
+  GradleUpdateResult nightly
+
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -60,8 +60,6 @@ final class DifferentGradleVersionsSpec extends BaseSpecification {
 
     where:
     gradleVersion << [
-      '1.5',
-      '1.12',
       '2.0',
       '3.3',
       '3.4',


### PR DESCRIPTION
This pull request modifies the plugin to also query information from the public gradle releases api (https://services.gradle.org/versions/) as requested & discussed in https://github.com/ben-manes/gradle-versions-plugin/issues/76
It integrates the results of the gradle version checks into the existing `Result` object which makes it compatible with the automated JSON and XML exporters. The PlainTextReporter has been updated to output the Gradle Releases accordingly.

The magic sauce behind the entire thing is the class `org.gradle.util.GradleVersion`, which as it turns out implements `Comparable`, so I didnt have to deal with any Regex or string manipulation shenanigans to compare versions. And it also provides a static getter for the currently running version.

There are still a few things to do / to discuss before this should be considered to be merged:
- [x] Version number bump to 0.18.0 ok? -> no
- [x] consolidate Cache classes into UpdateChecker class
- [x] GroovyDoc comments
- [x] The implementation does not deal with errors / connection failures at the moment / check for `--offline` flag -> done. deals with errors. offline flag only affects gradle-internal artifact resolvers.
- [x] Fix Scopes / condense scope annotations
- [ ] Tests
- [x] Is it necessary to add new aliases to the XML Serializer? -> doesn't look like it
- [x] I used an enum with a constructor to hold the different release channels and their associated url information. This seems to break Tests on Gradle 1.x, which may be caused by the Groovy 1.8 runtime. Gradle 2.x executes tests without failure (maybe because it uses Groovy 2.3). When deciding how to proceed here, it should also be noted that Gradle 5.0 will remove support for running Gradle Builds older than 2.6. (verbatim output: `Support for builds using Gradle older than 2.6 was deprecated and will be removed in 5.0. You are currently using Gradle version 1.5. You should upgrade your Gradle build to use Gradle 2.6 or later.`) Other possible solution: check for gradle version before executing gradle update checking? -> removed tests running on Gradle 1.x
- [x] At the moment I have the gradle releases api url hardcoded, which means that the tests and each execution of the task will always try to connect to the gradle api for each time the task is executed (see backwards compatibility test). -> won't change
- [x] Put the download url to the releases in the report? (Personally, I don't download the distributions manually but update the wrapper task and execute a build so I wouldn't need this) -> not for now
- [x] remove nightly (only from TextReporter?) -> done
- [x] breadcrumb format for TextReporter (each arrow points towards a newer version than on the left side of the arrow) -> done
- [x] Update readme with information & examples -> done
- [x] License text for new files -> no because not practice in the rest of the project
- [x] squash commits in pull request -> done

Examples for how this looks in the output: (source formatting in Github text does not preserve spaces)
1. PlainTextReporter:
`------------------------------------------------------------`
`: Project Dependency Updates (report to plain text file)`
`------------------------------------------------------------`
` `
`Gradle release channels:`
`Running Gradle version: 4.6`
`- 'current' channel: [4.6] UP-TO-DATE`
`- 'release-candidate' channel: [4.6 -> 4.7-rc-2]`
`- 'nightly' channel: [4.6 -> 4.8-20180414000021+0000]`

2. JSON Reporter:
`{`
`    "current": { ... },`
`    "gradle": {`
`        "current": {`
`            "version": "4.6",`
`            "isUpdateAvailable": false`
`        },`
`        "nightly": {`
`            "version": "4.8-20180414000021+0000",`
`            "isUpdateAvailable": true`
`        },`
`        "releaseCandidate": {`
`            "version": "4.7-rc-2",`
`            "isUpdateAvailable": true`
`        },`
`        "running": {`
`            "version": "4.6",`
`            "isUpdateAvailable": false`
`        }`
`    },`
`    "exceeded": { ... },`
`    "outdated": { ... },`
`    "unresolved": { ... },`
`    "count": 4`
`}`

3. XML Reporter:
`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
`<response>`
`  <count>4</count>`
`  <current> ... </current>`
`  <outdated> ... </outdated>`
`  <exceeded> ... </exceeded>`
`  <unresolved> ... </unresolved>`
`  <gradle>`
`    <running>`
`      <version>4.6</version>`
`      <isUpdateAvailable>false</isUpdateAvailable>`
`    </running>`
`    <current>`
`      <version>4.6</version>`
`      <isUpdateAvailable>false</isUpdateAvailable>`
`    </current>`
`    <releaseCandidate>`
`      <version>4.7-rc-2</version>`
`      <isUpdateAvailable>true</isUpdateAvailable>`
`    </releaseCandidate>`
`    <nightly>`
`      <version>4.8-20180414000021+0000</version>`
`      <isUpdateAvailable>true</isUpdateAvailable>`
`    </nightly>`
`  </gradle>`
`</response>`
