### PR TITLE
Avoid configuring dependencyUpdates task

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
@@ -17,7 +17,7 @@ class VersionsPlugin : Plugin<Project> {
     }
 
     val tasks = project.tasks
-    if (tasks.findByName("dependencyUpdates") == null) {
+    if (!tasks.getNames().contains("dependencyUpdates")) {
       tasks.register("dependencyUpdates", DependencyUpdatesTask::class.java)
     }
   }


### PR DESCRIPTION
Hi,

I noticed that the `dependencyUpdates` task (e.g. when added via global init script) is configured regardless of any task avoidance being used. This is caused by the usage of `tasks.findByName()` that was introduced with https://github.com/ben-manes/gradle-versions-plugin/pull/504 .
<img width="400" alt="image" src="https://user-images.githubusercontent.com/6304496/221651789-cb0070d3-8d30-481e-810c-d809c0f24189.png">
Eventually this causes an overhead by using Kotlin reflection in `DependencyUpdatesTask.callIncompatibleWithConfigurationCache`.

<img width="1666" alt="image" src="https://user-images.githubusercontent.com/6304496/221651918-21e16458-0c4f-4b63-9512-f2ffedea0136.png">

A workaround for this is to use `tasks.getNames().contains()`.

Let me know what you think.
Cheers,
Christoph