### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 cache:
   directories:
   - $HOME/.gradle
+script:
+  - ./gradlew build --scan
 deploy:
   provider: script
   script: ./gradlew bintrayUpload

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,13 @@ buildscript {
 }
 
 plugins {
+  id "com.gradle.build-scan" version "1.16"
   id "com.jfrog.bintray" version "1.7.3"
+}
+
+buildScan {
+  termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree = 'yes'
 }
 
 apply plugin: 'java-gradle-plugin'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.