### PR TITLE
Resolve dependency constraints.

### DIFF
--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -23,6 +23,7 @@ configurations {
   bom
   upToDate
   exceedLatest
+  platform
   upgradesFound
   upgradesFound2
   unresolvable
@@ -76,4 +77,14 @@ dependencies {
                'com.github.ben-manes:unresolvable2:1.0'
   unresolvable2 'com.github.ben-manes:unresolvable:1.0',
                 'com.github.ben-manes:unresolvable2:1.0'
+
+  platform 'com.linecorp.armeria:armeria',
+           'io.zipkin.brave:brave'
+  // Common usage would be to separate this into a project that uses the `java-platform` plugin to
+  // share constraints among several projects.
+  constraints {
+    platform 'com.linecorp.armeria:armeria:0.90.0',
+             'io.zipkin.brave:brave:5.7.0'
+
+  }
 }

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -13,6 +13,7 @@ configurations {
   register("bom")
   register("upToDate")
   register("exceedLatest")
+  register("platform")
   register("upgradesFound")
   register("upgradesFound2")
   register("unresolvable")
@@ -74,4 +75,12 @@ dependencies {
   "unresolvable"("com.github.ben-manes:unresolvable2:1.0")
   "unresolvable2"("com.github.ben-manes:unresolvable:1.0")
   "unresolvable2"("com.github.ben-manes:unresolvable2:1.0")
+  "platform"("com.linecorp.armeria:armeria")
+  "platform"("io.zipkin.brave:brave")
+  // Common usage would be to separate this into a project that uses the `java-platform` plugin to
+  // share constraints among several projects.
+  constraints {
+    "platform"("com.linecorp.armeria:armeria:0.90.0")
+    "platform"("io.zipkin.brave:brave:5.7.0")
+  }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Coordinate.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Coordinate.groovy
@@ -18,6 +18,7 @@ package com.github.benmanes.gradle.versions.updates
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.TypeChecked
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
@@ -58,6 +59,10 @@ class Coordinate implements Comparable<Coordinate> {
   }
 
   static Coordinate from(Dependency dependency) {
+    return new Coordinate(dependency.group, dependency.name, dependency.version)
+  }
+
+  static Coordinate from(DependencyConstraint dependency) {
     return new Coordinate(dependency.group, dependency.name, dependency.version)
   }
 

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
@@ -119,12 +119,10 @@ class Resolver {
     }
 
     // Common use case for dependency constraints is a java-platform BOM project.
-    try {
+    if (supportsConstraints(configuration)) {
       configuration.dependencyConstraints.each { dependency ->
         latest.add(createQueryDependency(dependency, revision))
       }
-    } catch (MissingPropertyException e) {
-      // Skip if constraints not supported
     }
 
     Configuration copy = configuration.copyRecursive().setTransitive(false)
@@ -239,13 +237,11 @@ class Resolver {
       coordinates.put(coordinate.key, declared.get(coordinate.key))
     }
 
-    try {
+    if (supportsConstraints(copy)) {
       for (DependencyConstraint constraint : copy.dependencyConstraints) {
         Coordinate coordinate = Coordinate.from(constraint)
         coordinates.put(coordinate.key, declared.get(coordinate.key))
       }
-    } catch (MissingPropertyException e) {
-      // Skip if constraints not supported
     }
 
     // Ignore undeclared (hidden) dependencies that appear when resolving a configuration
@@ -364,6 +360,10 @@ class Resolver {
     return null
   }
 
+  private static boolean supportsConstraints(Configuration configuration) {
+    return configuration.metaClass.respondsTo(configuration, "getDependencyConstraints");
+  }
+
   private static List<Coordinate> getResolvableDependencies(Configuration configuration) {
     List<Coordinate> coordinates = configuration.dependencies.findAll { dependency ->
       dependency instanceof ExternalDependency
@@ -371,12 +371,10 @@ class Resolver {
       Coordinate.from(dependency)
     }
 
-    try {
+    if (supportsConstraints(configuration)) {
       configuration.dependencyConstraints.each {
         coordinates.add(Coordinate.from(it))
       }
-    } catch (MissingPropertyException e) {
-      // Skip
     }
 
     return coordinates

--- a/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
@@ -46,4 +46,40 @@ final class JavaLibrarySpec extends Specification {
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  def "Show updates for an api dependency constraint in a java-library project"() {
+    given:
+    def mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'com.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
 }


### PR DESCRIPTION
Dependency constraints can be used to set versions, and in particular can be used with the `java-platform` plugin to define all constraints in a single location. It would be convenient if these constraints were resolved by the plugin since then instead of resolving the dependencies of all projects in a monorepo controlled by a platform, just need to resolve a single project for better performance and simpler output.

I am wondering whether this feature should be restricted to projects with the java-platform plugin. Let me know if you have thoughts.

Reference
- https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:dependency_constraints
- https://docs.gradle.org/current/userguide/java_platform_plugin.html

Fixes #350 