### PR TITLE
Guard constraint resolution by a property since it isn't really possi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,21 @@ tasks.withType<DependencyUpdatesTask> {
 
 </details>
 
+#### Constraints
+
+If you use constraints, for example to define a BOM using the [`java-platform`](https://docs.gradle.org/current/userguide/java_platform_plugin.html) 
+plugin or to [manage](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:dependency_constraints) 
+transitive dependency versions, you can enable checking of constraints by specifying the `checkConstraints`
+attribute of the `dependencyUpdates` task.
+
+```groovy
+tasks {
+  dependencyUpdates {
+    checkConstraints = true
+  }
+}
+```
+
 #### Kotlin DSL
 
 If using Gradle's [kotlin-dsl][kotlin_dsl], you could configure the `dependencyUpdates` like this:

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -45,6 +45,7 @@ class DependencyUpdates {
   String reportfileName
   boolean checkForGradleUpdate
   String gradleReleaseChannel
+  boolean checkConstraints
 
   /** Evaluates the dependencies and returns a reporter. */
   DependencyUpdatesReporter run() {
@@ -65,7 +66,7 @@ class DependencyUpdates {
   private Set<DependencyStatus> resolveProjects(Map<Project, Set<Configuration>> projectConfigs) {
     projectConfigs.keySet().collect { proj ->
       Set<Configuration> configurations = projectConfigs.get(proj)
-      Resolver resolver = new Resolver(proj, resolutionStrategy)
+      Resolver resolver = new Resolver(proj, resolutionStrategy, checkConstraints)
       configurations.collect { Configuration config ->
         resolve(resolver, proj, config)
       }.flatten() as Set<DependencyStatus>

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -57,6 +57,9 @@ class DependencyUpdatesTask extends DefaultTask {
   @Input
   boolean checkForGradleUpdate = true
 
+  @Input
+  boolean checkConstraints = false
+
   Object outputFormatter = 'plain'
 
   Closure resolutionStrategy = null;
@@ -80,7 +83,8 @@ class DependencyUpdatesTask extends DefaultTask {
     }
 
     def evaluator = new DependencyUpdates(project, resolutionStrategyAction, revisionLevel(),
-      outputFormatterProp(), outputDirectory(), getReportfileName(), checkForGradleUpdate, gradleReleaseChannelLevel())
+      outputFormatterProp(), outputDirectory(), getReportfileName(), checkForGradleUpdate, gradleReleaseChannelLevel(),
+      checkConstraints)
     DependencyUpdatesReporter reporter = evaluator.run()
     reporter?.write()
   }

--- a/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -1,0 +1,131 @@
+package com.github.benmanes.gradle.versions
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+final class ConstraintsSpec extends Specification {
+
+  @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile
+
+  def "Show updates for an api dependency constraint"() {
+    given:
+    def mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'com.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def "Does not override explicit dependency with constraint"() {
+    given:
+    def mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'com.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:3.0'
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def "Does not show updates for an api dependency constraint when disabled"() {
+    given:
+    def mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'com.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('No dependencies found.')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
@@ -46,40 +46,4 @@ final class JavaLibrarySpec extends Specification {
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
-
-  def "Show updates for an api dependency constraint in a java-library project"() {
-    given:
-    def mavenRepoUrl = getClass().getResource('/maven/').toURI()
-    buildFile = testProjectDir.newFile('build.gradle')
-    buildFile <<
-      """
-        plugins {
-          id 'java-library'
-          id 'com.github.ben-manes.versions'
-        }
-
-        repositories {
-          maven {
-            url '${mavenRepoUrl}'
-          }
-        }
-
-        dependencies {
-          constraints {
-            api 'com.google.inject:guice:2.0'
-          }
-        }
-      """.stripIndent()
-
-    when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('dependencyUpdates')
-      .withPluginClasspath()
-      .build()
-
-    then:
-    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
-    result.task(':dependencyUpdates').outcome == SUCCESS
-  }
 }


### PR DESCRIPTION
…ble to know if a constraint is added by a plugin and out of user control or not.

We found one of the most popular Gradle plugins, the Android plugin, uses constraints. There is one issue in general that if a constraint and dependency both are defined, there's no need to use the constraint in the report (i.e., we want a dependency that is updated to not show in the report even when the constraint is older) which I fix. 

But in the end, there isn't a way to know whether a constraint is added by a user or a plugin. I think this also applies for dependencies, but I guess it's less common for plugins to add those. So I've added a flag to enable constraint checking so the user can opt-in to it when they know they can use it.