### PR TITLE
Fix Kotlin example problems

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentFilter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentFilter.kt
@@ -3,6 +3,6 @@ package com.github.benmanes.gradle.versions.updates.resolutionstrategy
 import org.gradle.api.HasImplicitReceiver
 
 @HasImplicitReceiver
-interface ComponentFilter {
+fun interface ComponentFilter {
   fun reject(candidate: ComponentSelectionWithCurrent): Boolean
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -4,7 +4,7 @@ import org.gradle.api.artifacts.ComponentSelection
 
 class ComponentSelectionWithCurrent(
   private val delegate: ComponentSelection,
-  val currentVersion: String? = null,
+  val currentVersion: String,
 ) : ComponentSelection by delegate {
 
   override fun toString(): String {


### PR DESCRIPTION
Fixes https://github.com/ben-manes/gradle-versions-plugin/issues/673

It looks like the two problems with the Kotlin DSL example are fixed with the next (as suggested in the issue):

**Make ComponentFilter interface functional**

This enables the use of Kotlin's trailing lambda syntax in the `rejectVersionIf` API.

**Make ComponentSelectionWithCurrent.currentVersion not null**

* ComponentSelectionWithCurrent objects are only created in one place and the currentVersion argument passed there is never null, so it's safe to make the property non-null as it effectively never is.
* This also fixes some issues in the Kotlin example, in which the dependencyUpdates task configuration was assumming the `currentVersion` property was not-null.

**Testing**

*Manual*
I have checked that the Kotlin DSL example works after the changes.