### PR TITLE
Fix broken Sonatype links in HTML reports

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
@@ -417,12 +417,12 @@ class HtmlReporter(
     }
 
     private fun getMvnVersionString(group: String, name: String, version: String?): String {
-      // https://search.maven.org/artifact/com.azure/azure-core-http-netty/1.5.4
+      // https://central.sonatype.com/artifact/com.azure/azure-core-http-netty/1.5.4
       if (version == null) {
         return ""
       }
       val versionUrl = String
-        .format("https://search.maven.org/artifact/%s/%s/%s/bundle", group, name, version)
+        .format("https://central.sonatype.com/artifact/%s/%s/%s/bundle", group, name, version)
       return String.format("<a target=\"_blank\" href=\"%s\">%s</a>", versionUrl, "Sonatype")
     }
   }


### PR DESCRIPTION
https://github.com/ben-manes/gradle-versions-plugin/issues/748

Old `search.maven.org` domain was replaced with `central.sonatype.com`, the change was reflected in HTML generation code in `HtmlReporter.kt`.

Previous example link wasn't working anymore:
https://search.maven.org/artifact/com.azure/azure-core-http-netty/1.5.4

This URL leads to the correct page instead:
https://central.sonatype.com/artifact/com.azure/azure-core-http-netty/1.5.4