### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You may also wish to explore additional functionality provided by,
 [ ![JCenter](https://api.bintray.com/packages/fooberger/maven/com.github.ben-manes%3Agradle-versions-plugin/images/download.svg) ](https://bintray.com/fooberger/maven/com.github.ben-manes%3Agradle-versions-plugin/_latestVersion)
 [![gradlePluginPortal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/ben-manes/versions/com.github.ben-manes.versions.gradle.plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/com.github.ben-manes.versions)
 
-This plugin is available from [Bintray's JCenter repository](http://jcenter.bintray.com) and from the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.github.ben-manes.versions).
+This plugin is available from [Bintray's JCenter repository](https://jcenter.bintray.com) and from the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.github.ben-manes.versions).
 
 You can add it to your top-level build script using the following configuration:
 


### PR DESCRIPTION
JCenter is only available via https since January 2020.