### PR TITLE
declare explicit types

### DIFF
--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/HtmlReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/HtmlReporter.groovy
@@ -1,5 +1,9 @@
 package com.github.benmanes.gradle.versions.reporter
 
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.NIGHTLY
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
+
 import com.github.benmanes.gradle.versions.reporter.result.DependenciesGroup
 import com.github.benmanes.gradle.versions.reporter.result.Dependency
 import com.github.benmanes.gradle.versions.reporter.result.DependencyLatest
@@ -9,10 +13,6 @@ import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.reporter.result.VersionAvailable
 import groovy.transform.CompileStatic
 import groovy.transform.TupleConstructor
-
-import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
-import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.NIGHTLY
-import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
 
 /**
  * An html reporter for the dependency updates results.
@@ -94,11 +94,11 @@ class HtmlReporter extends AbstractReporter {
    """
 
   @Override
-  def write(printStream, Result result) {
+  void write(Appendable printStream, Result result) {
     writeHeader(printStream)
 
     if (result.count == 0) {
-      printStream.println '<P>No dependencies found.</P>'
+      printStream.println('<P>No dependencies found.</P>')
     } else {
       writeUpToDate(printStream, result)
       writeExceedLatestFound(printStream, result)
@@ -110,23 +110,23 @@ class HtmlReporter extends AbstractReporter {
     writeGradleUpdates(printStream, result)
   }
 
-  private def writeHeader(printStream) {
-    printStream.println header.stripMargin()
+  private void writeHeader(Appendable printStream) {
+    printStream.println(header.stripMargin())
   }
 
-  private def writeUpToDate(printStream, Result result) {
+  private void writeUpToDate(Appendable printStream, Result result) {
     SortedSet<Dependency> versions = result.getCurrent().getDependencies()
     if (!versions.isEmpty()) {
       printStream.println("<H2>Current dependencies</H2>")
       printStream.println("<p>The following dependencies are using the latest ${revision} version:<p>")
       printStream.println("<table class=\"currentInfo\">")
-      getCurrentRows(result).each { printStream.println it }
+      getCurrentRows(result).each { printStream.println(it) }
       printStream.println("</table>")
       printStream.println("<br>")
     }
   }
 
-  private static def getCurrentRows(Result result) {
+  private static List<String> getCurrentRows(Result result) {
     List<String> rows = new ArrayList<>()
     // The following dependencies are using the latest milestone version:
     DependenciesGroup<Dependency> list = result.getCurrent()
@@ -137,13 +137,13 @@ class HtmlReporter extends AbstractReporter {
       String rowStringFmt = "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>"
       rowString = String.format(rowStringFmt, item.getName(), item.getGroup(),
         getUrlString(item.getProjectUrl()), getVersionString(item.getGroup(), item.getName(), item.getVersion()),
-        item.getUserReason()?:'')
+        item.getUserReason() ?: '')
       rows.add(rowString)
     }
     return rows
   }
 
-  private def writeExceedLatestFound(printStream, Result result) {
+  private void writeExceedLatestFound(Appendable printStream, Result result) {
     SortedSet<DependencyLatest> versions = result.getExceeded().getDependencies()
     if (!versions.isEmpty()) {
       // The following dependencies exceed the version found at the '
@@ -151,13 +151,13 @@ class HtmlReporter extends AbstractReporter {
       printStream.println("<H2>Exceeded dependencies</H2>")
       printStream.println("<p>The following dependencies exceed the version found at the ${revision} revision level:<p>")
       printStream.println("<table class=\"warningInfo\">")
-      getExceededRows(result).each { printStream.println it }
+      getExceededRows(result).each { printStream.println(it) }
       printStream.println("</table>")
       printStream.println("<br>")
     }
   }
 
-  private static def getExceededRows(Result result) {
+  private static List<String> getExceededRows(Result result) {
     List<String> rows = new ArrayList<>()
     // The following dependencies are using the latest milestone version:
     DependenciesGroup<DependencyLatest> list = result.getExceeded()
@@ -169,25 +169,25 @@ class HtmlReporter extends AbstractReporter {
       rowString = String.format(rowStringFmt, item.getName(), item.getGroup(),
         getUrlString(item.getProjectUrl()), getVersionString(item.getGroup(), item.getName(), item.getVersion()),
         getVersionString(item.getGroup(), item.getName(), item.getVersion()),
-        item.getUserReason()?:'')
+        item.getUserReason() ?: '')
       rows.add(rowString)
     }
     return rows
   }
 
-  private def writeUpgrades(printStream, Result result) {
+  private void writeUpgrades(Appendable printStream, Result result) {
     SortedSet<DependencyOutdated> versions = result.getOutdated().getDependencies()
     if (!versions.isEmpty()) {
       printStream.println("<H2>Later dependencies</H2>")
       printStream.println("<p>The following dependencies have later ${revision} versions:<p>")
       printStream.println("<table class=\"warningInfo\">")
-      getUpgradesRows(result).each { printStream.println it }
+      getUpgradesRows(result).each { printStream.println(it) }
       printStream.println("</table>")
       printStream.println("<br>")
     }
   }
 
-  private def getUpgradesRows(Result result) {
+  private List<String> getUpgradesRows(Result result) {
     List<String> rows = new ArrayList<>()
     DependenciesGroup<DependencyOutdated> list = result.getOutdated()
     rows.add("<tr class=\"header\"><th colspan=\"5\"><b>Later dependencies<span>(Click to collapse)</span></b></th></tr>")
@@ -198,19 +198,19 @@ class HtmlReporter extends AbstractReporter {
       rowString = String.format(rowStringFmt, item.getName(), item.getGroup(),
         getUrlString(item.getProjectUrl()), getVersionString(item.getGroup(), item.getName(), item.getVersion()),
         getVersionString(item.getGroup(), item.getName(), getDisplayableVersion(item.getAvailable())),
-        item.getUserReason()?:'')
+        item.getUserReason() ?: '')
       rows.add(rowString)
     }
     return rows
   }
 
-  private static void writeUndeclared(printStream, Result result) {
+  private static void writeUndeclared(Appendable printStream, Result result) {
     SortedSet<Dependency> versions = result.undeclared.dependencies
     if (!versions.empty) {
       printStream.println("<H2>Undeclared dependencies</H2>")
       printStream.println("<p>Failed to compare versions for the following dependencies because they were declared without version:<p>")
       printStream.println("<table class=\"warningInfo\">")
-      getUndeclaredRows(result).each { String row -> printStream.println( row)}
+      getUndeclaredRows(result).each { String row -> printStream.println(row) }
       printStream.println("</table>")
       printStream.println("<br>")
     }
@@ -220,7 +220,7 @@ class HtmlReporter extends AbstractReporter {
     List<String> rows = new ArrayList<>()
     rows.add("<tr class=\"header\"><th colspan=\"2\"><b>Undeclared dependencies<span>(Click to collapse)</span></b></th></tr>")
     rows.add("<tr><td><b>Name</b></td><td><b>Group</b></td></tr>")
-    for(Dependency item : result.undeclared.dependencies) {
+    for (Dependency item : result.undeclared.dependencies) {
       String rowString
       rowString = String.format("<tr><td>%s</td><td>%s</td></tr>", item.name, item.group)
       rows.add(rowString)
@@ -239,19 +239,19 @@ class HtmlReporter extends AbstractReporter {
     return ""
   }
 
-  private static def writeUnresolved(printStream, Result result) {
+  private static void writeUnresolved(Appendable printStream, Result result) {
     SortedSet<DependencyUnresolved> versions = result.getUnresolved().getDependencies()
     if (!versions.isEmpty()) {
       printStream.println("<H2>Unresolved dependencies</H2>")
       printStream.println("<p>Failed to determine the latest version for the following dependencies:<p>")
       printStream.println("<table class=\"warningInfo\">")
-      getUnresolvedRows(result).each { printStream.println it }
+      getUnresolvedRows(result).each { printStream.println(it) }
       printStream.println("</table>")
       printStream.println("<br>")
     }
   }
 
-  private static def getUnresolvedRows(Result result) {
+  private static List<String> getUnresolvedRows(Result result) {
     List<String> rows = new ArrayList<>()
     DependenciesGroup<DependencyUnresolved> list = result.getUnresolved()
     rows.add("<tr class=\"header\"><th colspan=\"4\"><b>Unresolved dependencies<span>(Click to collapse)</span></b></th></tr>")
@@ -260,20 +260,19 @@ class HtmlReporter extends AbstractReporter {
       String rowString
       String rowStringFmt = "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>"
       rowString = String.format(rowStringFmt, item.getName(), item.getGroup(),
-        getUrlString(item.getProjectUrl()) , getVersionString(item.getGroup(), item.getName(), item.getVersion()),
-        item.getUserReason()?:'')
+        getUrlString(item.getProjectUrl()), getVersionString(item.getGroup(), item.getName(), item.getVersion()),
+        item.getUserReason() ?: '')
       rows.add(rowString)
     }
     return rows
   }
 
-  private def writeGradleUpdates(printStream, Result result) {
+  private void writeGradleUpdates(Appendable printStream, Result result) {
     if (!result.gradle.isEnabled()) {
       return
     }
 
     printStream.println("<H2>Gradle ${gradleReleaseChannel} updates</H2>")
-
 
     printStream.println("Gradle ${gradleReleaseChannel} updates:")
     result.gradle.with {
@@ -311,30 +310,30 @@ class HtmlReporter extends AbstractReporter {
     }
   }
 
-  private static def getGradleUrl() {
+  private static String getGradleUrl() {
     return "<P>For information about Gradle releases click <a target=\"_blank\" href=\"https://gradle.org/releases/\">here</a>."
   }
 
-  private static def getGradleVersionUrl(String version) {
+  private static String getGradleVersionUrl(String version) {
     if (version == null) {
       return "https://gradle.org/releases/"
     }
     return String.format("<a target=\"_blank\" href=\"https://docs.gradle.org/%s/release-notes.html\">%s</a>", version, version)
   }
 
-  private static def getUrlString(String url) {
+  private static String getUrlString(String url) {
     if (url == null) {
       return ""
     }
     return String.format("<a target=\"_blank\" href=\"%s\">%s</a>", url, url)
   }
 
-  private static def getVersionString(String group, String name, String version) {
+  private static String getVersionString(String group, String name, String version) {
     String mvn = getMvnVersionString(group, name, version)
     return String.format("%s %s", version, mvn)
   }
 
-  private static def getMvnVersionString(String group, String name, String version) {
+  private static String getMvnVersionString(String group, String name, String version) {
     // https://search.maven.org/artifact/com.azure/azure-core-http-netty/1.5.4
     if (version == null) {
       return ""
@@ -344,7 +343,7 @@ class HtmlReporter extends AbstractReporter {
   }
 
   @Override
-  def getFileExtension() {
+  String getFileExtension() {
     return 'html'
   }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/JsonReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/JsonReporter.groovy
@@ -12,12 +12,13 @@ import groovy.transform.TupleConstructor
 @TupleConstructor(callSuper = true, includeSuperProperties = true, includeSuperFields = true)
 class JsonReporter extends AbstractReporter {
 
-  def write(printStream, Result result) {
-    printStream.println new JsonBuilder(result).toPrettyString().stripMargin()
+  @Override
+  void write(Appendable printStream, Result result) {
+    printStream.println(new JsonBuilder(result).toPrettyString().stripMargin())
   }
 
   @Override
-  def getFileExtension() {
+  String getFileExtension() {
     return 'json'
   }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/Reporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/Reporter.groovy
@@ -15,7 +15,7 @@ interface Reporter {
    * @param result the result of the dependency update analysis
    * @see Result
    */
