### PR TITLE
Adding tasks getVersion and setVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,11 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 group = 'com.github.ben-manes'
-version = '0.38.0'
+version = '0.39.0-SNAPSHOT'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 
@@ -52,10 +53,10 @@ task createClasspathManifest {
 // Add the classpath file to the test runtime classpath
 dependencies {
   implementation 'com.thoughtworks.xstream:xstream:1.4.16'
+  api 'org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.50'
 
   testRuntimeOnly files(createClasspathManifest)
 
-  testImplementation gradleTestKit()
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
     exclude(module: 'groovy-all')
   }
@@ -154,6 +155,11 @@ publishing {
             id = 'jochenberger'
             name = 'Jochen Berger'
           }
+          developer {
+            id = 'ldenisey'
+            name = 'Lucien Denisey'
+            email = 'ldenisey@gmail.com'
+          }
         }
 
         issueManagement {
@@ -187,5 +193,5 @@ gradlePlugin {
 pluginBundle {
   website = 'https://github.com/ben-manes/gradle-versions-plugin'
   vcsUrl = 'https://github.com/ben-manes/gradle-versions-plugin'
-  tags = [ 'dependencies', 'versions', 'updates' ]
+  tags = ['dependencies', 'versions', 'updates']
 }

--- a/config/codenarc/rules.groovy
+++ b/config/codenarc/rules.groovy
@@ -21,6 +21,7 @@ ruleset {
   ruleset('rulesets/convention.xml')
   ruleset('rulesets/design.xml') {
     AbstractClassWithoutAbstractMethod(enabled: false)
+    Instanceof(ignoreTypeNames: '*Statement, *Expression, *Initializer')
   }
   ruleset('rulesets/dry.xml') {
     DuplicateStringLiteral(enabled: false) // too much hassle
@@ -29,6 +30,7 @@ ruleset {
   ruleset('rulesets/formatting.xml') {
     Indentation(spacesPerIndentLevel: 2)
     SpaceAroundMapEntryColon(characterAfterColonRegex: /\s/)
+    ClassEndsWithBlankLine(enabled: false)
   }
   ruleset('rulesets/comments.xml') {
     ClassJavadoc(enabled: false)

--- a/config/codenarc/testrules.groovy
+++ b/config/codenarc/testrules.groovy
@@ -18,7 +18,9 @@ ruleset {
   ruleset('rulesets/basic.xml')
   ruleset('rulesets/braces.xml')
   ruleset('rulesets/concurrency.xml')
-  ruleset('rulesets/convention.xml')
+  ruleset('rulesets/convention.xml') {
+    CompileStatic(enabled: false)
+  }
   ruleset('rulesets/design.xml') {
     AbstractClassWithoutAbstractMethod(enabled: false)
   }
@@ -30,6 +32,7 @@ ruleset {
   ruleset('rulesets/exceptions.xml')
   ruleset('rulesets/formatting.xml') {
     Indentation(spacesPerIndentLevel: 2)
+    ClassEndsWithBlankLine(enabled: false)
   }
   ruleset('rulesets/comments.xml') {
     ClassJavadoc(enabled: false)
@@ -48,8 +51,8 @@ ruleset {
   }
   ruleset('rulesets/imports.xml') {
     NoWildcardImports(enabled: false)
+    MisorderedStaticImports(enabled: false)
   }
-  ruleset('rulesets/junit.xml')
   ruleset('rulesets/logging.xml')
   ruleset('rulesets/naming.xml') {
     FactoryMethodName(enabled: false)
@@ -61,6 +64,7 @@ ruleset {
   ruleset('rulesets/serialization.xml')
   ruleset('rulesets/size.xml') {
     CrapMetric(enabled: false)
+    MethodCount(enabled: false)
   }
   ruleset('rulesets/unnecessary.xml') {
     UnnecessaryDefInMethodDeclaration(enabled: false)

--- a/src/main/groovy/com/github/benmanes/gradle/versions/VersionsPlugin.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/VersionsPlugin.groovy
@@ -16,24 +16,30 @@
 package com.github.benmanes.gradle.versions
 
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import com.github.benmanes.gradle.versions.version.GetVersion
+import com.github.benmanes.gradle.versions.version.SetVersion
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.util.GradleVersion
 
 /**
- * Registers the plugin's tasks.
+ * Registers the plugin's tasks and extension.
  */
 @CompileStatic
 class VersionsPlugin implements Plugin<Project> {
+
   @Override
   void apply(Project project) {
-    if (GradleVersion.current() < GradleVersion.version("5.0")) {
+    if (GradleVersion.current() < GradleVersion.version('5.0')) {
       project.logger.error(
-        "Gradle 5.0 or greater is required to apply the com.github.ben-manes.versions plugin.")
+        'Gradle 5.0 or greater is required to apply the com.github.ben-manes.versions plugin.')
       return
     }
 
+    project.extensions.create('versions', VersionsPluginExtension)
     project.tasks.register('dependencyUpdates', DependencyUpdatesTask)
+    project.tasks.register('getVersion', GetVersion)
+    project.tasks.register('setVersion', SetVersion)
   }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/VersionsPluginExtension.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/VersionsPluginExtension.groovy
@@ -1,0 +1,15 @@
+package com.github.benmanes.gradle.versions
+
+import groovy.transform.CompileStatic
+
+/**
+ * Plugin extension (i.e. configuration options).
+ */
+@CompileStatic
+class VersionsPluginExtension {
+
+  String defaultSuffix = 'SNAPSHOT'
+
+  Boolean skipVersionUpdate = false
+
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/parser/BuildGradleGroovyParser.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/parser/BuildGradleGroovyParser.groovy
@@ -1,0 +1,91 @@
+package com.github.benmanes.gradle.versions.parser
+
+import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.builder.AstBuilder
+import org.codehaus.groovy.ast.expr.BinaryExpression
+import org.codehaus.groovy.ast.expr.Expression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.stmt.BlockStatement
+import org.codehaus.groovy.ast.stmt.ExpressionStatement
+import org.codehaus.groovy.ast.stmt.ReturnStatement
+import org.codehaus.groovy.ast.stmt.Statement
+import org.gradle.api.GradleException
+
+/**
+ * Parser for build.gradle files which are based on groovy syntax.
+ */
+@CompileStatic
+class BuildGradleGroovyParser extends BuildGradleParser {
+
+  private List<ASTNode> astNodes
+  private Expression versionAstExpr
+  private String versionDefinition, versionExpression
+
+  BuildGradleGroovyParser(final File file) {
+    super(file)
+  }
+
+  @Override
+  String getVersionExpression() {
+    if (!versionExpression) {
+      if (getVersionAstExpr()) {
+        versionExpression = ''
+        final String[] contentLines = content.split('\\r?\\n')
+        final String newLine = content.find('\r\n') ?: '\n'
+        for (i in getVersionAstExpr().getLineNumber()..getVersionAstExpr().getLastLineNumber()) {
+          int startPos = i == getVersionAstExpr().getLineNumber() ? getVersionAstExpr().getColumnNumber() - 1 : 0
+          if (i == getVersionAstExpr().getLastLineNumber()) {
+            versionExpression += contentLines[i - 1].substring(startPos, getVersionAstExpr().getLastColumnNumber() - 1)
+          } else {
+            versionExpression += contentLines[i - 1].substring(startPos) + newLine
+          }
+        }
+      }
+    }
+    return versionExpression
+  }
+
+  @Override
+  String getVersionDefinition() {
+    if (!versionDefinition) {
+      if (getVersionAstExpr()) {
+        if (getVersionAstExpr() instanceof MethodCallExpression) {
+          versionDefinition = ((MethodCallExpression) getVersionAstExpr()).getArguments().getText()
+        } else if (getVersionAstExpr() instanceof BinaryExpression) {
+          versionDefinition = ((BinaryExpression) getVersionAstExpr()).getRightExpression().getText()
+        }
+      }
+    }
+    return versionDefinition
+  }
+
+  private List<ASTNode> getAstNodes() {
+    if (astNodes == null) {
+      astNodes = (List<ASTNode>) new AstBuilder().buildFromString(content)
+    }
+    return astNodes
+  }
+
+  @TypeChecked(TypeCheckingMode.SKIP)
+  private Expression getVersionAstExpr() {
+    if (versionAstExpr == null) {
+      final BlockStatement blockStatement = getAstNodes()[0] as BlockStatement
+      blockStatement.getStatements().each { Statement statement ->
+        if (statement instanceof ExpressionStatement || statement instanceof ReturnStatement) {
+          final Expression expression = statement.getExpression()
+          if ((expression instanceof MethodCallExpression && expression.getMethod().getText() == 'version')
+            || (expression instanceof BinaryExpression && expression.getLeftExpression().getText() == 'version')) {
+            versionAstExpr = expression
+          }
+        }
+      }
+      if (!versionAstExpr) {
+        throw new GradleException("Could not locate version declaration in file ${file.getPath()}")
+      }
+    }
+    return versionAstExpr
+  }
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/parser/BuildGradleKotlinParser.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/parser/BuildGradleKotlinParser.groovy
@@ -1,0 +1,64 @@
+package com.github.benmanes.gradle.versions.parser
+
+import groovy.transform.CompileStatic
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.psi.*
+
+@CompileStatic
+class BuildGradleKotlinParser extends BuildGradleParser {
+
+  private KtFile psi
+  private KtBinaryExpression versionKtBinaryExpression
+
+  BuildGradleKotlinParser(final File file) {
+    super(file)
+  }
+
+  @Override
+  String getVersionExpression() {
+    return getVersionKtBinaryExpression() ? getVersionKtBinaryExpression().getText() : null
+  }
+
+  @Override
+  String getVersionDefinition() {
+    return getVersionKtBinaryExpression() ?
+      getVersionKtBinaryExpression().getLastChild().getText().replaceAll(/['"]/, '') : null
+  }
+
+  private KtFile getPsi() {
+    if (psi == null) {
+      final CompilerConfiguration compilerConf = new CompilerConfiguration()
+      compilerConf.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
+        new PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false))
+      Disposer.newDisposable().with { Disposable disposable ->
+        final KotlinCoreEnvironment env = KotlinCoreEnvironment.createForProduction(
+          disposable, compilerConf, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+        psi = new KtPsiFactory(env.project).createFile(file.getName(), getContent())
+      }
+    }
+    return psi
+  }
+
+  private KtBinaryExpression getVersionKtBinaryExpression() {
+    if (versionKtBinaryExpression == null) {
+      for (final KtExpression statement : getPsi().findChildByClass(KtScript).getBlockExpression().getStatements()) {
+        if (statement instanceof KtScriptInitializer) {
+          final PsiElement element = statement.getFirstChild()
+          if (element instanceof KtBinaryExpression && element.getFirstChild().getText() == 'version') {
+            versionKtBinaryExpression = (KtBinaryExpression) element
+            break
+          }
+        }
+      }
+    }
+    return versionKtBinaryExpression
+  }
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/parser/BuildGradleParser.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/parser/BuildGradleParser.groovy
@@ -1,0 +1,53 @@
+package com.github.benmanes.gradle.versions.parser
+
+import groovy.transform.CompileStatic
+
+/**
+ * Parser targeted for analyzing gradle build files.
+ */
+@CompileStatic
+abstract class BuildGradleParser {
+
+  protected File file
+  protected String content
+
+  private BuildGradleParser() {
+  }
+
+  protected BuildGradleParser(final File file) {
+    if (!file.exists()) {
+      throw new FileNotFoundException("Can not find file ${file.getPath()}")
+    }
+    this.file = file
+    this.content = file.getText()
+  }
+
+  /**
+   * Get the parsed file.
+   * @return File.
+   */
+  File getFile() {
+    return file
+  }
+
+  /**
+   * Get the content of the gradle build file.
+   * @return Gradle build file content.
+   */
+  String getContent() {
+    return content
+  }
+
+  /**
+   * Get the project version expression, exactly as defined in the gradle build file.
+   * @return Project version expression, i.e. 'version=project.findProperty("projectVersion").toString()',
+   * 'version "1.0.0"' ...
+   */
+  abstract String getVersionExpression()
+
+  /**
+   * Get the project version definition, after java class generation.
+   * @return Project version definition.
+   */
+  abstract String getVersionDefinition()
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/parser/GradlePropertiesParser.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/parser/GradlePropertiesParser.groovy
@@ -1,0 +1,66 @@
+package com.github.benmanes.gradle.versions.parser
+
+import groovy.transform.CompileStatic
+
+import java.util.regex.Matcher
+
+@CompileStatic
+class GradlePropertiesParser {
+
+  final File file
+  final String content
+  final Properties props
+
+  GradlePropertiesParser(final File propertiesFile) {
+    this.file = propertiesFile
+    this.content = propertiesFile.getText()
+    props = new Properties()
+    propertiesFile.withInputStream { InputStream inputStream ->
+      props.load(inputStream)
+    }
+  }
+
+  /**
+   * Get entries.
+   * @return List entries.
+   */
+  List<Map.Entry<String, String>> getEntries() {
+    return (props.entrySet()).toList() as List<Map.Entry<String, String>>
+  }
+
+  /**
+   * Get all the keys with a given value.
+   * @param value Value to look for.
+   * @return List of keys.
+   */
+  List<String> getKeys(final String value) {
+    return (List<String>) props.findResults { final Map.Entry entry ->
+      (entry.getValue() == value) ? (String) entry.getKey() : null
+    }
+  }
+
+  /**
+   * Get the keys of this properties file that are contained in a given string.
+   * @param string String in which to look for keys.
+   * @return Set of keys.
+   */
+  Set<String> getKeysContainedIn(final String string) {
+    props.keySet().findAll { final Object curKey ->
+      string.contains((String) curKey)
+    } as Set<String>
+  }
+
+  /**
+   * Get the definition of a given key, with original formatting.
+   * @param key Key to look for.
+   * @return Key/value definition.
+   */
+  String getExpression(final String key) {
+    final String value = props.get(key)
+    if (value) {
+      final Matcher matcher = content =~ /(?m)^(\s*${key}\s*[=:]\s*['"]?${value}['"]?\s*)$/
+      return ((List<String>) matcher[0])[0]
+    }
+    return null
+  }
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/version/GetVersion.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/version/GetVersion.groovy
@@ -1,0 +1,239 @@
+package com.github.benmanes.gradle.versions.version
+
+import com.github.benmanes.gradle.versions.VersionsPluginExtension
+import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+
+import java.util.regex.Matcher
+
+@CompileStatic
+class GetVersion extends DefaultTask {
+
+  protected final static String HYPHEN = '-'
+  protected final static String SNAPSHOT = 'SNAPSHOT'
+
+  protected final static String OPT_DEFAULT_SUFFIX = 'defaultSuffix'
+  protected final static String OPT_NEW_VERSION = 'new-version'
+  protected final static String OPT_SUFFIX = 'suffix'
+  protected final static String OPT_NO_SUFFIX = 'no-suffix'
+  protected final static String OPT_INCREMENT = 'increment'
+  protected final static String OPT_INCREMENT_MAJOR = 'major'
+  protected final static String OPT_INCREMENT_MINOR = 'minor'
+  protected final static String OPT_INCREMENT_TECHNICAL = 'technical'
+  protected final static String ERROR_SUFFIX_AND_NOSUFFIX = "Options '$OPT_SUFFIX' and '$OPT_NO_SUFFIX' are " +
+    'mutually exclusive, you can use only one of those.'
+  protected final static String ERROR_NEWVERSION_AND_SUFFIX_OR_NOSUFFIX = "Options '$OPT_NEW_VERSION', " +
+    "'$OPT_SUFFIX' and '$OPT_NO_SUFFIX' are mutually exclusive, you can use only one of those."
+  protected final static String ERROR_INCREMENT_POSITION_OUT_OF_BOUND = 'Increment position (%s) is greater than the ' +
+    'numbers of digits in the version (%s).'
+  protected final static String ERROR_UNKNOWN_INCREMENT = "Value of option '$OPT_INCREMENT' must be a digit, " +
+    "'$OPT_INCREMENT_MAJOR', '$OPT_INCREMENT_MINOR', or '$OPT_INCREMENT_TECHNICAL'."
+  protected final static String WARN_UNSPECIFIED_VERSION = 'Version is undefined, can not apply any change onto it.'
+
+  protected String newVersion = System.properties[OPT_NEW_VERSION]
+
+  @Input
+  @Optional
+  String getNewVersion() {
+    return newVersion
+  }
+
+  @Option(option = OPT_NEW_VERSION, description = 'Specify the new version for scratch')
+  void setNewVersion(final String newVersion) {
+    this.newVersion = newVersion
+  }
+
+  protected String suffix = System.properties[OPT_SUFFIX]
+
+  @Input
+  @Optional
+  String getSuffix() {
+    return suffix
+  }
+
+  @Option(option = OPT_SUFFIX,
+    description = 'Append or replace a suffix to the version. Can be a string, true to append the default suffix or false to trim any existing suffix.')
+  void setSuffix(final String suffix) {
+    this.suffix = suffix
+  }
+
+  protected Boolean noSuffix = System.properties[OPT_NO_SUFFIX]
+
+  @Input
+  @Optional
+  Boolean getNoSuffix() {
+    return noSuffix
+  }
+
+  @Option(option = OPT_NO_SUFFIX, description = 'Remove existing suffix if any.')
+  void setNoSuffix(final Boolean noSuffix) {
+    this.noSuffix = noSuffix
+  }
+
+  protected String increment = System.properties[OPT_INCREMENT]
+
+  @Input
+  @Optional
+  String getIncrement() {
+    return increment
+  }
+
+  @Option(option = OPT_INCREMENT,
+    description = 'Position of a version digit to increment, starting at 1, from left to right. Following digits will be set to 0. Aliases can be used : \'major\' for the first digit, \'minor\' for the second, \'technical\' for the third.')
+  void setIncrement(final String increment) {
+    this.increment = increment
+  }
+
+  @Internal
+  String currentVersion
+
+  @Internal
+  String computedVersion
+
+  GetVersion() {
+    description = 'Get current version eventually modified by incrementation and/or suffix addition or removal.'
+    group = 'Help'
+  }
+
+  @TaskAction
+  void run() {
+    logger.quiet(getComputedVersion())
+  }
+
+  String getCurrentVersion() {
+    if (!currentVersion) {
+      currentVersion = ((String) project.getVersion()).trim()
+    }
+    return currentVersion
+  }
+
+  /**
+   * Compute version following given options.
+   * @return Computed version.
+   */
+  String getComputedVersion() {
+    if (!computedVersion) {
+      checkOptions()
+
+      // Get new version
+      if (getCurrentVersion() == project.DEFAULT_VERSION) { // No version defined in the project
+        logger.warn(WARN_UNSPECIFIED_VERSION)
+        computedVersion = getCurrentVersion()
+      } else if (newVersion) { // A new version is provided
+        computedVersion = newVersion
+      } else { // Computing version based on task options
+        // Parse current version into prefix, baseVersion and suffix
+        final Tuple3 versionElements = parseVersion(getCurrentVersion())
+
+        // Increment base version if needed
+        final String baseVersion = incrementVersion((String) versionElements.getSecond())
+
+        // Append/remove a suffix if needed
+        String newSuffix = versionElements.getThird()
+        if (noSuffix) {
+          newSuffix = ''
+        } else if (getSuffix()) {
+          newSuffix = HYPHEN + getSuffix()
+        }
+
+        // Build new version
+        computedVersion = ((String) versionElements.getFirst() ?: '') + baseVersion + (newSuffix ?: '')
+      }
+    }
+    return computedVersion
+  }
+
+  @TypeChecked(TypeCheckingMode.SKIP)
+  protected static Tuple3 parseVersion(final String version) {
+    final Matcher baseVersionMatcher = version =~ /[a-zA-Z0-1\/_-]*((\d+.)+\d+)[a-zA-Z0-1\/_-]*/
+    String baseVersion = baseVersionMatcher[0][1]
+    final Matcher prefixMatcher = version =~ /([a-zA-Z0-1\/_-]*)$baseVersion.*/
+    String prefix = prefixMatcher[0][1]
+    final Matcher suffixMatcher = version =~ /.*$baseVersion([a-zA-Z0-1\/_-]*)/
+    String suffix = suffixMatcher[0][1]
+    return new Tuple3(prefix, baseVersion, suffix)
+  }
+
+  protected void checkOptions() {
+    if (suffix) {
+      switch (suffix.toLowerCase()) {
+        case 'true':
+          suffix = ((VersionsPluginExtension) project.extensions.getByName('versions')).defaultSuffix
+          break
+        case 'false':
+          noSuffix = true
+          suffix = null
+          break
+        default:
+          // nothing to do
+          break
+      }
+    }
+
+    if (suffix && noSuffix) {
+      throw new InvalidUserDataException(ERROR_SUFFIX_AND_NOSUFFIX)
+    } else if (newVersion && (suffix || noSuffix)) {
+      throw new InvalidUserDataException(ERROR_NEWVERSION_AND_SUFFIX_OR_NOSUFFIX)
+    }
+  }
+
+  /**
+   * Apply increments options to {@code version}.
+   * @param version Version to increment.
+   * @return Incremented version.
+   */
+  protected String incrementVersion(final String version) {
+    // Parse increment option
+    Integer incrementPosition
+    switch (increment) {
+      case null:
+      case '':
+        return version
+      case OPT_INCREMENT_MAJOR:
+        incrementPosition = 1
+        break
+      case OPT_INCREMENT_MINOR:
+        incrementPosition = 2
+        break
+      case OPT_INCREMENT_TECHNICAL:
+        incrementPosition = 3
+        break
+      case ~/^[0-9]+$/:
+        incrementPosition = increment.toInteger()
+        break
+      default:
+        throw new InvalidUserDataException(ERROR_UNKNOWN_INCREMENT)
+    }
+
+    // Split numbers
+    String[] versionComponents = version.split('\\.')
+    if (incrementPosition > versionComponents.size()) {
+      throw new InvalidUserDataException(
+        String.format(ERROR_INCREMENT_POSITION_OUT_OF_BOUND, incrementPosition, versionComponents.size()))
+    }
+
+    // Increment the number
+    String number = versionComponents[incrementPosition - 1]
+    int numberInt = Integer.valueOf(number)
+    versionComponents[incrementPosition - 1] = ++numberInt
+
+    // Concatenate the version string
+    String newVersion = ''
+    int i = 0
+    for (; i < incrementPosition; i++) {
+      newVersion += versionComponents[i] + '.'
+    }
+    for (; i < versionComponents.length; i++) {
+      newVersion += '0.'
+    }
+    return newVersion[0..-2]
+  }
+}

--- a/src/main/groovy/com/github/benmanes/gradle/versions/version/SetVersion.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/version/SetVersion.groovy
@@ -1,0 +1,129 @@
+package com.github.benmanes.gradle.versions.version
+
+import com.github.benmanes.gradle.versions.VersionsPluginExtension
+import com.github.benmanes.gradle.versions.parser.BuildGradleGroovyParser
+import com.github.benmanes.gradle.versions.parser.BuildGradleKotlinParser
+import com.github.benmanes.gradle.versions.parser.BuildGradleParser
+import com.github.benmanes.gradle.versions.parser.GradlePropertiesParser
+import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskAction
+import org.gradle.util.GFileUtils
+
+@CompileStatic
+class SetVersion extends GetVersion {
+
+  protected final static String INFO_SKIPPED = 'Version update skipped by configuration.'
+  protected final static String WARN_DO_NOT_SET_SAME_VERSION = 'Trying to set the same version already configured' +
+    ', skipping task.'
+
+  @TaskAction
+  void run() {
+    if (((VersionsPluginExtension) project.extensions.getByName('versions')).skipVersionUpdate) {
+      logger.info(INFO_SKIPPED)
+      return
+    }
+    if (getCurrentVersion() == getComputedVersion()) {
+      logger.warn(WARN_DO_NOT_SET_SAME_VERSION)
+      return
+    }
+
+    // Try and update version from project build file
+    if (updateVersionFromBuildFile(project.getBuildFile())) {
+      return
+    }
+
+    // Try and update version from a buildSrc plugin
+    final File buildSrcRootFile = project.getRootProject().file('buildSrc')
+    if (buildSrcRootFile.exists()) {
+      logger.info('Looking in buildSrc for the version definition in a plugin.')
+      final List<String> projectPlugins = project.getPlugins().collect { final Plugin plugin ->
+        plugin.getClass().getName().replace('Plugin', '').toLowerCase()
+      }
+
+      final Collection<File> buildScripts = GFileUtils.listFiles(new File(buildSrcRootFile, 'src/main'),
+        ['gradle', 'gradle.kts'] as String[], true)
+      for (final File gradleFile : buildScripts) {
+        if (projectPlugins.contains(gradleFile.getName().replaceAll('\\.gradle(\\.kts)?', ''))
+          && updateVersionFromBuildFile(gradleFile)) {
+          return
+        }
+      }
+    }
+
+    // Did not find the version anywhere ...
+    throw new GradleException("Can not find the definition of current version '${getCurrentVersion()}'. " +
+      'Activate info traces to see where it was searched.')
+  }
+
+  @TypeChecked(TypeCheckingMode.SKIP)
+  private static BuildGradleParser getBuildGradleParser(final File buildGradleFile) {
+    return buildGradleFile.getName().endsWith('.kts') ? new BuildGradleKotlinParser(buildGradleFile)
+      : new BuildGradleGroovyParser(buildGradleFile)
+  }
+
+  private Boolean updateVersionFromBuildFile(final File buildFile) {
+    Boolean found = false
+    final BuildGradleParser buildGradleParser = getBuildGradleParser(buildFile)
+
+    final String versionDefinition = buildGradleParser.getVersionDefinition()
+    if (versionDefinition) {
+      if (versionDefinition.contains(getCurrentVersion())) {
+        logger.info("Version defined in file ${buildGradleParser.getFile().getPath()}, updating it.")
+        updateVersionInFile(buildGradleParser)
+        found = true
+      } else if (project.tasks.size() > 1 && versionDefinition.contains(getComputedVersion())) {
+        logger.info('Version already updated, probably in a previous task execution.')
+        found = true
+      } else {
+        logger.info('Version not defined directly in build file, looking for a variable in gradle.properties files.')
+        for (Project curProject = project; !found && curProject; curProject = curProject.getParent()) {
+          found = updateVersionFromProperties(buildGradleParser, curProject.file('gradle.properties'))
+        }
+      }
+    } else {
+      logger.info("No version definition found in ${buildGradleParser.getFile().getPath()}.")
+    }
+    return found
+  }
+
+  private Boolean updateVersionFromProperties(final BuildGradleParser buildGradleParser,
+                                              final File gradlePropertiesFile) {
+    Boolean found = false
+    if (gradlePropertiesFile.exists()) {
+      logger.info("Searching version variable in ${gradlePropertiesFile.getPath()}")
+      final GradlePropertiesParser propertiesParser = new GradlePropertiesParser(gradlePropertiesFile)
+      // Loop in keys that are found in build.gradle version definition
+      for (final String curKey : propertiesParser.getKeysContainedIn(buildGradleParser.getVersionDefinition())) {
+        final String curValue = propertiesParser.props[curKey]
+        if (curValue == getCurrentVersion()) {
+          updateVersionInFile(propertiesParser.getFile(), propertiesParser.getExpression(curKey),
+            propertiesParser.getContent())
+          found = true
+        } else if (project.tasks.size() > 1 && curValue == getComputedVersion()) {
+          logger.info('Version already updated, probably in a previous task execution.')
+          found = true
+        }
+      }
+      logger.info("Could not find a variable matching project version in ${gradlePropertiesFile.getPath()}.")
+    }
+    return found
+  }
+
+  private void updateVersionInFile(final BuildGradleParser buildGradleParser) {
+    updateVersionInFile(buildGradleParser.getFile(), buildGradleParser.getVersionExpression(),
+      buildGradleParser.getContent())
+  }
+
+  private void updateVersionInFile(final File file, final String versionExpression,
+                                   final String fileContent = file.getText()) {
+    file.delete()
+    file << fileContent.replace(
+      versionExpression,
+      versionExpression.replace(getCurrentVersion(), getComputedVersion()))
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionErrorSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionErrorSpec.groovy
@@ -1,0 +1,124 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GetVersionErrorSpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { final String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "'$path'" }
+      .join(', ')
+  }
+
+  void cleanup() {
+    if (buildFile) {
+      buildFile.delete()
+    }
+  }
+
+  void 'Warning when version unspecified'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains(GetVersion.WARN_UNSPECIFIED_VERSION)
+    result.output.contains('unspecified')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Error when specifying suffix and no-suffix at the same time'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = 'com.github.ben-manes'
+        version = '1.0.0-SNAPSHOT'
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_SUFFIX}=rc", "--${GetVersion.OPT_NO_SUFFIX}")
+      .withPluginClasspath()
+      .buildAndFail()
+
+    then:
+    !result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains(GetVersion.ERROR_SUFFIX_AND_NOSUFFIX)
+    result.task(':getVersion').outcome == FAILED
+  }
+
+  void 'Error when options new-version and no-suffix are given'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "-D${GetVersion.OPT_NEW_VERSION}=1.2.3", "--${GetVersion.OPT_NO_SUFFIX}")
+      .withPluginClasspath()
+      .buildAndFail()
+
+    then:
+    final String buildFileContent = buildFile.getText()
+    buildFileContent.contains('1.0.0-SNAPSHOT')
+    !result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains(SetVersion.ERROR_NEWVERSION_AND_SUFFIX_OR_NOSUFFIX)
+    result.task(':setVersion').outcome == FAILED
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionGroovySpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionGroovySpec.groovy
@@ -1,0 +1,399 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GetVersionGroovySpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile, propertiesFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { final String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "'$path'" }
+      .join(', ')
+  }
+
+  void cleanup() {
+    if (buildFile) {
+      buildFile.delete()
+    }
+    if (propertiesFile) {
+      propertiesFile.delete()
+    }
+  }
+
+  void 'Get version from build.gradle'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = 'com.github.ben-manes'
+        version = '1.0.0-SNAPSHOT'
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with beta suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group 'com.github.ben-manes'
+        version '1.0.0-SNAPSHOT'
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_SUFFIX}=beta")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('1.0.0-beta')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle without suffix and existing prefix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "rel12-1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_NO_SUFFIX}")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('1.0.0')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with default suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "1.0.0"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_SUFFIX}=true")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with 3 digits version, technical increment and existing suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group 'com.github.ben-manes'
+        version '1.0.0-beta'
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_INCREMENT}=technical")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0-beta')
+    result.output.contains('1.0.1-beta')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with 3 digits version, minor increment, default suffix and existing prefix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "v1.0.1"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_INCREMENT}=minor", "--${GetVersion.OPT_SUFFIX}=true")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('v1.0.1-dev')
+    result.output.contains('v1.1.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with 3 digits version, major increment and rc suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = "com.github.ben-manes"
+        version = "1.2.3-dev"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_SUFFIX}=rc", "--${GetVersion.OPT_INCREMENT}=major")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.2.3-dev')
+    result.output.contains('2.0.0-rc')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with 4 digits version, 4th digit increment, existing suffix and prefix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "feature/42-1.2.3.4dev"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_INCREMENT}=4")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('feature/42-1.2.3.4dev')
+    result.output.contains('feature/42-1.2.3.5dev')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with 2 digits version, minor increment, existing prefix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "v1.0"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_INCREMENT}=minor")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('v1.0')
+    result.output.contains('v1.1')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle with custom default suffix configured in build file'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "1.0.0"
+
+        versions {
+          ${GetVersion.OPT_DEFAULT_SUFFIX} = 'alpha'
+        }
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_SUFFIX}=true")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-alpha')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from gradle.properties'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = 'com.github.ben-manes'
+        version "\${pluginVersion}"
+""".stripIndent()
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0')
+    result.output.contains('2.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from gradle.properties with already existing suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = 'com.github.ben-manes'
+        version "\${pluginVersion}"
+""".stripIndent()
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion: '1.0.0'
+        pluginVersion: '2.0.0-SNAPSHOT'
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_SUFFIX}=SNAPSHOT")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0')
+    result.output.contains('2.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionKotlinSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionKotlinSpec.groovy
@@ -1,0 +1,196 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GetVersionKotlinSpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile, propertiesFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "\"$path\"" }
+      .join(', ')
+  }
+
+  void cleanup() {
+    if (buildFile) {
+      buildFile.delete()
+    }
+    if (propertiesFile) {
+      propertiesFile.delete()
+    }
+  }
+
+  void 'Get version from build.gradle.kts'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle.kts with beta suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "--${GetVersion.OPT_SUFFIX}=beta")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('1.0.0-beta')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from build.gradle.kts without suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_NO_SUFFIX}=true")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('1.0.0')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from gradle.properties'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0')
+    result.output.contains('2.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+
+  void 'Get version from gradle.properties with already existing suffix'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        fun properties(key: String) = project.findProperty(key).toString()
+
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = properties("pluginVersion")
+""".stripIndent()
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion: '1.0.0'
+        pluginVersion: '2.0.0-SNAPSHOT'
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion', "-D${GetVersion.OPT_SUFFIX}=SNAPSHOT")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    !result.output.contains('1.0.0')
+    result.output.contains('2.0.0-SNAPSHOT')
+    result.task(':getVersion').outcome == SUCCESS
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionMultiModuleSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/GetVersionMultiModuleSpec.groovy
@@ -1,0 +1,264 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GetVersionMultiModuleSpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  @Shared
+  private File settingsGradle
+  @Shared
+  private File module1Folder
+  @Shared
+  private File module2Folder
+  @Shared
+  private File module1BuildFile
+  @Shared
+  private File module2BuildFile
+  @Shared
+  private File propertiesFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "\"$path\"" }
+      .join(', ')
+  }
+
+  void setup() {
+    if (!settingsGradle || !settingsGradle.exists()) {
+      settingsGradle = testProjectDir.newFile('settings.gradle.kts')
+      settingsGradle << '''
+rootProject.name = "dummy"
+include("module1", "module2")
+'''
+    }
+    if (!module1Folder || !module1Folder.exists()) {
+      module1Folder = testProjectDir.newFolder('module1')
+    }
+    if (!module1BuildFile || !module1BuildFile.exists()) {
+      module1BuildFile = new File(module1Folder, 'build.gradle.kts')
+    }
+    if (!module2Folder || !module2Folder.exists()) {
+      module2Folder = testProjectDir.newFolder('module2')
+    }
+    if (!module2BuildFile || !module2BuildFile.exists()) {
+      module2BuildFile = new File(module2Folder, 'build.gradle.kts')
+    }
+  }
+
+  void cleanup() {
+    if (module1BuildFile) {
+      module1BuildFile.delete()
+    }
+    if (module2BuildFile) {
+      module2BuildFile.delete()
+    }
+    if (propertiesFile) {
+      propertiesFile.delete()
+    }
+  }
+
+  void 'Get versions from 2 modules that define their own version'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "2.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('2.0.0-SNAPSHOT')
+    result.task(':getVersion') == null
+    result.task(':module1:getVersion').outcome == SUCCESS
+    result.task(':module2:getVersion').outcome == SUCCESS
+  }
+
+  void 'Get versions from 2 modules with one which does not define a version'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('unspecified')
+    result.task(':getVersion') == null
+    result.task(':module1:getVersion').outcome == SUCCESS
+    result.task(':module2:getVersion').outcome == SUCCESS
+  }
+
+  void 'Get versions from 2 modules with a common version defined in common gradle.properties'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('2.0.0-SNAPSHOT')
+    !result.output.contains('unspecified')
+    result.task(':getVersion') == null
+    result.task(':module1:getVersion').outcome == SUCCESS
+    result.task(':module2:getVersion').outcome == SUCCESS
+  }
+
+  void 'Get versions from 2 modules with versions defined in common and local gradle.properties'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    final File localGradlePropertiesFile = new File(module1Folder, 'gradle.properties')
+    localGradlePropertiesFile << '''pluginVersion=1.0.0-SNAPSHOT'''.stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('getVersion')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('1.0.0-SNAPSHOT')
+    result.output.contains('2.0.0-SNAPSHOT')
+    !result.output.contains('unspecified')
+    result.task(':getVersion') == null
+    result.task(':module1:getVersion').outcome == SUCCESS
+    result.task(':module2:getVersion').outcome == SUCCESS
+  }
+
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/SetVersionGroovySpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/SetVersionGroovySpec.groovy
@@ -1,0 +1,174 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class SetVersionGroovySpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile, propertiesFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { final String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "'$path'" }
+      .join(', ')
+  }
+
+  void cleanup() {
+    if (buildFile) {
+      buildFile.delete()
+    }
+    if (propertiesFile) {
+      propertiesFile.delete()
+    }
+  }
+
+  void 'Set version without suffix in build.gradle'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = 'com.github.ben-manes'
+        version = '1.0.0-SNAPSHOT'
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "--${GetVersion.OPT_NO_SUFFIX}")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String buildFileContent = buildFile.getText()
+    !result.output.contains('1.0.0-SNAPSHOT')
+    !result.output.contains('1.0.0')
+    !buildFileContent.contains('1.0.0-SNAPSHOT')
+    buildFileContent.contains('1.0.0')
+    result.task(':setVersion').outcome == SUCCESS
+  }
+
+  void 'Set dev version in build.gradle'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group 'com.github.ben-manes'
+        version '1.0.0-SNAPSHOT'
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "-D${GetVersion.OPT_SUFFIX}=dev")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String buildFileContent = buildFile.getText()
+    !result.output.contains('1.0.0-SNAPSHOT')
+    !result.output.contains('1.0.0-dev')
+    !buildFileContent.contains('1.0.0-SNAPSHOT')
+    buildFileContent.contains('1.0.0-dev')
+    result.task(':setVersion').outcome == SUCCESS
+  }
+
+  void 'Set current version in build.gradle'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group "com.github.ben-manes"
+        version "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "-D${GetVersion.OPT_SUFFIX}=SNAPSHOT")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String buildFileContent = buildFile.getText()
+    !result.output.contains('1.0.0-SNAPSHOT')
+    buildFileContent.contains('1.0.0-SNAPSHOT')
+    result.output.contains(SetVersion.WARN_DO_NOT_SET_SAME_VERSION)
+    result.task(':setVersion').outcome == SUCCESS
+  }
+
+  void 'Set rc version in gradle.properties'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: "com.github.ben-manes.versions"
+
+        group = 'com.github.ben-manes'
+        version = "\${pluginVersion}"
+""".stripIndent()
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "--${GetVersion.OPT_SUFFIX}=rc")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String propertiesFileContent = propertiesFile.getText()
+    !result.output.contains('2.0.0-SNAPSHOT')
+    !result.output.contains('1.0.0')
+    !result.output.contains('2.0.0-rc')
+    !propertiesFileContent.contains('1.0.0-SNAPSHOT')
+    propertiesFileContent.contains('1.0.0')
+    propertiesFileContent.contains('2.0.0-rc')
+    result.task(':setVersion').outcome == SUCCESS
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/SetVersionKotlinSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/SetVersionKotlinSpec.groovy
@@ -1,0 +1,142 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class SetVersionKotlinSpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile, propertiesFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "\"$path\"" }
+      .join(', ')
+  }
+
+  void cleanup() {
+    if (buildFile) {
+      buildFile.delete()
+    }
+    if (propertiesFile) {
+      propertiesFile.delete()
+    }
+  }
+
+  void 'Set custom version in build.gradle.kts'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "-D${GetVersion.OPT_NEW_VERSION}=1.2.3")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String buildFileContent = buildFile.getText()
+    !result.output.contains('1.0.0-SNAPSHOT')
+    !result.output.contains('1.2.3')
+    !buildFileContent.contains('1.0.0-SNAPSHOT')
+    buildFileContent.contains('1.2.3')
+    result.task(':setVersion').outcome == SUCCESS
+  }
+
+  void 'Set current version in build.gradle.kts'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "--${GetVersion.OPT_SUFFIX}=SNAPSHOT")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String buildFileContent = buildFile.getText()
+    !result.output.contains('1.0.0-SNAPSHOT')
+    buildFileContent.contains('1.0.0-SNAPSHOT')
+    result.output.contains(SetVersion.WARN_DO_NOT_SET_SAME_VERSION)
+    result.task(':setVersion').outcome == SUCCESS
+  }
+
+  void 'Set release version in gradle.properties'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle.kts')
+    buildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', "-D${GetVersion.OPT_SUFFIX}=release")
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String propertiesFileContent = propertiesFile.getText()
+    !result.output.contains('1.0.0')
+    !result.output.contains('2.0.0-SNAPSHOT')
+    !result.output.contains('2.0.0-release')
+    !propertiesFileContent.contains('2.0.0-SNAPSHOT')
+    propertiesFileContent.contains('1.0.0')
+    propertiesFileContent.contains('2.0.0-release')
+    result.task(':setVersion').outcome == SUCCESS
+  }
+}

