### PR TITLE
Use lazy task configuration for dependencyUpdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ initscript {
 allprojects {
   apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
 
-  dependencyUpdates {
+  tasks.named("dependencyUpdates").configure {
     // configure the task, for example wrt. resolution strategies
   }
 }
@@ -151,7 +151,7 @@ You can either use the simplified syntax `rejectVersionIf { ... }` or configure 
 <!--  Always modify first examples/groovy and make sure that it works. THEN modify the README -->
 
 ```groovy
-dependencyUpdates {
+tasks.named("dependencyUpdates").configure {
   // Example 1: reject all non stable versions
   rejectVersionIf {
     isNonStable(it.candidate.version)
@@ -184,7 +184,7 @@ dependencyUpdates {
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-tasks.withType<DependencyUpdatesTask> {
+tasks.named("dependencyUpdates", DependencyUpdatesTask::class.java).configure {
   // Example 1: reject all non stable versions
   rejectVersionIf {
     isNonStable(candidate.version)
@@ -232,10 +232,8 @@ transitive dependency versions, you can enable checking of constraints by specif
 attribute of the `dependencyUpdates` task.
 
 ```groovy
-tasks {
-  dependencyUpdates {
+tasks.named("dependencyUpdates").configure {
     checkConstraints = true
-  }
 }
 ```
 
@@ -246,7 +244,7 @@ If using Gradle's [kotlin-dsl][kotlin_dsl], you could configure the `dependencyU
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-tasks.withType<DependencyUpdatesTask> {
+tasks.named("dependencyUpdates", DependencyUpdatesTask::class.java).configure {
 
   // optional parameters
   checkForGradleUpdate = true
@@ -558,7 +556,7 @@ For example, if you wanted to create an html table for the upgradable dependenci
 
 ```groovy
 ...
-dependencyUpdates {
+tasks.named("dependencyUpdates").configure {
   outputFormatter = { result ->
     def updatable = result.outdated.dependencies
     if (!updatable.isEmpty()){

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -36,7 +36,7 @@ def isNonStable = { String version ->
   return !stableKeyword && !(version ==~ regex)
 }
 
-dependencyUpdates {
+tasks.named("dependencyUpdates").configure {
   checkForGradleUpdate = true
 
   // Example 1: reject all non stable versions

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -36,9 +36,7 @@ fun isNonStable(version: String): Boolean {
   return isStable.not()
 }
 
-
-
-tasks.withType<DependencyUpdatesTask> {
+tasks.named("dependencyUpdates", DependencyUpdatesTask::class.java).configure {
 
   // Example 1: reject all non stable versions
   rejectVersionIf {


### PR DESCRIPTION
Instead of configuring the task using the instance of it, use "named" function that returns TaskProvider.

Kotlin sample before changes: https://scans.gradle.com/s/agejecharcfa6/performance/configuration?focused=5&openScriptsAndPlugins=WzBd
Kotlin sample after changes: https://scans.gradle.com/s/mxv25ulispr4w/performance/configuration

Groovy sample before changes: https://scans.gradle.com/s/szcsxpdg6tfzu/performance/configuration?focused=5&openScriptsAndPlugins=WzBd
Groovy sample after changes: https://scans.gradle.com/s/xwxm6zqwivgew/performance/configuration

Closes https://github.com/ben-manes/gradle-versions-plugin/issues/407