### PR TITLE
Add dependency-submission workflow and address deprecations/vulnerabilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,11 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Run build with caching enabled
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: clean build -s
+        run: ./gradlew clean build -s
 
       - name: Run examples
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,16 +26,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1.0.6
+        uses: gradle/wrapper-validation-action@v2
 
       - name: Configure JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
       - name: Run build with caching enabled
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: clean build -s
 
@@ -49,7 +49,7 @@ jobs:
           cd examples/kotlin/ && ../../gradlew dU && cd -
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: gradle-versions-plugin-${{ github.workflow }}-${{ github.run_id }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,28 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+
+      - name: Configure JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,19 +10,19 @@ jobs:
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1.0.6
+        uses: gradle/wrapper-validation-action@v2
 
       - name: Configure JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
 
       - name: Publish
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: |
             publishPlugins -s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,11 @@ jobs:
           distribution: temurin
           java-version: 8
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Publish
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: |
-            publishPlugins -s
+        run: >-
+          ./gradlew publishPlugins -s
             -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
             -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'org.jetbrains.kotlin.jvm' version '1.8.20' apply false
   id 'org.jetbrains.dokka' version '1.8.10' apply false
-  id 'org.jlleitschuh.gradle.ktlint' version '10.2.1' apply false
+  id 'org.jlleitschuh.gradle.ktlint' version '12.1.0' apply false
   id 'java-gradle-plugin'
   id 'java-library'
   id 'groovy'


### PR DESCRIPTION
- Updates workflows to use Node20-compatible actions where available
- Switches from `gradle/gradle-build-action` to `gradle/actions/setup-gradle`
- Adds a workflow using `gradle/actions/dependency-submission` to generate and upload dependency-graph
- Bumps the version of the 'ktlint' plugin to address reported vulnerability