### PR TITLE
Replace deprecated toUpperCase() kotlin.text calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ def isNonStable = { String version ->
 
 ```kotlin
 fun isNonStable(version: String): Boolean {
-    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
     val regex = "^[0-9,.v-]+(-r)?$".toRegex()
     val isStable = stableKeyword || regex.matches(version)
     return isStable.not()

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -30,7 +30,7 @@ configurations {
 }
 
 fun String.isNonStable(): Boolean {
-  val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { toUpperCase().contains(it) }
+  val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { uppercase().contains(it) }
   val regex = "^[0-9,.v-]+(-r)?$".toRegex()
   val isStable = stableKeyword || regex.matches(this)
   return isStable.not()


### PR DESCRIPTION
Hello! Kotlin's String `toUpperCase()` is deprecated. The new recommended way is to use `uppercase()`.