### PR TITLE
Use Gradle Repo instead of Jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    gradlePluginPortal()
   }
 
   dependencies {
@@ -16,7 +16,7 @@ plugins {
 }
 
 repositories {
-  jcenter()
+  gradlePluginPortal()
 }
 
 apply plugin: 'nexus'


### PR DESCRIPTION
 - Use Gradle Repo - mirrors `jcenter` and `mavenCentral`


Helps to address @anuraaga comment here: https://github.com/ben-manes/gradle-versions-plugin/pull/457#discussion_r554291918.