### PR TITLE
ignore failOnDynamicVersions() to fetch latest versions

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
@@ -41,9 +41,6 @@ import org.gradle.api.artifacts.result.ComponentArtifactsResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.HasConfigurableAttributes
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
-import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
-import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.maven.MavenModule
 import org.gradle.maven.MavenPomArtifact

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Resolver.groovy
@@ -41,6 +41,9 @@ import org.gradle.api.artifacts.result.ComponentArtifactsResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.HasConfigurableAttributes
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.maven.MavenModule
 import org.gradle.maven.MavenPomArtifact
@@ -129,6 +132,12 @@ class Resolver {
     // https://github.com/ben-manes/gradle-versions-plugin/issues/127
     if (copy.metaClass.respondsTo(copy, "setCanBeResolved", Boolean)) {
       copy.setCanBeResolved(true)
+    }
+
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/592
+    // allow resolution of dynamic latest versions regardless of the original strategy
+    if(copy.resolutionStrategy.metaClass.hasProperty(copy.resolutionStrategy, "failOnDynamicVersions")) {
+      copy.resolutionStrategy.metaClass.setProperty(copy.resolutionStrategy, "failOnDynamicVersions", false)
     }
 
     // Resolve using the latest version of explicitly declared dependencies and retains Kotlin's

--- a/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -136,6 +136,30 @@ final class DependencyUpdatesSpec extends Specification {
     checkUndeclaredVersions(reporter)
   }
 
+  @Issue("https://github.com/ben-manes/gradle-versions-plugin/issues/592")
+  def 'Project configurations failOnDynamicVersions'() {
+    given:
+    def project = singleProject()
+    addRepositoryTo(project)
+    addDependenciesTo(project)
+    project.configurations.all {
+      resolutionStrategy {
+        failOnDynamicVersions()
+      }
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    checkUnresolvedVersions(reporter)
+    checkUpgradeVersions(reporter)
+    checkUpToDateVersions(reporter)
+    checkDowngradeVersions(reporter)
+    checkUndeclaredVersions(reporter)
+  }
+
   @Unroll
   def 'Single project (#revision, #outputFormat)'() {
     given:


### PR DESCRIPTION
Provides a way to fetch the latest version despite having `resolutionStrategy.failOnDynamicVersions()` active.
Gradle does not expose an official way to disable this check once activated currently. The proposed solution relies on the implementation of the internal `DefaultResolutionStrategy`, but is generally backwards compatible.

resolves #592 