### PR TITLE
remove reflection

### DIFF
--- a/gradle-versions-plugin/build.gradle
+++ b/gradle-versions-plugin/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
   implementation localGroovy()
   implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21'
+  implementation 'org.jetbrains.kotlin:kotlin-reflect:1.6.21'
   implementation 'com.squareup.okhttp3:okhttp:4.9.3'
   implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
   implementation 'com.thoughtworks.xstream:xstream:1.4.19'

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -1,7 +1,5 @@
 package com.github.benmanes.gradle.versions.updates
 
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.getMetaClass
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
@@ -76,11 +74,7 @@ class Coordinate(
 
   companion object {
     fun from(dependency: ExternalModuleDependency): Coordinate {
-      var userReason: String? = null
-      if (asBoolean(getMetaClass(dependency).respondsTo(dependency, "getReason"))) {
-        userReason = dependency.reason
-      }
-      return Coordinate(dependency.group, dependency.name, dependency.version, userReason)
+      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
     fun from(selector: ModuleVersionSelector): Coordinate {
@@ -92,11 +86,7 @@ class Coordinate(
     }
 
     fun from(dependency: Dependency): Coordinate {
-      var userReason: String? = null
-      if (asBoolean(getMetaClass(dependency).respondsTo(dependency, "getReason"))) {
-        userReason = dependency.reason
-      }
-      return Coordinate(dependency.group, dependency.name, dependency.version, userReason)
+      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
     fun keyFrom(selector: ModuleVersionSelector): Key {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -5,8 +5,6 @@ import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentF
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import groovy.lang.Closure
-import org.codehaus.groovy.runtime.DefaultGroovyMethods
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.getMetaClass
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -79,9 +77,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     group = "Help"
     outputs.upToDateWhen { false }
 
-    if (supportsIncompatibleWithConfigurationCache()) {
-      callIncompatibleWithConfigurationCache()
-    }
+    callIncompatibleWithConfigurationCache()
   }
 
   @TaskAction
@@ -133,17 +129,8 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     return (System.getProperties()["outputFormatter"] ?: outputFormatter)
   }
 
-  private fun supportsIncompatibleWithConfigurationCache(): Boolean {
-    return DefaultGroovyMethods.asBoolean(
-      getMetaClass(this)
-        .respondsTo(this, "notCompatibleWithConfigurationCache", arrayOf<Any>(String::class.java))
-    )
-  }
-
   private fun callIncompatibleWithConfigurationCache() {
-    val methodName = "notCompatibleWithConfigurationCache"
-    val methodArgs =
-      arrayOf<Any>("The gradle-versions-plugin isn't compatible with the configuration cache")
-    getMetaClass(this).invokeMethod(this, methodName, methodArgs)
+    this::class.members.find { it.name == "notCompatibleWithConfigurationCache" }
+      ?.call(this, "The gradle-versions-plugin isn't compatible with the configuration cache")
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -411,8 +411,7 @@ class Resolver(
   }
 
   private fun supportsConstraints(configuration: Configuration): Boolean {
-    return checkConstraints && !getMetaClass(configuration)
-      .respondsTo(configuration, "getDependencyConstraints").isNullOrEmpty()
+    return checkConstraints && !configuration.dependencyConstraints.isNullOrEmpty()
   }
 
   private fun getResolvableDependencies(configuration: Configuration): List<Coordinate> {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -106,14 +106,7 @@ class Resolver(
     }
 
     val copy = configuration.copyRecursive().setTransitive(false)
-    // https://github.com/ben-manes/gradle-versions-plugin/issues/127
-    if (asBoolean(
-        getMetaClass(copy)
-          .respondsTo(copy, "setCanBeResolved", arrayOf<Any>(Boolean::class.java))
-      )
-    ) {
-      copy.isCanBeResolved = true
-    }
+    copy.isCanBeResolved = true
 
     // https://github.com/ben-manes/gradle-versions-plugin/issues/592
     // allow resolution of dynamic latest versions regardless of the original strategy
@@ -265,14 +258,7 @@ class Resolver(
 
     val coordinates = hashMapOf<Coordinate.Key, Coordinate>()
     val copy = configuration.copyRecursive().setTransitive(transitive)
-    // https://github.com/ben-manes/gradle-versions-plugin/issues/127
-    if (asBoolean(
-        getMetaClass(copy)
-          .respondsTo(copy, "setCanBeResolved", arrayOf<Any>(Boolean::class.java))
-      )
-    ) {
-      copy.isCanBeResolved = true
-    }
+    copy.isCanBeResolved = true
     val lenient = copy.resolvedConfiguration.lenientConfiguration
 
     val resolved = lenient.getFirstLevelModuleDependencies(SATISFIES_ALL)


### PR DESCRIPTION
```
    /**
     * Gets the set of dependency constraints directly contained in this configuration
     * (ignoring superconfigurations).
     *
     * @return the set of dependency constraints
     *
     * @since 4.6
     */
    DependencyConstraintSet getDependencyConstraints();
```

```
    /**
     * Configures if a configuration can be resolved.
     *
     * @since 3.3
     */
    void setCanBeResolved(boolean allowed);
```

We can remove this also since it has been in Gradle since 4.6

@ben-manes 