### PR TITLE
remove reflection

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -1,7 +1,5 @@
 package com.github.benmanes.gradle.versions.updates
 
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.getMetaClass
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
@@ -76,11 +74,7 @@ class Coordinate(
 
   companion object {
     fun from(dependency: ExternalModuleDependency): Coordinate {
-      var userReason: String? = null
-      if (asBoolean(getMetaClass(dependency).respondsTo(dependency, "getReason"))) {
-        userReason = dependency.reason
-      }
-      return Coordinate(dependency.group, dependency.name, dependency.version, userReason)
+      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
     fun from(selector: ModuleVersionSelector): Coordinate {
@@ -92,11 +86,7 @@ class Coordinate(
     }
 
     fun from(dependency: Dependency): Coordinate {
-      var userReason: String? = null
-      if (asBoolean(getMetaClass(dependency).respondsTo(dependency, "getReason"))) {
-        userReason = dependency.reason
-      }
-      return Coordinate(dependency.group, dependency.name, dependency.version, userReason)
+      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
     fun keyFrom(selector: ModuleVersionSelector): Key {


### PR DESCRIPTION
```
    /**
     * Returns a reason why this dependency should be used, in particular with regards to its version. The dependency report
     * will use it to explain why a specific dependency was selected, or why a specific dependency version was used.
     *
     * @return a reason to use this dependency
     *
     * @since 4.6
     */
    @Nullable
    String getReason();
```

`getReason` has been around Gradle 4.6, this plugin supports 5.0+.

@ben-manes 