### PR TITLE
272 Specify Gradle Release Channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin
 build
+out
 .classpath
 .settings
 .project

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/AbstractReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/AbstractReporter.groovy
@@ -12,4 +12,6 @@ abstract class AbstractReporter implements Reporter {
   Project project
   /** The revision strategy evaluated with. */
   String revision
+  /** The gradle release channel to use for reporting. */
+  String gradleReleaseChannel
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.groovy
@@ -20,10 +20,10 @@ import com.github.benmanes.gradle.versions.reporter.result.DependencyLatest
 import com.github.benmanes.gradle.versions.reporter.result.DependencyOutdated
 import com.github.benmanes.gradle.versions.reporter.result.DependencyUnresolved
 import com.github.benmanes.gradle.versions.reporter.result.Result
-import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel
 import groovy.transform.TupleConstructor
 import groovy.transform.TypeChecked
 
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.*
 import static groovy.transform.TypeCheckingMode.SKIP
 
 /**
@@ -66,17 +66,17 @@ class PlainTextReporter extends AbstractReporter {
       return
     }
 
-    printStream.println('\nGradle updates:')
+    printStream.println("\nGradle ${gradleReleaseChannel} updates:")
     result.gradle.with {
       // Log Gradle update checking failures.
       if (current.isFailure) {
-        printStream.println("[ERROR] [release channel: ${GradleReleaseChannel.CURRENT.id}] " + current.reason)
+        printStream.println("[ERROR] [release channel: ${CURRENT.id}] " + current.reason)
       }
-      if (releaseCandidate.isFailure) {
-        printStream.println("[ERROR] [release channel: ${GradleReleaseChannel.RELEASE_CANDIDATE.id}] " + releaseCandidate.reason)
+      if ((gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id) && releaseCandidate.isFailure) {
+        printStream.println("[ERROR] [release channel: ${RELEASE_CANDIDATE.id}] " + releaseCandidate.reason)
       }
-      if (nightly.isFailure) {
-        printStream.println("[ERROR] [release channel: ${GradleReleaseChannel.NIGHTLY.id}] " + nightly.reason)
+      if (gradleReleaseChannel == NIGHTLY.id && nightly.isFailure) {
+        printStream.println("[ERROR] [release channel: ${NIGHTLY.id}] " + nightly.reason)
       }
 
       // print Gradle updates in breadcrumb format
@@ -86,11 +86,14 @@ class PlainTextReporter extends AbstractReporter {
         updatePrinted = true
         printStream.print(" -> " + current.version)
       }
-      if (releaseCandidate.isUpdateAvailable && releaseCandidate > current) {
+      if ((gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id) && releaseCandidate.isUpdateAvailable && releaseCandidate > current) {
         updatePrinted = true
         printStream.print(" -> " + releaseCandidate.version)
       }
-      // ignore nightly in textual output
+      if (gradleReleaseChannel == NIGHTLY.id && nightly.isUpdateAvailable && nightly > current) {
+        updatePrinted = true
+        printStream.print(" -> " + nightly.version)
+      }
       if (!updatePrinted) {
         printStream.print(": UP-TO-DATE")
       }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -45,6 +45,7 @@ class DependencyUpdates {
   String outputDir
   String reportfileName
   boolean checkForGradleUpdate
+  String gradleReleaseChannel
 
   /** Evaluates the dependencies and returns a reporter. */
   DependencyUpdatesReporter run() {
@@ -105,8 +106,8 @@ class DependencyUpdates {
     GradleUpdateChecker gradleUpdateChecker = new GradleUpdateChecker(checkForGradleUpdate)
 
     return new DependencyUpdatesReporter(project, revision, outputFormatter, outputDir, reportfileName,
-      currentVersions, latestVersions, upToDateVersions, downgradeVersions, upgradeVersions,
-      unresolved, projectUrls, gradleUpdateChecker)
+       currentVersions, latestVersions, upToDateVersions, downgradeVersions, upgradeVersions,
+      unresolved, projectUrls, gradleUpdateChecker, gradleReleaseChannel)
   }
 
   private static Map<Map<String, String>, String> toMap(Set<Coordinate> coordinates) {

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.groovy
@@ -35,6 +35,8 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.UnresolvedDependency
 
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.*
+
 /**
  * A reporter for the dependency updates results.
  */
@@ -72,11 +74,14 @@ class DependencyUpdatesReporter {
   /** facade object to access information about running gradle versions and gradle updates */
   GradleUpdateChecker gradleUpdateChecker
 
+  /** The gradle release channel to use for reporting. */
+  String gradleReleaseChannel
+
   private static final Object MUTEX = new Object()
 
   def write() {
     synchronized (MUTEX) {
-      PlainTextReporter plainTextReporter = new PlainTextReporter(project, revision)
+      PlainTextReporter plainTextReporter = new PlainTextReporter(project, revision, gradleReleaseChannel)
 
       plainTextReporter.write(System.out, buildBaseObject())
 
@@ -127,13 +132,13 @@ class DependencyUpdatesReporter {
 
     switch (formatter) {
       case 'json':
-        reporter = new JsonReporter(project, revision)
+        reporter = new JsonReporter(project, revision, gradleReleaseChannel)
         break
       case 'xml':
-        reporter = new XmlReporter(project, revision)
+        reporter = new XmlReporter(project, revision, gradleReleaseChannel)
         break
       default:
-        reporter = new PlainTextReporter(project, revision)
+        reporter = new PlainTextReporter(project, revision, gradleReleaseChannel)
     }
 
     return reporter
@@ -167,8 +172,8 @@ class DependencyUpdatesReporter {
       enabled: enabled,
       running: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.runningGradleVersion),
       current: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.currentGradleVersion),
-      releaseCandidate: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.releaseCandidateGradleVersion),
-      nightly: new GradleUpdateResult(enabled, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.nightlyGradleVersion)
+      releaseCandidate: new GradleUpdateResult(gradleReleaseChannel == RELEASE_CANDIDATE.id, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.releaseCandidateGradleVersion),
+      nightly: new GradleUpdateResult(gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id, gradleUpdateChecker.runningGradleVersion, gradleUpdateChecker.nightlyGradleVersion)
     )
   }
 

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.*
+
 /**
  * A task that reports which dependencies have later versions.
  */
@@ -31,6 +33,9 @@ class DependencyUpdatesTask extends DefaultTask {
 
   @Input
   String revision = 'milestone'
+
+  @Input
+  String gradleReleaseChannel = RELEASE_CANDIDATE.id
 
   @Input
   String outputDir =
@@ -62,7 +67,7 @@ class DependencyUpdatesTask extends DefaultTask {
     project.evaluationDependsOnChildren()
 
     def evaluator = new DependencyUpdates(project, resolutionStrategy, revisionLevel(),
-      outputFormatterProp(), outputDirectory(), getReportfileName(), checkForGradleUpdate)
+      outputFormatterProp(), outputDirectory(), getReportfileName(), checkForGradleUpdate, gradleReleaseChannelLevel())
     DependencyUpdatesReporter reporter = evaluator.run()
     reporter?.write()
   }
@@ -79,6 +84,9 @@ class DependencyUpdatesTask extends DefaultTask {
 
   /** Returns the resolution revision level. */
   String revisionLevel() { System.properties['revision'] ?: revision }
+
+  /** Returns the resolution revision level. */
+  String gradleReleaseChannelLevel() { System.properties['gradleReleaseChannel'] ?: gradleReleaseChannel }
 
   /** Returns the outputDir format. */
   Object outputFormatterProp() { System.properties['outputFormatter'] ?: outputFormatter }

--- a/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -24,6 +24,8 @@ import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.*
+
 /**
  * A specification for the dependency updates task.
  */
@@ -545,6 +547,27 @@ final class DependencyUpdatesSpec extends Specification {
     }
   }
 
+  def 'Constructor takes gradle release channel'() {
+    given:
+    def project = new ProjectBuilder().withName('single').build()
+    addRepositoryTo(project)
+    project.configurations {
+      compile
+    }
+    project.dependencies {
+      compile 'com.google.guava:guava:15.0'
+    }
+
+    when:
+    def reporter = evaluate(project, 'milestone', 'plain', 'build', null, null, true, CURRENT.id)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      gradleReleaseChannel.equals(CURRENT.id)
+    }
+  }
+
   private static def singleProject() {
     new ProjectBuilder().withName('single').build()
   }
@@ -557,8 +580,8 @@ final class DependencyUpdatesSpec extends Specification {
   }
 
   private static def evaluate(project, revision = 'milestone', outputFormatter = 'plain',
-    outputDir = 'build', resolutionStrategy = null) {
-    new DependencyUpdates(project, resolutionStrategy, revision, outputFormatter, outputDir).run()
+                              outputDir = 'build', resolutionStrategy = null, reportfileName = null, checkForGradleUpdate = true, gradleReleaseChannel = RELEASE_CANDIDATE.id) {
+    new DependencyUpdates(project, resolutionStrategy, revision, outputFormatter, outputDir, reportfileName, checkForGradleUpdate, gradleReleaseChannel).run()
   }
 
   private def addRepositoryTo(project) {


### PR DESCRIPTION
Specify Gradle Release Channel when checking for Gradle updates.

Don't tell me that there is a RC release for Gradle when I only want final release versions of Gradle, e.g. don't show me:
```
Gradle updates:
 - Gradle: [4.10.2 -> 5.0-rc-1]
```