### PR TITLE
Add flag to disable gradle update check (fixes #241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Displays a report of the project dependencies that are up-to-date, exceed the la
 have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
 logged at the `info` level.
 
-Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels.
-The plaintext report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds).
-The xml and json reports include information about all three release channels, whether a release is considered an update
-with respect to the running (executing) gradle instance, whether an update check on on a release channel has failed, as
-well as a reason field explaining failures or missing information.
+Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels. The plaintext
+report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds). The xml and json
+reports include information about all three release channels, whether a release is considered an update with respect to
+the running (executing) gradle instance, whether an update check on on a release channel has failed, as well as a reason
+field explaining failures or missing information. The update check may be disabled using the `checkForGradleUpdate` flag.
 
 #### Multi-project build
 
@@ -172,7 +172,7 @@ The following dependencies have later integration versions:
      http://code.google.com/p/google-guice/
 
 Gradle updates:
-- Gradle: [4.6 -> 4.7 -> 4.8-rc-2]
+ - Gradle: [4.6 -> 4.7 -> 4.8-rc-2]
 ```
 
 Json report
@@ -196,6 +196,7 @@ Json report
     "count": 2
   },
   "gradle": {
+    "enabled": true,
     "current": {
       "version": "4.7",
       "reason": "",
@@ -369,6 +370,7 @@ XML report
     </dependencies>
   </unresolved>
   <gradle>
+    <enabled>true</enabled>
     <running>
       <version>4.6</version>
       <isUpdateAvailable>false</isUpdateAvailable>

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -29,14 +29,17 @@ configurations {
   unresolvable2
 }
 
-dependencyUpdates.resolutionStrategy {
-  componentSelection { rules ->
-    rules.all { ComponentSelection selection ->
-      boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
-        selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
-      }
-      if (rejected) {
-        selection.reject('Release candidate')
+dependencyUpdates {
+  checkForGradleUpdate = true
+  resolutionStrategy {
+    componentSelection { rules ->
+      rules.all { ComponentSelection selection ->
+        boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
+          selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+        }
+        if (rejected) {
+          selection.reject('Release candidate')
+        }
       }
     }
   }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.groovy
@@ -62,8 +62,11 @@ class PlainTextReporter extends AbstractReporter {
   }
 
   private def writeGradleUpdates(printStream, Result result) {
-    printStream.println('\nGradle updates:')
+    if (!result.gradle.isEnabled()) {
+      return
+    }
 
+    printStream.println('\nGradle updates:')
     result.gradle.with {
       // Log Gradle update checking failures.
       if (current.isFailure) {

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -44,6 +44,7 @@ class DependencyUpdates {
   Object outputFormatter
   String outputDir
   String reportfileName
+  boolean checkForGradleUpdate
 
   /** Evaluates the dependencies and returns a reporter. */
   DependencyUpdatesReporter run() {
@@ -101,7 +102,7 @@ class DependencyUpdates {
     Map<Map<String, String>, String> upgradeVersions = toMap(versions.upgrade)
 
     // Check for Gradle updates.
-    GradleUpdateChecker gradleUpdateChecker = new GradleUpdateChecker()
+    GradleUpdateChecker gradleUpdateChecker = new GradleUpdateChecker(checkForGradleUpdate)
 
     return new DependencyUpdatesReporter(project, revision, outputFormatter, outputDir, reportfileName,
       currentVersions, latestVersions, upToDateVersions, downgradeVersions, upgradeVersions,

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
@@ -162,11 +162,13 @@ class DependencyUpdatesReporter {
    * @return filled out object instance
    */
   private GradleUpdateResults buildGradleUpdateResults() {
+    boolean enabled = gradleUpdateChecker.isEnabled()
     return new GradleUpdateResults(
-      running: new GradleUpdateResult(gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.runningGradleVersion),
-      current: new GradleUpdateResult(gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.currentGradleVersion),
-      releaseCandidate: new GradleUpdateResult(gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.releaseCandidateGradleVersion),
-      nightly: new GradleUpdateResult(gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.nightlyGradleVersion)
+      enabled: enabled,
+      running: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.runningGradleVersion),
+      current: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.currentGradleVersion),
+      releaseCandidate: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.releaseCandidateGradleVersion),
+      nightly: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.nightlyGradleVersion)
     )
   }
 

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -44,6 +44,9 @@ class DependencyUpdatesTask extends DefaultTask {
     return (outputFormatter instanceof String) ? ((String) outputFormatter) : null
   }
 
+  @Input
+  boolean checkForGradleUpdate = true
+
   Object outputFormatter = 'plain';
   Closure resolutionStrategy = null;
 
@@ -58,8 +61,8 @@ class DependencyUpdatesTask extends DefaultTask {
   def dependencyUpdates() {
     project.evaluationDependsOnChildren()
 
-    def evaluator = new DependencyUpdates(project, resolutionStrategy,
-      revisionLevel(), outputFormatterProp(), outputDirectory(), getReportfileName())
+    def evaluator = new DependencyUpdates(project, resolutionStrategy, revisionLevel(),
+      outputFormatterProp(), outputDirectory(), getReportfileName(), checkForGradleUpdate)
     DependencyUpdatesReporter reporter = evaluator.run()
     reporter?.write()
   }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResult.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResult.groovy
@@ -31,8 +31,13 @@ class GradleUpdateResult implements Comparable<GradleUpdateResult> {
    */
   final String reason
 
-  GradleUpdateResult(GradleUpdateChecker.ReleaseStatus.Available running, GradleUpdateChecker.ReleaseStatus release) {
-    if (release instanceof GradleUpdateChecker.ReleaseStatus.Available) {
+  GradleUpdateResult(boolean enabled, GradleUpdateChecker.ReleaseStatus.Available running, GradleUpdateChecker.ReleaseStatus release) {
+    if (!enabled) {
+      this.version = ""
+      this.isUpdateAvailable = false
+      this.isFailure = false
+      this.reason = "update check disabled"
+    } else if (release instanceof GradleUpdateChecker.ReleaseStatus.Available) {
       this.version = release.gradleVersion.version
       this.isUpdateAvailable = release.gradleVersion > running.gradleVersion
       this.isFailure = false

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResults.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateResults.groovy
@@ -8,7 +8,7 @@ import groovy.transform.TupleConstructor
  */
 @TupleConstructor
 class GradleUpdateResults {
-
+  boolean enabled
   GradleUpdateResult running
   GradleUpdateResult current
   GradleUpdateResult releaseCandidate


### PR DESCRIPTION
The task property `checkForGradleUpdate` is defaulted to `true`. When set to `false` no check is performed, the plain text report, does not include the statement, and the json/xml report includes an enable flag, no version, and the reason.

Due to URLConnection defaulting to infinite timeout that can cause a hung build, the maximum connection and read timeouts are set to 15 seconds as a failsafe.

@aaronols @imanushin