### PR TITLE
Explain multi-project builds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Displays a report of the project dependencies that are up-to-date, exceed the la
 have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
 logged at the `info` level.
 
+#### Multi-project build
+
+In a multi-project build, running this task in the root project will generate a consolidated/merged
+report for dependency updates in all subprojects. Alternatively, you can run the task separately in
+each subproject to generate separate reports for each subproject.
+
 #### Revisions
 
 The `revision` task property controls the resolution strategy of determining what constitutes the


### PR DESCRIPTION
The README doesn't mention how dependencyUpdates works in multi-project builds.
I was running it separately in each subproject, when what I actually wanted was just to
run it in the root project – but I wasn't aware the later worked. So, add some text to the
README so others aren't confused like I was.