### PR TITLE
Publish to the portal directly (fixes #473)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: deploy
 
-on:  
-  push:
-    tags:
-      - '*'
+on:
+  release:
+    types: [created]
 
 jobs:
   publish:
@@ -25,7 +24,7 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.6
         with:
           remote-build-cache-proxy-enabled: false
-          arguments: clean build bintrayUpload -s --scan
-        env:
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-          BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
+          properties: |
+            gradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
+            gradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+          arguments: publishPlugins -s --scan

--- a/README.md
+++ b/README.md
@@ -17,12 +17,9 @@ You may also wish to explore additional functionality provided by,
 ## Usage
 
 [![Build](https://github.com/ben-manes/gradle-versions-plugin/workflows/build/badge.svg)](https://github.com/ben-manes/gradle-versions-plugin/actions)
-[![JCenter](https://api.bintray.com/packages/fooberger/maven/com.github.ben-manes%3Agradle-versions-plugin/images/download.svg) ](https://bintray.com/fooberger/maven/com.github.ben-manes%3Agradle-versions-plugin/_latestVersion)
 [![gradlePluginPortal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/ben-manes/versions/com.github.ben-manes.versions.gradle.plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/com.github.ben-manes.versions)
 
-This plugin is available from [Bintray's JCenter repository](https://bintray.com/search?query=gradle-versions-plugin) and from the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.github.ben-manes.versions).
-
-You can add it to your top-level build script using the following configuration:
+You can add this plugin to your top-level build script using the following configuration:
 
 ### `plugins` block:
 
@@ -40,7 +37,7 @@ apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
   repositories {
-    jcenter()
+    gradlePluginPortal()
   }
 
   dependencies {
@@ -54,7 +51,7 @@ You can also transparently add the plugin to every Gradle project that you run v
 ```groovy
 initscript {
   repositories {
-     jcenter()
+     gradlePluginPortal()
   }
 
   dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-  id 'com.jfrog.bintray' version '1.8.5'
+  id 'com.gradle.plugin-publish' version '0.13.0'
   id 'java-gradle-plugin'
   id 'maven-publish'
-  id 'groovy'
   id 'codenarc'
+  id 'groovy'
 }
 
 repositories {
-  jcenter()
+  mavenCentral()
 }
 
 group = 'com.github.ben-manes'
@@ -51,7 +51,6 @@ task createClasspathManifest {
 
 // Add the classpath file to the test runtime classpath
 dependencies {
-  implementation gradleApi()
   implementation 'com.thoughtworks.xstream:xstream:1.4.15'
 
   testRuntimeOnly files(createClasspathManifest)
@@ -174,29 +173,19 @@ publishing {
 publish.dependsOn jar, docsJar, sourcesJar, testsJar, reportsZip
 publish.dependsOn 'generatePomFileForPluginMavenPublication'
 
-// Publishes to JFrog Bintray's JCenter repository
-bintray {
-  user = project.properties['BINTRAY_USERNAME'] ?: System.env.'BINTRAY_USERNAME'
-  key = project.properties['BINTRAY_API_KEY'] ?: System.env.'BINTRAY_API_KEY'
-  configurations = ['archives']
-  publish = true
-
-  pkg {
-    repo = 'maven'
-    name = 'com.github.ben-manes:gradle-versions-plugin'
-    desc = 'Gradle plugin that provides tasks for discovering dependency updates.'
-    websiteUrl = 'https://github.com/ben-manes/gradle-versions-plugin'
-    issueTrackerUrl = 'https://github.com/ben-manes/gradle-versions-plugin/issues'
-    vcsUrl = 'https://github.com/ben-manes/gradle-versions-plugin'
-    labels = ['gradle', 'plugin', 'versions']
-    githubRepo = 'ben-manes/gradle-versions-plugin'
-    githubReleaseNotesFile = 'README.md'
-
-    version {
-      desc = 'Gradle plugin that provides tasks for discovering dependency updates.'
-      attributes = ['gradle-plugin': 'com.github.ben-manes.versions:com.github.ben-manes:gradle-versions-plugin']
+gradlePlugin {
+  plugins {
+    versionsPlugin {
+      id = 'com.github.ben-manes.versions'
+      displayName = 'Gradle Versions Plugin'
+      implementationClass = 'com.github.benmanes.gradle.versions.VersionsPlugin'
+      description = 'Gradle plugin that provides tasks for discovering dependency updates.'
     }
   }
 }
-bintrayUpload.dependsOn jar, docsJar, sourcesJar, testsJar, reportsZip
-bintrayUpload.dependsOn 'generatePomFileForPluginMavenPublication'
+
+pluginBundle {
+  website = 'https://github.com/ben-manes/gradle-versions-plugin'
+  vcsUrl = 'https://github.com/ben-manes/gradle-versions-plugin'
+  tags = [ 'dependencies', 'versions', 'updates' ]
+}


### PR DESCRIPTION
Migrates off of JCenter and publishes directly to the plugin portal. The github action is run only when a release is created.