### PR TITLE
Ignore constraints of own projects ("DefaultProjectDependencyConstraint")

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.HasConfigurableAttributes
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint
 import org.gradle.api.specs.Specs.SATISFIES_ALL
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.maven.MavenModule
@@ -101,7 +102,9 @@ class Resolver(
     // version of transitive dependency.
     if (supportsConstraints(configuration)) {
       for (dependency in configuration.allDependencyConstraints) {
-        latest.add(createQueryDependency(dependency))
+        if (dependency !is DefaultProjectDependencyConstraint) {
+          latest.add(createQueryDependency(dependency))
+        }
       }
     }
 


### PR DESCRIPTION
In multimodule projects having external constraints but also constraints to own sub projects it makes no sense to check for updates of the these own subprojects (when using checkConstraints=true)

Dependening on the number of own suprojects and also the network performance of the repositories this can give a huge performance boost (for example a few minutes vs. >2 hours in a concrete project)