### PR TITLE
Fixes reference link to Result class on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ Alternatively, the report may be outputed to a structured file.
 <details>
 <summary>Custom report</summary>
 
-If you need to create a report in a custom format, you can set the `dependencyUpdates` tasks's `outputFormatter` property to a Closure. The closure will be called with a single argument that is an instance of [com.github.benmanes.gradle.versions.reporter.result.Result](src/main/groovy/com/github/benmanes/gradle/versions/reporter/result/Result.groovy).
+If you need to create a report in a custom format, you can set the `dependencyUpdates` tasks's `outputFormatter` property to a Closure. The closure will be called with a single argument that is an instance of [com.github.benmanes.gradle.versions.reporter.result.Result](gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt).
 
 For example, if you wanted to create an html table for the upgradable dependencies, you could use:
 


### PR DESCRIPTION
Self-explained. 

Learned that when hitting [this link](https://github.com/ben-manes/gradle-versions-plugin/blob/master/src/main/groovy/com/github/benmanes/gradle/versions/reporter/result/Result.groovy)

![image](https://user-images.githubusercontent.com/484670/187712275-457b96ef-ce0e-46b2-a3a3-158dc0cc2631.png)

Thanks for the great plugin!