### PR TITLE
fix XmlSlurper deprecation

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -1,9 +1,9 @@
 package com.github.benmanes.gradle.versions.updates
 
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
-import groovy.util.XmlSlurper
-import groovy.util.slurpersupport.GPathResult
-import groovy.util.slurpersupport.NodeChildren
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import groovy.xml.slurpersupport.NodeChildren
 import org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean
 import org.codehaus.groovy.runtime.DefaultGroovyMethods.getMetaClass
 import org.gradle.api.Action

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -38,7 +38,7 @@ final class KotlinDslUsageSpec extends Specification {
   }
 
   @Unroll
-  def "user friendly kotlin-dsl with"() {
+  def "user friendly kotlin-dsl"() {
     given:
     buildFile << '''
       tasks.named<DependencyUpdatesTask>("dependencyUpdates") {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 import groovy.json.JsonSlurper
+import groovy.xml.XmlParser
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder


### PR DESCRIPTION
- `groovy.util.XmlSlurper` -> `groovy.xml.XmlSlurper`
- `groovy.util.slurpersupport.GPathResult` -> `groovy.xml.slurpersupport.GPathResult`
- `groovy.util.slurpersupport.NodeChildren` -> `groovy.xml.slurpersupport.NodeChildren`
- Use non deprecated `groovy.xml.XmlParser`


@ben-manes 