### PR TITLE
Use correct install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Have a look at [`examples/groovy`](https://github.com/ben-manes/gradle-versions-
 
 ```bash
 # Publish the latest version of the plugin to mavenLocal()
-$ ./gradlew install
+$ ./gradlew publishToMavenLocal
 
 # Try out the samples
 $ ./gradlew -p examples/groovy dependencyUpdate


### PR DESCRIPTION
At some point this changed. I don't know when or why, but I know using `./gradlew publishToMavenLocal` worked for me.