### PR TITLE
Bump com.squareup.moshi:moshi-kotlin from 1.12.0 to 1.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,6 @@ versions = { id = "com.github.ben-manes.versions", version = "0.51.0" }
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-moshi = { module = "com.squareup.moshi:moshi-kotlin", version = "1.12.0" }
+moshi = { module = "com.squareup.moshi:moshi-kotlin", version = "1.13.0" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }
 spock = { module = "org.spockframework:spock-junit4", version = "2.4-M4-groovy-3.0" }


### PR DESCRIPTION
Bump com.squareup.moshi:moshi-kotlin from 1.12.0 to 1.13.0

Slowing upgrading - see https://github.com/ben-manes/gradle-versions-plugin/pull/889

@ben-manes