### PR TITLE
Fix conflict locally project plugin vs global defined

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/VersionsPlugin.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/VersionsPlugin.groovy
@@ -34,6 +34,8 @@ class VersionsPlugin implements Plugin<Project> {
       return
     }
 
-    project.tasks.register('dependencyUpdates', DependencyUpdatesTask)
+    if (!project.tasks.findByName("dependencyUpdates")) {
+      project.tasks.register('dependencyUpdates', DependencyUpdatesTask)
+    }
   }
 }


### PR DESCRIPTION
`Failed to apply plugin 'com.github.ben-manes.versions'.
 > Cannot add task 'dependencyUpdates' as a task with that name already exists.`
 when global added plugin via https://github.com/ben-manes/gradle-versions-plugin#using-a-gradle-init-script