### PR TITLE
Fail the build when an insecure XML parser is detected

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
@@ -1,24 +1,55 @@
 package com.github.benmanes.gradle.versions
 
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.util.GradleVersion
+import org.xml.sax.SAXException
+import javax.xml.parsers.SAXParserFactory
 
 /**
  * Registers the plugin's tasks.
  */
 class VersionsPlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    if (GradleVersion.current() < GradleVersion.version("5.0")) {
-      project.logger
-        .error("Gradle 5.0 or greater is required to apply the com.github.ben-manes.versions plugin.")
-      return
-    }
+    requireMinimumGradleVersion()
+    requireSupportedSaxParser()
 
     val tasks = project.tasks
     if (!tasks.getNames().contains("dependencyUpdates")) {
       tasks.register("dependencyUpdates", DependencyUpdatesTask::class.java)
+    }
+  }
+
+  private fun requireMinimumGradleVersion() {
+    if (GradleVersion.current() < GradleVersion.version("5.0")) {
+      throw GradleException(
+        "Gradle 5.0 or greater is required to apply the com.github.ben-manes.versions plugin.")
+    }
+  }
+
+  private fun requireSupportedSaxParser() {
+    val isRestrictedInPatch = GradleVersion.current() >= GradleVersion.version("7.6.3")
+        && GradleVersion.current() <= GradleVersion.version("8.0")
+    val isRestrictedInMajor = GradleVersion.current() >= GradleVersion.version("8.4")
+
+    if (isRestrictedInPatch || isRestrictedInMajor) {
+      try {
+        val factory = SAXParserFactory.newInstance()
+        factory.newSAXParser().setProperty("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
+      } catch (ex: SAXException) {
+        throw GradleException(
+            """A plugin or custom build logic has included an insecure XML parser, which is not compatible for
+              |dependency resolution with this version of Gradle. You can work around this issue by specifying the
+              |SAXParserFactory to use or by updating any plugin that depends on an old XML parser version.
+              |
+              |Use ./gradlew buildEnvironment to check your build's plugin dependencies.
+              |
+              |For more details and a workaround see,
+              |https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#changes_8.4
+              |""".trimMargin())
+      }
     }
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
@@ -24,14 +24,13 @@ class VersionsPlugin : Plugin<Project> {
 
   private fun requireMinimumGradleVersion() {
     if (GradleVersion.current() < GradleVersion.version("5.0")) {
-      throw GradleException(
-        "Gradle 5.0 or greater is required to apply the com.github.ben-manes.versions plugin.")
+      throw GradleException("Gradle 5.0 or greater is required to apply the com.github.ben-manes.versions plugin.")
     }
   }
 
   private fun requireSupportedSaxParser() {
-    val isRestrictedInPatch = GradleVersion.current() >= GradleVersion.version("7.6.3")
-        && GradleVersion.current() <= GradleVersion.version("8.0")
+    val isRestrictedInPatch = GradleVersion.current() >= GradleVersion.version("7.6.3") &&
+      GradleVersion.current() <= GradleVersion.version("8.0")
     val isRestrictedInMajor = GradleVersion.current() >= GradleVersion.version("8.4")
 
     if (isRestrictedInPatch || isRestrictedInMajor) {
@@ -40,15 +39,16 @@ class VersionsPlugin : Plugin<Project> {
         factory.newSAXParser().setProperty("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
       } catch (ex: SAXException) {
         throw GradleException(
-            """A plugin or custom build logic has included an insecure XML parser, which is not compatible for
-              |dependency resolution with this version of Gradle. You can work around this issue by specifying the
-              |SAXParserFactory to use or by updating any plugin that depends on an old XML parser version.
-              |
-              |Use ./gradlew buildEnvironment to check your build's plugin dependencies.
-              |
-              |For more details and a workaround see,
-              |https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#changes_8.4
-              |""".trimMargin())
+          """A plugin or custom build logic has included an insecure XML parser, which is not compatible for
+            |dependency resolution with this version of Gradle. You can work around this issue by specifying
+            |the SAXParserFactory to use or by updating any plugin that depends on an old XML parser version.
+            |
+            |Use ./gradlew buildEnvironment to check your build's plugin dependencies.
+            |
+            |For more details and a workaround see,
+            |https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#changes_8.4
+            |""".trimMargin()
+        )
       }
     }
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -15,7 +15,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
-import org.gradle.util.ConfigureUtil
 import javax.annotation.Nullable
 
 /**
@@ -123,7 +122,8 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   fun dependencyUpdates() {
     project.evaluationDependsOnChildren()
     if (resolutionStrategy != null) {
-      resolutionStrategy(ConfigureUtil.configureUsing(resolutionStrategy))
+      val closure = resolutionStrategy!!
+      resolutionStrategy { current -> project.configure(current, closure) }
       logger.warn(
         "dependencyUpdates.resolutionStrategy: " +
           "Remove the assignment operator, \"=\", when setting this task property"
@@ -144,6 +144,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
       strategy.componentSelection { selection ->
         selection.all(
           Action<ComponentSelectionWithCurrent> { current ->
+            @Suppress("SENSELESS_COMPARISON")
             val isNotNull = current.currentVersion != null && current.candidate.version != null
             if (isNotNull && filter.reject(current)) {
               current.reject("Rejected by rejectVersionIf ")

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -206,12 +206,13 @@ class Resolver(
   private fun addAttributes(
     target: HasConfigurableAttributes<*>,
     source: HasConfigurableAttributes<*>,
-    filter: (String) -> Boolean = { key: String -> true },
+    filter: (String) -> Boolean = { _ -> true },
   ) {
     target.attributes { container ->
       for (key in source.attributes.keySet()) {
         if (filter.invoke(key.name)) {
-          val value = source.attributes.getAttribute(key as Attribute<Any>)
+          @Suppress("UNCHECKED_CAST")
+          val value = source.attributes.getAttribute(key as Attribute<Any>)!!
           container.attribute(key, value)
         }
       }
@@ -234,8 +235,6 @@ class Resolver(
         rules.all { selectionAction ->
           if (ComponentSelection::class.members.any { it.name == "getMetadata" }) {
             revisionFilter(selectionAction, selectionAction.metadata)
-          } else {
-            revisionFilter
           }
         }
       }


### PR DESCRIPTION
As described in a prior release and in (gradle/gradle#26672, the insecure parser causes confusing build errors. Thanks @hvisser for the idea to check upfront to give users a clearer error message and point them towards a fix.