--- a/src/test/groovy/com/github/benmanes/gradle/versions/version/SetVersionMultiModuleSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/version/SetVersionMultiModuleSpec.groovy
@@ -1,0 +1,419 @@
+package com.github.benmanes.gradle.versions.version
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class SetVersionMultiModuleSpec extends Specification {
+
+  @Rule
+  private final TemporaryFolder testProjectDir = new TemporaryFolder()
+  @Shared
+  private File settingsGradle
+  @Shared
+  private File module1Folder
+  @Shared
+  private File module2Folder
+  @Shared
+  private File module1BuildFile
+  @Shared
+  private File module2BuildFile
+  @Shared
+  private File propertiesFile
+  @Shared
+  private String classpathString
+
+  void setupSpec() {
+    final URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException('Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+
+    classpathString = pluginClasspathResource.readLines().collect { String res -> new File(res) }
+      .collect { final File file -> file.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { final String path -> "\"$path\"" }
+      .join(', ')
+  }
+
+  void setup() {
+    if (!settingsGradle || !settingsGradle.exists()) {
+      settingsGradle = testProjectDir.newFile('settings.gradle.kts')
+      settingsGradle << '''
+rootProject.name = "dummy"
+include("module1", "module2")
+'''
+    }
+    if (!module1Folder || !module1Folder.exists()) {
+      module1Folder = testProjectDir.newFolder('module1')
+    }
+    if (!module1BuildFile || !module1BuildFile.exists()) {
+      module1BuildFile = new File(module1Folder, 'build.gradle.kts')
+    }
+    if (!module2Folder || !module2Folder.exists()) {
+      module2Folder = testProjectDir.newFolder('module2')
+    }
+    if (!module2BuildFile || !module2BuildFile.exists()) {
+      module2BuildFile = new File(module2Folder, 'build.gradle.kts')
+    }
+  }
+
+  void cleanup() {
+    if (module1BuildFile) {
+      module1BuildFile.delete()
+    }
+    if (module2BuildFile) {
+      module2BuildFile.delete()
+    }
+    if (propertiesFile) {
+      propertiesFile.delete()
+    }
+  }
+
+  void 'Set versions from 2 modules that define their own version'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "2.0.0-SNAPSHOT"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', '--increment=minor', '--no-suffix')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String module1BuildFileContent = module1BuildFile.getText()
+    !module1BuildFileContent.contains('1.0.0-SNAPSHOT')
+    module1BuildFileContent.contains('1.1.0')
+    final String module2BuildFileContent = module2BuildFile.getText()
+    !module2BuildFileContent.contains('2.0.0-SNAPSHOT')
+    module2BuildFileContent.contains('2.1.0')
+    result.task(':setVersion') == null
+    result.task(':module1:setVersion').outcome == SUCCESS
+    result.task(':module2:setVersion').outcome == SUCCESS
+  }
+
+  void 'Set versions from 2 modules with one which does not define a version'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = "1.0.0-SNAPSHOT"
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+""".stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', '--new-version=v1.2')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String module1BuildFileContent = module1BuildFile.getText()
+    !module1BuildFileContent.contains('1.0.0-SNAPSHOT')
+    module1BuildFileContent.contains('v1.2')
+    result.output.contains(SetVersion.WARN_DO_NOT_SET_SAME_VERSION)
+    result.task(':setVersion') == null
+    result.task(':module1:setVersion').outcome == SUCCESS
+    result.task(':module2:setVersion').outcome == SUCCESS
+  }
+
+  void 'Set versions from 2 modules with a common version defined in common gradle.properties'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', '-Dsuffix=false', '-Dincrement=major')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String propertiesFileContent = propertiesFile.getText()
+    !propertiesFileContent.contains('2.0.0-SNAPSHOT')
+    propertiesFileContent.contains('3.0.0')
+    result.task(':setVersion') == null
+    result.task(':module1:setVersion').outcome == SUCCESS
+    result.task(':module2:setVersion').outcome == SUCCESS
+  }
+
+  void 'Set versions from 2 modules with versions defined in common and local gradle.properties'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    final File localGradlePropertiesFile = new File(module1Folder, 'gradle.properties')
+    localGradlePropertiesFile << '''pluginVersion=1.0.0-SNAPSHOT'''.stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        group = "com.github.ben-manes"
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=1.0.0
+        pluginVersion=2.0.0-SNAPSHOT
+'''.stripIndent()
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', '--increment=technical')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String localGradlePropertiesFileContent = localGradlePropertiesFile.getText()
+    final String propertiesFileContent = propertiesFile.getText()
+    !localGradlePropertiesFileContent.contains('1.0.0-SNAPSHOT')
+    localGradlePropertiesFileContent.contains('1.0.1-SNAPSHOT')
+    !propertiesFileContent.contains('2.0.0-SNAPSHOT')
+    propertiesFileContent.contains('2.0.1-SNAPSHOT')
+    result.task(':setVersion') == null
+    result.task(':module1:setVersion').outcome == SUCCESS
+    result.task(':module2:setVersion').outcome == SUCCESS
+  }
+
+  void 'Set versions from 2 modules with a common version defined in a buildSrc plugin'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        plugins {
+            id("common")
+        }
+""".stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        plugins {
+            id("common")
+        }
+""".stripIndent()
+
+    final File buildSrcFolder = testProjectDir.newFolder('buildSrc')
+    final File buildSrcBuildGradle = new File(buildSrcFolder, 'build.gradle.kts')
+    buildSrcBuildGradle << '''
+        plugins {
+            `kotlin-dsl`
+        }
+
+        repositories {
+            jcenter()
+            mavenLocal()
+        }
+
+'''.stripIndent()
+
+    final File buildSrcKotlinFolder = new File(buildSrcFolder, 'src/main/kotlin')
+    buildSrcKotlinFolder.mkdirs()
+    final File buildSrcPlugin = new File(buildSrcKotlinFolder, 'common.gradle.kts')
+    buildSrcPlugin << '''
+        apply(plugin = "com.github.ben-manes.versions")
+
+        version = "1.2.3-SNAPSHOT"
+'''
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', '-Dsuffix=false', '-Dincrement=major')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String buildSrcPluginContent = buildSrcPlugin.getText()
+    !buildSrcPluginContent.contains('1.2.3-SNAPSHOT')
+    buildSrcPluginContent.contains('2.0.0')
+    result.task(':setVersion') == null
+    result.task(':module1:setVersion').outcome == SUCCESS
+    result.task(':module2:setVersion').outcome == SUCCESS
+  }
+
+  void 'Set versions from 2 modules with one defined in a buildSrc plugin, one from build file through properties'() {
+    given:
+    module1BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        apply(plugin = "com.github.ben-manes.versions")
+
+        version = project.findProperty("pluginVersion").toString()
+""".stripIndent()
+
+    propertiesFile = testProjectDir.newFile('gradle.properties')
+    propertiesFile << '''
+        anotherVersion=4.0.0
+        pluginVersion=12.1.8-SNAPSHOT
+'''.stripIndent()
+
+    module2BuildFile << """
+        buildscript {
+          dependencies {
+            classpath(files($classpathString))
+          }
+        }
+
+        plugins {
+            id("common")
+        }
+""".stripIndent()
+
+    final File module2PropertiesFile = new File(module2Folder, 'gradle.properties')
+    module2PropertiesFile << '''
+        anotherVersion=3.0.0
+        pluginVersion=0.0.1-SNAPSHOT
+'''.stripIndent()
+
+    final File buildSrcFolder = testProjectDir.newFolder('buildSrc')
+    final File buildSrcBuildGradle = new File(buildSrcFolder, 'build.gradle.kts')
+    buildSrcBuildGradle << '''
+        plugins {
+            `kotlin-dsl`
+        }
+
+        repositories {
+            jcenter()
+            mavenLocal()
+        }
+'''.stripIndent()
+
+    final File buildSrcKotlinFolder = new File(buildSrcFolder, 'src/main/kotlin')
+    buildSrcKotlinFolder.mkdirs()
+    final File buildSrcPlugin = new File(buildSrcKotlinFolder, 'common.gradle.kts')
+    buildSrcPlugin << '''
+        apply(plugin = "com.github.ben-manes.versions")
+        version = project.findProperty("pluginVersion").toString()
+'''
+
+    when:
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('setVersion', '-Dsuffix=dev', '-Dincrement=minor')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    final String propertiesFileContent = propertiesFile.getText()
+    !propertiesFileContent.contains('12.1.8-SNAPSHOT')
+    propertiesFileContent.contains('4.0.0')
+    propertiesFileContent.contains('12.2.0-dev')
+    final String module2PropertiesFileContent = module2PropertiesFile.getText()
+    !module2PropertiesFileContent.contains('0.0.1-SNAPSHOT')
+    module2PropertiesFileContent.contains('3.0.0')
+    module2PropertiesFileContent.contains('0.1.0-dev')
+    result.task(':setVersion') == null
+    result.task(':module1:setVersion').outcome == SUCCESS
+    result.task(':module2:setVersion').outcome == SUCCESS
+  }
+
+}


### PR DESCRIPTION
Hello,

I want to implement something like the maven goal versions:set to ease modification, mostly for CI needs. I think you plugin is right place to centralize this feature, but please do tell me if you disagree so that I publish it in a new plugin.

In term of functionality, the idea is to be able to change project current version with a single line command, either by setting a new one from scratch (like mvn versions:set) but also modifying it (like npm version).

I have created 2 tasks : getVersion mostly for dry run and setVersion that actually modify the version in gradle build or properties file.

The documentation is added in the readme, codenarc issues are fixed (except 3 that can't be) and added unit tests.

In term of design, I have created groovy and kotlin parsers in dedicated package for later reuse.