### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: build
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, labeled, unlabeled, synchronize ]
 
 jobs:
   jvm:
@@ -18,18 +23,18 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Configure JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.1.0
         with:
-          distribution: 'zulu'
+          distribution: temurin
           java-version: ${{ matrix.java-version }}
 
       - name: Run build with caching enabled
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: clean build -s --scan
+          arguments: clean build -s
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,18 +13,18 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Configure JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.1.0
         with:
-          distribution: 'zulu'
+          distribution: temurin
           java-version: 8
 
       - name: Publish
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            publishPlugins -s --scan
+            publishPlugins -s
             -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
             -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,12 @@ plugins {
   `gradle-enterprise`
 }
 
+gradleEnterprise {
+  buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+    publishAlways()
+  }
+}
+
 rootProject.name = "gradle-versions-plugin"


### PR DESCRIPTION
 - Only build when based on `opened`, `labeled`, `unlabeled`, `synchronize`
   -  Prevents double builds, see https://github.com/ben-manes/gradle-versions-plugin/pull/600
 - Update `wrapper-validation-action`
 - Update `setup-java`
   - Use `temurin`
 - Remove `--scan`, allow publishing automatically after builds
 
@ben-manes 