### PR TITLE
Documentation / Skip non-stable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ no agreed standard on this, but this is a good starting point:
 
 ```groovy
 def isNonStable = { String version ->
+  def nonStableKeyword = ["BETA"].any { it -> version.toUpperCase().contains(it) }
+  if (nonStableKeyword) {
+    return true
+  }
   def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
   def regex = /^[0-9,.v-]+(-r)?$/
   return !stableKeyword && !(version ==~ regex)


### PR DESCRIPTION
I tried to extend the rejection rule to exclude versions like `org.jetbrains.kotlin:kotlin-stdlib [1.9.22 -> 2.0.0-Beta3]` but for some reason it is still listed. 
Do you spot the mistake?