### PR TITLE
Escape . and - correctly in `isNonStable()` RegEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ no agreed standard on this, but this is a good starting point:
 ```groovy
 def isNonStable = { String version ->
   def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-  def regex = /^[0-9,.v-]+$/
+  def regex = /^[0-9,\\.v\\-]+(-r)?$/
   return !stableKeyword && !(version ==~ regex)
 }
 ```
@@ -108,7 +108,7 @@ def isNonStable = { String version ->
 ```kotlin
 fun isNonStable(version: String): Boolean {
     val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
-    val regex = "^[0-9,.v-]+$".toRegex()
+    val regex = "^[0-9,\\.v\\-]+(-r)?$".toRegex()
     val isStable = stableKeyword || regex.matches(version)
     return isStable.not()
 }

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -31,7 +31,7 @@ configurations {
 
 def isNonStable = { String version ->
   def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-  def regex = /^[0-9,.v-]+$/
+  def regex = /^[0-9,\\.v\\-]+(-r)?$/
   return !stableKeyword && !(version ==~ regex)
 }
 

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -21,7 +21,7 @@ configurations {
 
 fun isNonStable(version: String): Boolean {
   val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
-  val regex = "^[0-9,.v-]+$".toRegex()
+  val regex = "^[0-9,\\.v\\-]+(-r)?$".toRegex()
   val isStable = stableKeyword || regex.matches(version)
   return isStable.not()
 }


### PR DESCRIPTION
Since the `.` matches every character in a RegEx, when you don't escape it every version is considered stable.
Also I added an optional `-r` to the end, because for example `jgit` uses this in version numbers of stable releases.