### PR TITLE
Remove unnecessary/incorrect escaping in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ dependencyUpdates.resolutionStrategy {
     rules.all {
       def isNonStable = { String version -> 
         ['alpha', 'beta', 'rc', 'cr', 'm', 'preview', 'b', 'ea'].any { qualifier ->
-          version ==~ /(?i).*[.-]\$qualifier[.\\d-+]*/
+          version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
         }
       }
 
@@ -119,7 +119,7 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     componentSelection {
       all {
         fun isNonStable(version: String) = listOf("alpha", "beta", "rc", "cr", "m", "preview", "b", "ea").any { qualifier ->
-          version.matches(Regex("(?i).*[.-]\$qualifier[.\\d-+]*"))
+          version.matches(Regex("(?i).*[.-]$qualifier[.\\d-+]*"))
         }
         if (isNonStable(candidate.version) && !isNonStable(currentVersion)) {
           reject("Release candidate")


### PR DESCRIPTION
Extra escaping was added in c0b850601d74fd961762e6c8a80be980608714da and appears to break the matching; because $ is being treated as literal. Additionally, escaping the `\d` isn't necessary in a Groovy regex. 

Otherwise the new feature from #327 looks great - thanks!