### PR TITLE
Upgrade documentation with --refresh-dependencies flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Displays a report of the project dependencies that are up-to-date, exceed the la
 have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
 logged at the `info` level.
 
-To refresh the cache (i.e. fetch the new releases of the dependencies), add flag `--refresh-dependencies`.
+To refresh the cache (i.e. fetch the new releases/versions of the dependencies), add flag `--refresh-dependencies`.
 
 Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels. The plaintext
 report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds). The xml and json

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Displays a report of the project dependencies that are up-to-date, exceed the la
 have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
 logged at the `info` level.
 
-To refresh the cache (i.e. fetch the new releases/versions of the dependencies), add flag `--refresh-dependencies`.
+To refresh the cache (i.e. fetch the new releases/versions of the dependencies), use flag `--refresh-dependencies`.
 
 Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels. The plaintext
 report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds). The xml and json

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Displays a report of the project dependencies that are up-to-date, exceed the la
 have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
 logged at the `info` level.
 
+To refresh the cache (i.e. fetch the new releases of the dependencies), add flag `--refresh-dependencies`.
+
 Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels. The plaintext
 report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds). The xml and json
 reports include information about all three release channels, whether a release is considered an update with respect to


### PR DESCRIPTION
I kept it simple. Personally I searched for "refresh" on the README. I suppose other people might have the same issue.