### PR TITLE
remove reflection

### DIFF
--- a/gradle-versions-plugin/build.gradle
+++ b/gradle-versions-plugin/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
   implementation localGroovy()
   implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21'
+  implementation 'org.jetbrains.kotlin:kotlin-reflect:1.6.21'
   implementation 'com.squareup.okhttp3:okhttp:4.9.3'
   implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
   implementation 'com.thoughtworks.xstream:xstream:1.4.19'

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -1,7 +1,5 @@
 package com.github.benmanes.gradle.versions.updates
 
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.getMetaClass
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
@@ -76,11 +74,7 @@ class Coordinate(
 
   companion object {
     fun from(dependency: ExternalModuleDependency): Coordinate {
-      var userReason: String? = null
-      if (asBoolean(getMetaClass(dependency).respondsTo(dependency, "getReason"))) {
-        userReason = dependency.reason
-      }
-      return Coordinate(dependency.group, dependency.name, dependency.version, userReason)
+      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
     fun from(selector: ModuleVersionSelector): Coordinate {
@@ -92,11 +86,7 @@ class Coordinate(
     }
 
     fun from(dependency: Dependency): Coordinate {
-      var userReason: String? = null
-      if (asBoolean(getMetaClass(dependency).respondsTo(dependency, "getReason"))) {
-        userReason = dependency.reason
-      }
-      return Coordinate(dependency.group, dependency.name, dependency.version, userReason)
+      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
     fun keyFrom(selector: ModuleVersionSelector): Key {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -5,8 +5,6 @@ import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentF
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import groovy.lang.Closure
-import org.codehaus.groovy.runtime.DefaultGroovyMethods
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.getMetaClass
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -79,9 +77,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     group = "Help"
     outputs.upToDateWhen { false }
 
-    if (supportsIncompatibleWithConfigurationCache()) {
-      callIncompatibleWithConfigurationCache()
-    }
+    callIncompatibleWithConfigurationCache()
   }
 
   @TaskAction
@@ -133,17 +129,8 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     return (System.getProperties()["outputFormatter"] ?: outputFormatter)
   }
 
-  private fun supportsIncompatibleWithConfigurationCache(): Boolean {
-    return DefaultGroovyMethods.asBoolean(
-      getMetaClass(this)
-        .respondsTo(this, "notCompatibleWithConfigurationCache", arrayOf<Any>(String::class.java))
-    )
-  }
-
   private fun callIncompatibleWithConfigurationCache() {
-    val methodName = "notCompatibleWithConfigurationCache"
-    val methodArgs =
-      arrayOf<Any>("The gradle-versions-plugin isn't compatible with the configuration cache")
-    getMetaClass(this).invokeMethod(this, methodName, methodArgs)
+    this::class.members.find { it.name == "notCompatibleWithConfigurationCache" }
+      ?.call(this, "The gradle-versions-plugin isn't compatible with the configuration cache")
   }
 }


### PR DESCRIPTION
```
    /**
     * Specifies that this task is not compatible with the configuration cache.
     *
     * <p>
     * Configuration cache problems found in the task will be reported but won't cause the build to fail.
     * </p>
     *
     * <p>
     * The presence of incompatible tasks in the task graph will cause the configuration state to be discarded
     * at the end of the build unless the global {@code configuration-cache-problems} option is set to {@code warn},
     * in which case the configuration state would still be cached in a best-effort manner as usual for the option.
     * </p>
     *
     * <p>
     * <b>IMPORTANT:</b> This setting doesn't affect how Gradle treats problems found in other tasks also present in the task graph and those
     * could still cause the build to fail.
     * </p>
     *
     * @since 7.4
     */
    @Incubating
    void notCompatibleWithConfigurationCache(String reason);
```

Since this is in 7.4, we have to keep it but we can atleast use Kotlin reflection

@ben-manes 