### PR TITLE
Remove  deblibs-gradle-plugin from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ You may also wish to explore additional functionality provided by,
  - [gradle-update-checker](https://github.com/marketplace/actions/gradle-update-checker)
  - [gradle-libraries-plugin](https://github.com/fkorotkov/gradle-libraries-plugin)
  - [gradle-update-notifier](https://github.com/y-yagi/gradle-update-notifier)
- - [deblibs-gradle-plugin](https://github.com/hellofresh/deblibs-gradle-plugin)
  - [refreshVersions](https://github.com/jmfayard/refreshVersions)
 
 ## Tasks


### PR DESCRIPTION
Hey @ben-manes. Unfortunately we decided to stop support for https://github.com/hellofresh/deblibs-gradle-plugin. 

This PR removes a reference to it, so we can avoid redirecting people to deprecated plugin which will be really hard to integrate. If at any point we will decide to update the deblibs plugin and put it back we would let you know. 

Thank you very much!