### PR TITLE
Add matrix build for Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         java-version:
           - 1.8
+          - 11
 
     steps:
-
       - name: Checkout Project
         uses: actions/checkout@v2
 


### PR DESCRIPTION
 - Build with Java 8 and 11 for future proofing builds on newer Java releases
 - Still release using Java 8