### PR TITLE
DependencyUpdatesReporter: Avoid output of mixed file separators

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
@@ -102,7 +102,7 @@ class DependencyUpdatesReporter {
   }
 
   def generateFileReport(Reporter reporter) {
-    String filename = outputDir + File.separator + reportfileName + '.' + reporter.getFileExtension()
+    File filename = new File(outputDir, reportfileName + '.' + reporter.getFileExtension())
     try {
       project.file(outputDir).mkdirs()
       File outputFile = project.file(filename)


### PR DESCRIPTION
If running on Windows and if outputDir contains Unix separators, this
previous resulted in output like

    Generated report file C:\Dev\oss-review-toolkit\model\build/dependencyUpdates\report.txt

Avoid the mixed use different separators by using a File instead of a
String here.