### PR TITLE
Replace broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,4 +597,4 @@ dependencyUpdates {
 
 [kotlin_dsl]: https://github.com/gradle/kotlin-dsl
 [ivy_resolution_strategy]: http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html#Latest%20(Status)%20Matcher
-[component_selection_rules]: https://docs.gradle.org/current/userguide/customizing_dependency_resolution_behavior.html#sec:component_selection_rules
+[component_selection_rules]: https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:component_selection_rules


### PR DESCRIPTION
The `current` Gradle docs don't have this section (and the whole site) anymore.
I'm not sure if this is an issue (at Gradle) or just placed somewhere else. But unfortunately I can't find it "somewhere else". Therefore I decided to replace the broken link with the latest working version. With that we have at least some kind of documentation , even if its maybe outdated.. 🙃 

## Update
Oh wait, while I'm write this is had another idea to search in the Gradle docs and... Tada:
https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:component_selection_rules

I guess we can use the new link. Or should we point to a specific version like currently https://docs.gradle.org/6.5/userguide/dynamic_versions.html#sec:component_selection_rules? 🤔 
What do you think?