### PR TITLE
Issue #528: also check 'strictly' dependency constraints

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
@@ -155,6 +155,9 @@ class Resolver {
     copy.dependencies.addAll(latest)
     copy.dependencies.addAll(inherited)
 
+    // Remove all dependency constraints, even the 'strictly' ones
+    copy.dependencyConstraints.clear()
+
     addRevisionFilter(copy, revision)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, currentCoordinates)

--- a/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -56,6 +56,45 @@ final class ConstraintsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  def "Show updates for an strictly implementation dependency constraint"() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'com.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            implementation('com.google.inject:guice') {version {strictly '2.0'}}
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def "Does not override explicit dependency with constraint"() {
     given:
     buildFile = testProjectDir.newFile('build.gradle')


### PR DESCRIPTION
This PR removes the dependency constraints, enabling update checks for 'strictly' constraints.
Closes #528 