### PR TITLE
Custom filename for reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,18 @@ You can also set multiple output formats using comma as the separator:
 gradle dependencyUpdates -Drevision=release -DoutputFormatter=json,xml
 ```
 
-Last, the task property `outputDir` controls the output directory for the report  file(s). The directory will be created if it does not exist.
+The task property `outputDir` controls the output directory for the report  file(s). The directory will be created if it does not exist.
 The default value is set to `build/dependencyUpdates`
 
 ```groovy
 gradle dependencyUpdates -Drevision=release -DoutputFormatter=json -DoutputDir=/any/path/with/permission
+```
+
+Last the property `reportfileName` sets the filename (without extension) of the generated report. It defaults to `report`.
+The extension will be set according to the used output format.
+
+```groovy
+gradle dependencyUpdates -Drevision=release -DoutputFormatter=json -DreportfileName=myCustomReport
 ```
 
 This displays a report to the console, e.g.

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/JsonReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/JsonReporter.groovy
@@ -17,7 +17,7 @@ class JsonReporter extends AbstractReporter {
   }
 
   @Override
-  def getFileName() {
-    return 'report.json'
+  def getFileExtension() {
+    return 'json'
   }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.groovy
@@ -47,8 +47,8 @@ class PlainTextReporter extends AbstractReporter {
   }
 
   @Override
-  def getFileName() {
-    return 'report.txt'
+  def getFileExtension() {
+    return 'txt'
   }
 
   private def writeHeader(printStream) {

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/Reporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/Reporter.groovy
@@ -15,5 +15,5 @@ interface Reporter {
    */
   def write(target, Result result)
 
-  def getFileName()
+  def getFileExtension()
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/XmlReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/XmlReporter.groovy
@@ -37,7 +37,7 @@ class XmlReporter extends AbstractReporter {
   }
 
   @Override
-  def getFileName() {
-    return 'report.xml'
+  def getFileExtension() {
+    return 'xml'
   }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -39,6 +39,7 @@ class DependencyUpdates {
   String revision
   Object outputFormatter
   String outputDir
+  String reportfileName
 
   /** Evaluates the dependencies and returns a reporter. */
   DependencyUpdatesReporter run() {
@@ -78,7 +79,7 @@ class DependencyUpdates {
     Map<Map<String, String>, String> downgradeVersions = toMap(versions.downgrade)
     Map<Map<String, String>, String> upgradeVersions = toMap(versions.upgrade)
 
-    return new DependencyUpdatesReporter(project, revision, outputFormatter, outputDir,
+    return new DependencyUpdatesReporter(project, revision, outputFormatter, outputDir, reportfileName,
       currentVersions, latestVersions, upToDateVersions, downgradeVersions, upgradeVersions,
       unresolved, projectUrls)
   }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
@@ -46,6 +46,8 @@ class DependencyUpdatesReporter {
   Object outputFormatter
   /** The outputDir for report. */
   String outputDir
+  /** The filename of the report file. */
+  String reportfileName
 
   /** The current versions of each dependency declared in the project(s). */
   Map<Map<String, String>, String> currentVersions
@@ -94,7 +96,7 @@ class DependencyUpdatesReporter {
   }
 
   def generateFileReport(Reporter reporter) {
-    String filename = outputDir + File.separator + reporter.getFileName()
+    String filename = outputDir + File.separator + reportfileName + '.' + reporter.getFileExtension()
     try {
       project.file(outputDir).mkdirs()
       File outputFile = project.file(filename)

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -35,6 +35,9 @@ class DependencyUpdatesTask extends DefaultTask {
     "${project.buildDir.path.replace(project.projectDir.path + '/', '')}/dependencyUpdates"
 
   @Input @Optional
+  String reportfileName = 'report'
+
+  @Input @Optional
   String getOutputFormatterName() {
     return (outputFormatter instanceof String) ? ((String) outputFormatter) : null
   }
@@ -54,7 +57,7 @@ class DependencyUpdatesTask extends DefaultTask {
     project.evaluationDependsOnChildren()
 
     def evaluator = new DependencyUpdates(project, resolutionStrategy,
-      revisionLevel(), outputFormatterProp(), outputDirectory())
+      revisionLevel(), outputFormatterProp(), outputDirectory(), getReportfileName())
     DependencyUpdatesReporter reporter = evaluator.run()
     reporter?.write()
   }
@@ -67,4 +70,7 @@ class DependencyUpdatesTask extends DefaultTask {
 
   /** Returns the outputDir destination. */
   String outputDirectory() { System.properties['outputDir'] ?: outputDir }
+
+  /** Returns the filename of the report. */
+  String getReportfileName() { System.properties.get('reportfileName', reportfileName) }
 }


### PR DESCRIPTION
This PR holds the option to specify the name of the generated report file.
It doesn't use gradle's build-in report features but for now does the job.

Its closes #225 und was inspired by #48 

I thought about a way to test the `reportfileName` option, but without success. If you have something in your mind about it or any remarks on the changes feel free to write.