### PR TITLE
WIP: rejectVersionIf { }  

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,31 +2,37 @@ buildscript {
   repositories {
     jcenter()
   }
-
   dependencies {
     classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
   }
 }
 
 plugins {
-  id "com.gradle.build-scan" version "1.16"
   id "com.jfrog.bintray" version "1.7.3"
+  id 'com.gradle.build-scan' version '2.4.1'
+  id("org.gradle.maven-publish")
+  id("org.gradle.java-gradle-plugin")
+  id("org.gradle.groovy")
+  id("org.gradle.codenarc")
 }
+apply plugin: 'nexus'
 
 buildScan {
   termsOfServiceUrl = 'https://gradle.com/terms-of-service'
   termsOfServiceAgree = 'yes'
 }
 
-apply plugin: 'java-gradle-plugin'
-apply plugin: 'groovy'
-apply plugin: 'nexus'
-apply plugin: 'codenarc'
 
 group = 'com.github.ben-manes'
 version = '0.24.0'
 
 sourceCompatibility = '1.6'
+
+publishing {
+  repositories {
+    maven { url = "build/repository" }
+  }
+}
 
 repositories {
   mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildScan {
 
 
 group = 'com.github.ben-manes'
-version = '0.24.0'
+version = '0.25.0'
 
 sourceCompatibility = '1.6'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+  }
+}
 rootProject.name = 'gradle-versions-plugin'

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -22,6 +22,7 @@ import groovy.transform.TypeChecked
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.UnresolvedDependency
 
 /**
@@ -48,8 +49,9 @@ class DependencyUpdates {
 
   /** Evaluates the dependencies and returns a reporter. */
   DependencyUpdatesReporter run() {
-    Map<Project, Set<Configuration>> projectConfigs = project.allprojects.collectEntries { proj ->
-      [proj, proj.configurations.plus(proj.buildscript.configurations) as Set]
+    Map<Project, ConfigurationContainer> projectConfigs = project.allprojects.collectEntries { proj ->
+      proj.configurations.addAll(proj.buildscript.configurations)
+      [proj, proj.configurations]
     }
     Set<DependencyStatus> status = resolveProjects(projectConfigs)
 
@@ -62,7 +64,7 @@ class DependencyUpdates {
     return createReporter(versions, unresolved, projectUrls)
   }
 
-  private Set<DependencyStatus> resolveProjects(Map<Project, Set<Configuration>> projectConfigs) {
+  private Set<DependencyStatus> resolveProjects(Map<Project, ConfigurationContainer> projectConfigs) {
     projectConfigs.keySet().collect { proj ->
       Set<Configuration> configurations = projectConfigs.get(proj)
       Resolver resolver = new Resolver(proj, resolutionStrategy)

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -15,10 +15,14 @@
  */
 package com.github.benmanes.gradle.versions.updates
 
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionRulesWithCurrent
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import groovy.transform.TypeChecked
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.Transformer
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -61,6 +65,7 @@ class DependencyUpdatesTask extends DefaultTask {
   Closure resolutionStrategy = null;
   private Action<? super ResolutionStrategyWithCurrent> resolutionStrategyAction = null
 
+
   DependencyUpdatesTask() {
     description = 'Displays the dependency updates for the project.'
     group = 'Help'
@@ -91,6 +96,18 @@ class DependencyUpdatesTask extends DefaultTask {
   void resolutionStrategy(final Action<? super ResolutionStrategyWithCurrent> resolutionStrategy) {
     this.resolutionStrategyAction = resolutionStrategy
     this.resolutionStrategy = null
+  }
+
+  void rejectVersionIf(final Transformer<Boolean, ComponentSelectionWithCurrent> filter) {
+    resolutionStrategy { ResolutionStrategyWithCurrent strategy ->
+      strategy.componentSelection { ComponentSelectionRulesWithCurrent selection ->
+        selection.all { ComponentSelectionWithCurrent current ->
+          if (filter.transform(current)) {
+            current.reject("Rejected")
+          }
+        }
+      }
+    }
   }
 
   /** Returns the resolution revision level. */

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -54,8 +54,10 @@ class DependencyUpdatesTask extends DefaultTask {
   @Input
   boolean checkForGradleUpdate = true
 
+  @Input @Optional
   Object outputFormatter = 'plain'
 
+  @Input @Optional
   Closure resolutionStrategy = null;
   private Action<? super ResolutionStrategyWithCurrent> resolutionStrategyAction = null
 


### PR DESCRIPTION
I had a first try  at implementing #325 

```kotlin
rejectVersionIf { current: ComponentSelectionWithCurrent ->
        isNonStable(current.candidate.version) || !isNonStable(current.currentVersion)
}
```

It would be better if we can change the syntax to this but I don't know how to do it:

```kotlin
rejectVersionIf { candidate: ModuleComponentIdentifier ->
        isNonStable(candidate.version) || !isNonStable(currentVersion)
}
```



`isNonStable` being defined as this:

```kotlin
fun isNonStable(version: String): Boolean {
  val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
  val regex = "^[0-9,.v-]+$".toRegex()
  val isStable = stableKeyword || regex.matches(version)
  return isStable.not()
}
```

Since my Groovy skills are closed to zero, I tried to upgrade Gradle so that at least that part is familiar for me. 

Because of the Gradle update, one test is not working anymore https://scans.gradle.com/s/unwddfvrt5xak

```
    > Could not find method componentSelection() for arguments [build_6aatid6bxisq96bm8bf31j5zh$_run_closure3$_closure5@243ebea0] on root project 'junit8907024250739898265' of type org.gradle.api.Project.

dependencyUpdates.resolutionStrategy = componentSelection {
        all(new Rule())
   }
}
```

I have also run `./gradlew publish` and then use the artifact in my own plugin

https://github.com/jmfayard/buildSrcVersions/pull/62/files

One part of this is also wrong:

`Cannot change dependencies of configuration ':classpath' after it has been resolved.`

https://gist.github.com/jmfayard/f8455c2cdc658035e8d542ecf0f841ac

