### PR TITLE
tests: use modern Kotlin DSL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ buildscript {
 }
 ```
 
-The current version is known to work with Gradle versions up to 5.0.
+The current version is known to work with Gradle versions up to 5.6.
 
 ## Tasks
 

--- a/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -41,8 +41,11 @@ final class KotlinDslUsageSpec extends Specification {
     given:
     def srdErrWriter = new StringWriter()
     buildFile << '''
-      tasks {
-        "dependencyUpdates"(DependencyUpdatesTask::class) {
+      tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+          checkForGradleUpdate = true
+          outputFormatter = "json"
+          outputDir = "build/dependencyUpdates"
+          reportfileName = "report"
           resolutionStrategy {
             componentSelection {
               all {
@@ -53,7 +56,6 @@ final class KotlinDslUsageSpec extends Specification {
             }
           }
         }
-      }
     '''
 
     when:
@@ -71,6 +73,6 @@ final class KotlinDslUsageSpec extends Specification {
     srdErrWriter.toString().empty
 
     where:
-    gradleVersion << ['4.8']
+    gradleVersion << ['5.6']
   }
 }


### PR DESCRIPTION
check that the syntax from `examples/kotlin/build.gradle.kts` actually works