### PR TITLE
Copy dependency attributes for dynamic query (fixes #334)

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
@@ -147,9 +147,16 @@ class Resolver {
     // query (see issue #97). Otherwise if its a file then use 'none' to pass it through.
     String version = (dependency.version == null) ? (dependency.artifacts.empty ? '+' : 'none') : '+'
 
-    return project.dependencies.create("${dependency.group}:${dependency.name}:${version}") {
+    def latest = project.dependencies.create("${dependency.group}:${dependency.name}:${version}") {
       transitive = false
     }
+    latest.attributes { container ->
+      for (def key : dependency.attributes.keySet()) {
+        def value = dependency.attributes.getAttribute(key)
+        container.attribute(key, value)
+      }
+    }
+    return latest
   }
 
   /** Returns a variant of the provided dependency used for querying the latest version. */


### PR DESCRIPTION
This resolves `okhttp-bom` dependency in @ZacSweers's https://github.com/ZacSweers/CatchUp project. The attributes are copied over so that the variant resolution is successful.

@Vampire @mike-ross-88 can you please test this in your projects as confirmation? I don't believe they are public for me to verify myself.

Simply checkout this branch, increment the build's version, and run `gradlew install`. In your project, you will want to include `mavenLocal()` as a plugin repository. Using the buildscript syntax versus plugins block seems to be needed. It should then run with the local artifact.