### PR TITLE
Security Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
   testRuntimeOnly files(createClasspathManifest)
 
   testImplementation gradleTestKit()
-  testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
+  testImplementation('org.spockframework:spock-core:2.0-groovy-2.5') {
     exclude(module: 'groovy-all')
   }
 }


### PR DESCRIPTION
  Upgrade org.spockframework:spock-core@1.3-groovy-2.5 to org.spockframework:spock-core@2.0-groovy-2.5 to fix
  ✗ Information Exposure [Low Severity][https://snyk.io/vuln/SNYK-JAVA-JUNIT-1017047] in junit:junit@4.12
    introduced by org.spockframework:spock-core@1.3-groovy-2.5 > junit:junit@4.12 and 1 other path(s)
  ✗ Information Disclosure [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSGROOVY-1048694] in org.codehaus.groovy:groovy@2.5.4
    introduced by org.spockframework:spock-core@1.3-groovy-2.5 > org.codehaus.groovy:groovy@2.5.4 and 8 other path(s)

