### PR TITLE
Only resolve resolvable configurations

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
@@ -66,8 +66,10 @@ class DependencyUpdates @JvmOverloads constructor(
     projectConfigs.forEach { (currentProject, currentConfigurations) ->
       val resolver = Resolver(currentProject, resolutionStrategy, checkConstraints)
       for (currentConfiguration in currentConfigurations) {
-        for (newStatus in resolve(resolver, currentProject, currentConfiguration)) {
-          addValidatedDependencyStatus(resultStatus, newStatus)
+        if (currentConfiguration.isCanBeResolved) {
+          for (newStatus in resolve(resolver, currentProject, currentConfiguration)) {
+            addValidatedDependencyStatus(resultStatus, newStatus)
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes: #718

Updates plugin to only resolve resolvable configurations. As a result, configurations like implementation are not resolved individually, but transitively via any resolvable configurations which extend it. To handle this change, Resolver.kt was updated throughout to use allDependencies and allDependencyConstraints in order to ensure the resolved/unresolved dependency comparisons with the latest versions include inherited dependencies from non-resolvable configurations which were previously being resolved individually.