-  def write(target, Result result)
+  void write(Appendable target, Result result)
 
-  def getFileExtension()
+  String getFileExtension()
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/reporter/XmlReporter.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/reporter/XmlReporter.groovy
@@ -19,7 +19,7 @@ import groovy.transform.TupleConstructor
 class XmlReporter extends AbstractReporter {
 
   @Override
-  def write(printStream, Result result) {
+  void write(Appendable printStream, Result result) {
 
     XStream xstream = new XStream()
     xstream.with {
@@ -32,12 +32,12 @@ class XmlReporter extends AbstractReporter {
       alias('group', DependenciesGroup)
     }
 
-    printStream.println '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-    printStream.println xstream.toXML(result).stripMargin()
+    printStream.println('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>')
+    printStream.println(xstream.toXML(result).stripMargin())
   }
 
   @Override
-  def getFileExtension() {
+  String getFileExtension() {
     return 'xml'
   }
 }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/Coordinate.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/Coordinate.groovy
@@ -17,6 +17,7 @@ package com.github.benmanes.gradle.versions.updates
 
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
+import javax.annotation.Nullable
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
@@ -32,9 +33,9 @@ class Coordinate implements Comparable<Coordinate> {
   final String groupId
   final String artifactId
   final String version
-  final String userReason
+  @Nullable final String userReason
 
-  Coordinate(String groupId, String artifactId, String version, String userReason) {
+  Coordinate(String groupId, String artifactId, String version, @Nullable String userReason) {
     this.groupId = groupId ?: 'none'
     this.artifactId = artifactId ?: 'none'
     this.version = version ?: 'none'

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdates.groovy
@@ -54,15 +54,15 @@ class DependencyUpdates {
    */
   DependencyUpdatesReporter run() {
     Map<Project, Set<Configuration>> projectConfigs = project.allprojects
-      .collectEntries { proj -> [proj, new LinkedHashSet<>(proj.configurations) ] }
+      .collectEntries { proj -> [proj, new LinkedHashSet<>(proj.configurations)] }
     Set<DependencyStatus> status = resolveProjects(projectConfigs, checkConstraints)
 
     Map<Project, Set<Configuration>> buildscriptProjectConfigs = project.allprojects
-      .collectEntries { proj -> [proj, new LinkedHashSet<>(proj.buildscript.configurations) ] }
+      .collectEntries { proj -> [proj, new LinkedHashSet<>(proj.buildscript.configurations)] }
     Set<DependencyStatus> buildscriptStatus = resolveProjects(
       buildscriptProjectConfigs, checkBuildEnvironmentConstraints)
 
-    def statuses = status + buildscriptStatus
+    Set<DependencyStatus> statuses = status + buildscriptStatus
     VersionMapping versions = new VersionMapping(project, statuses)
     Set<UnresolvedDependency> unresolved =
       statuses.findAll { it.unresolved != null }.collect { it.unresolved } as Set
@@ -75,12 +75,12 @@ class DependencyUpdates {
   }
 
   private Set<DependencyStatus> resolveProjects(
-      Map<Project, Set<Configuration>> projectConfigs, boolean checkConstraints) {
+    Map<Project, Set<Configuration>> projectConfigs, boolean checkConstraints) {
     Set<DependencyStatus> resultStatus = []
     projectConfigs.each { currentProject, currentConfigurations ->
       Resolver resolver = new Resolver(currentProject, resolutionStrategy, checkConstraints)
       for (Configuration currentConfiguration : currentConfigurations) {
-        for(DependencyStatus newStatus : resolve(resolver, currentProject, currentConfiguration)) {
+        for (DependencyStatus newStatus : resolve(resolver, currentProject, currentConfiguration)) {
           addValidatedDependencyStatus(resultStatus, newStatus)
         }
       }
@@ -97,15 +97,15 @@ class DependencyUpdates {
    * </ol>
    */
   private static void addValidatedDependencyStatus(
-      Collection<DependencyStatus> statusCollection, DependencyStatus status) {
+    Collection<DependencyStatus> statusCollection, DependencyStatus status) {
     DependencyStatus statusWithSameCoordinateKey = statusCollection.find {
-        DependencyStatus it -> it.coordinate.key == status.coordinate.key}
-    if( !statusWithSameCoordinateKey) {
-      statusCollection.add(status)
+      DependencyStatus it -> it.coordinate.key == status.coordinate.key
     }
-    else if(status.coordinate.version != 'none') {
+    if (!statusWithSameCoordinateKey) {
       statusCollection.add(status)
-      if(statusWithSameCoordinateKey.coordinate.version == 'none') {
+    } else if (status.coordinate.version != 'none') {
+      statusCollection.add(status)
+      if (statusWithSameCoordinateKey.coordinate.version == 'none') {
         statusCollection.remove(statusWithSameCoordinateKey)
       }
     }
@@ -121,7 +121,7 @@ class DependencyUpdates {
   }
 
   private DependencyUpdatesReporter createReporter(VersionMapping versions,
-      Set<UnresolvedDependency> unresolved, Map<Map<String, String>, String> projectUrls) {
+                                                   Set<UnresolvedDependency> unresolved, Map<Map<String, String>, String> projectUrls) {
     Map<Map<String, String>, Coordinate> currentVersions =
       versions.current.collectEntries { [[group: it.groupId, name: it.artifactId]: it] }
     Map<Map<String, String>, Coordinate> latestVersions =
@@ -145,7 +145,7 @@ class DependencyUpdates {
     for (Coordinate coordinate : coordinates) {
       for (int i = 0; ; i++) {
         String artifactId = coordinate.artifactId + ((i == 0) ? '' : "[${i + 1}]")
-        def key = [group: coordinate.groupId, name: artifactId]
+        LinkedHashMap<String, String> key = [group: coordinate.groupId, name: artifactId]
         if (!map.containsKey(key)) {
           map.put(key, coordinate)
           break

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.groovy
@@ -15,6 +15,8 @@
  */
 package com.github.benmanes.gradle.versions.updates
 
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
+
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentFilter
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionRulesWithCurrent
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
@@ -27,8 +29,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.ConfigureUtil
-
-import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
 
 /**
  * A task that reports which dependencies have later versions.
@@ -89,7 +89,7 @@ class DependencyUpdatesTask extends DefaultTask {
 
     outputs.upToDateWhen { false }
 
-    if(supportsIncompatibleWithConfigurationCache()) {
+    if (supportsIncompatibleWithConfigurationCache()) {
       callIncompatibleWithConfigurationCache()
     }
   }
@@ -105,7 +105,7 @@ class DependencyUpdatesTask extends DefaultTask {
   }
 
   @TaskAction
-  def dependencyUpdates() {
+  void dependencyUpdates() {
     project.evaluationDependsOnChildren()
 
     if (resolutionStrategy != null) {
@@ -114,7 +114,7 @@ class DependencyUpdatesTask extends DefaultTask {
         'Remove the assignment operator, \'=\', when setting this task property')
     }
 
-    def evaluator = new DependencyUpdates(project, resolutionStrategyAction, revisionLevel(),
+    DependencyUpdates evaluator = new DependencyUpdates(project, resolutionStrategyAction, revisionLevel(),
       outputFormatterProp(), outputDirectory(), getReportfileName(), checkForGradleUpdate, gradleReleaseChannelLevel(),
       checkConstraints, checkBuildEnvironmentConstraints)
     DependencyUpdatesReporter reporter = evaluator.run()
@@ -125,16 +125,16 @@ class DependencyUpdatesTask extends DefaultTask {
    * Sets the {@link #resolutionStrategy} to the provided strategy.
    * @param resolutionStrategy the resolution strategy
    */
-  void resolutionStrategy(final Action<? super ResolutionStrategyWithCurrent> resolutionStrategy) {
+  void resolutionStrategy(Action<? super ResolutionStrategyWithCurrent> resolutionStrategy) {
     this.resolutionStrategyAction = resolutionStrategy
     this.resolutionStrategy = null
   }
 
-  void rejectVersionIf(final ComponentFilter filter) {
+  void rejectVersionIf(ComponentFilter filter) {
     resolutionStrategy { ResolutionStrategyWithCurrent strategy ->
       strategy.componentSelection { ComponentSelectionRulesWithCurrent selection ->
         selection.all { ComponentSelectionWithCurrent current ->
-          def isNotNull = current.currentVersion != null && current.candidate.version != null
+          boolean isNotNull = current.currentVersion != null && current.candidate.version != null
           if (isNotNull && filter.reject(current)) {
             current.reject("Rejected by rejectVersionIf ")
           }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/VersionMapping.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/VersionMapping.groovy
@@ -18,6 +18,7 @@ package com.github.benmanes.gradle.versions.updates
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 
 /**
@@ -77,9 +78,9 @@ class VersionMapping {
     }
   }
 
-  private Comparator<String> makeVersionComparator() {
-    def baseComparator = new DefaultVersionComparator().asVersionComparator()
-    def versionParser = new VersionParser()
+  private static Comparator<String> makeVersionComparator() {
+    Comparator<Version> baseComparator = new DefaultVersionComparator().asVersionComparator()
+    VersionParser versionParser = new VersionParser()
     return new Comparator<String>() {
       int compare(String string1, String string2) {
         return baseComparator.compare(

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateChecker.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/gradle/GradleUpdateChecker.groovy
@@ -34,8 +34,10 @@ class GradleUpdateChecker {
   private void fetch() {
     GradleReleaseChannel.values().each {
       try {
-        def versionObject = new JsonSlurper().parse(new URL(API_BASE_URL + it.id), [
-          'connectTimeout': TIMEOUT_MS, 'readTimeout': TIMEOUT_MS])
+        Map<String, Long> params = new HashMap<String, Long>()
+        params.put("connectTimeout", TIMEOUT_MS)
+        params.put("readTimeout", TIMEOUT_MS)
+        Object versionObject = new JsonSlurper().parse(new URL(API_BASE_URL + it.id), params)
         if (versionObject.version) {
           cacheMap.put(it, new ReleaseStatus.Available(GradleVersion.version(versionObject.version as String)))
         } else {
@@ -117,7 +119,7 @@ class GradleUpdateChecker {
     static class Failure extends ReleaseStatus {
       final String reason
 
-      private Failure(reason) {
+      private Failure(String reason) {
         this.reason = reason
       }
     }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.groovy
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions.updates.resolutionstrategy
 import com.github.benmanes.gradle.versions.updates.Coordinate
 import groovy.transform.CompileStatic
 import groovy.transform.TupleConstructor
+import javax.annotation.Nullable
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.ComponentSelectionRules
@@ -19,6 +20,7 @@ class ComponentSelectionRulesWithCurrent {
   ComponentSelectionRulesWithCurrent all(
       Action<? super ComponentSelectionWithCurrent> selectionAction) {
     delegate.all(new Action<ComponentSelection>() {
+      @Override
       void execute(ComponentSelection inner) {
         ComponentSelectionWithCurrent wrapped = wrapComponentSelection(inner)
         if (wrapped != null) {
@@ -31,6 +33,7 @@ class ComponentSelectionRulesWithCurrent {
 
   ComponentSelectionRulesWithCurrent all(Closure<?> closure) {
     delegate.all(new Action<ComponentSelection>() {
+      @Override
       void execute(ComponentSelection inner) {
         ComponentSelectionWithCurrent wrapped = wrapComponentSelection(inner)
         if (wrapped != null) {
@@ -46,10 +49,11 @@ class ComponentSelectionRulesWithCurrent {
     RuleSourceBackedRuleAction<Object, ComponentSelectionWithCurrent> ruleAction = RuleSourceBackedRuleAction.create(
       ModelType.of(ComponentSelectionWithCurrent), ruleSource)
     delegate.all(new Action<ComponentSelection>() {
+      @Override
       void execute(ComponentSelection inner) {
         ComponentSelectionWithCurrent wrapped = wrapComponentSelection(inner)
         if (wrapped != null) {
-          ruleAction.execute(wrapped, [])
+          ruleAction.execute(wrapped, new ArrayList<Object>())
         }
       }
     })
@@ -59,6 +63,7 @@ class ComponentSelectionRulesWithCurrent {
   ComponentSelectionRulesWithCurrent withModule(Object id,
       Action<? super ComponentSelectionWithCurrent> selectionAction) {
     delegate.withModule(id, new Action<ComponentSelection>() {
+      @Override
       void execute(ComponentSelection inner) {
         ComponentSelectionWithCurrent wrapped = wrapComponentSelection(inner)
         if (wrapped != null) {
@@ -71,6 +76,7 @@ class ComponentSelectionRulesWithCurrent {
 
   ComponentSelectionRulesWithCurrent withModule(Object id, Closure<?> closure) {
     delegate.withModule(id, new Action<ComponentSelection>() {
+      @Override
       void execute(ComponentSelection inner) {
         ComponentSelectionWithCurrent wrapped = wrapComponentSelection(inner)
         if (wrapped != null) {
@@ -86,20 +92,24 @@ class ComponentSelectionRulesWithCurrent {
     RuleSourceBackedRuleAction<Object, ComponentSelectionWithCurrent> ruleAction = RuleSourceBackedRuleAction.create(
       ModelType.of(ComponentSelectionWithCurrent), ruleSource)
     delegate.withModule(id, new Action<ComponentSelection>() {
+      @Override
       void execute(ComponentSelection inner) {
         ComponentSelectionWithCurrent wrapped = wrapComponentSelection(inner)
         if (wrapped != null) {
-          ruleAction.execute(wrapped, [])
+          ruleAction.execute(wrapped, new ArrayList<Object>())
         }
       }
     })
     return this
   }
 
+  @Nullable
   private ComponentSelectionWithCurrent wrapComponentSelection(ComponentSelection inner) {
     Coordinate candidateCoordinate = Coordinate.from(inner.candidate)
     Coordinate current = currentCoordinates.get(candidateCoordinate.key)
-    if (current == null) return null
+    if (current == null) {
+      return null
+    }
 
     return new ComponentSelectionWithCurrent(current?.version, inner)
   }

--- a/src/main/groovy/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.groovy
+++ b/src/main/groovy/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.groovy
@@ -13,7 +13,6 @@ class ComponentSelectionWithCurrent {
   @Delegate
   private final ComponentSelection delegate
 
-
   @Override
   String toString() {
     return """\


### PR DESCRIPTION
 - Declare the types explicitly. This helps make the codebase more readable and easier to convert to Kotlin in the future.
 - Fix formatting

@ben-manes 