### PR TITLE
Update README.md for upstream Gradle issue workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ checks for updates to Gradle itself.
   - [buildscript block](#buildscript-block)
   - [Using a Gradle init script](#using-a-gradle-init-script)
   - [Related plugins](#related-plugins)
+  - [Known issues](#known-issues)
 - [dependencyUpdates](#dependencyupdates)
   - [Multi-project build](#multi-project-build)
   - [Revisions](#revisions)
@@ -121,6 +122,9 @@ You may also wish to explore additional functionality provided by,
  - [gradle-update-notifier](https://github.com/y-yagi/gradle-update-notifier)
  - [refreshVersions](https://github.com/jmfayard/refreshVersions)
  - [update-versions-gradle-plugin](https://github.com/tomasbjerre/update-versions-gradle-plugin)
+
+### Known Issues ###
+[Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) is not supported.  To work around the issue, run with `--no-configuration-cache` if it is enabled in your Gradle configuration.
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ You may also wish to explore additional functionality provided by,
  - [refreshVersions](https://github.com/jmfayard/refreshVersions)
  - [update-versions-gradle-plugin](https://github.com/tomasbjerre/update-versions-gradle-plugin)
 
-### Known Issues ###
-[Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) is not supported, and there appears to also be an upstream issue with Gradle's configuration cache opt-out mechanism.  To work around the issue, run with `--no-configuration-cache` if it is enabled in your Gradle configuration and you see error logs such as `problems were found storing the configuration cache`.
+### Workarounds for related Gradle Issues ###
+ - https://github.com/gradle/gradle/issues/24636: setting the flag `org.gradle.configuration-cache.problems=warn` in `gradle.properties` causes the dependency check to fail to find dependencies with message `No dependencies found`.  Comment out that line until the upstream issue with Gradle is fixed.
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You may also wish to explore additional functionality provided by,
  - [update-versions-gradle-plugin](https://github.com/tomasbjerre/update-versions-gradle-plugin)
 
 ### Known Issues ###
-[Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) is not supported.  To work around the issue, run with `--no-configuration-cache` if it is enabled in your Gradle configuration.
+[Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) is not supported, and there appears to also be an upstream issue with Gradle's configuration cache opt-out mechanism.  To work around the issue, run with `--no-configuration-cache` if it is enabled in your Gradle configuration and you see error logs such as `problems were found storing the configuration cache`.
 
 ## Tasks
 


### PR DESCRIPTION
Add known issues section and workaround for configuration cache incompatibility.

```
5 problems were found storing the configuration cache, 4 of which seem unique.
- Task `:app:dependencyUpdates` of type `com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask`: cannot deserialize Gradle script object references as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14.3/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
- Task `:app:dependencyUpdates` of type `com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14.3/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
- Task `:app:dependencyUpdates` of type `com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask`: cannot serialize a lambda that captures or accepts a parameter of type 'org.gradle.api.artifacts.Configuration' as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14.3/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
- Task `:app:dependencyUpdates` of type `com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/8.14.3/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
```