### PR TITLE
fix: create snapshot of configurations to prevent ConcurrentModificationException

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
@@ -39,15 +39,18 @@ class DependencyUpdates
      * task options and returns a reporter for the results.
      */
     fun run(): DependencyUpdatesReporter {
+      // Create a snapshot of configurations to avoid ConcurrentModificationException
+      // when configurations are lazily created during resolution (e.g., by AGP 9.x)
+      // See: https://github.com/ben-manes/gradle-versions-plugin/issues/966
       val projectConfigs =
         project.allprojects
-          .associateBy({ it }, { it.configurations.matching(filterConfigurations) })
+          .associateBy({ it }, { it.configurations.matching(filterConfigurations).toSet() })
 
       val status: Set<DependencyStatus> = resolveProjects(projectConfigs, checkConstraints)
 
       val buildscriptProjectConfigs =
         project.allprojects
-          .associateBy({ it }, { it.buildscript.configurations })
+          .associateBy({ it }, { it.buildscript.configurations.toSet() })
       val buildscriptStatus: Set<DependencyStatus> =
         resolveProjects(
           buildscriptProjectConfigs,


### PR DESCRIPTION
## Summary

This PR fixes the `ConcurrentModificationException` that occurs when running `dependencyUpdates` with Gradle 9.x and AGP 9.x.

### Root Cause

When iterating over configurations using `matching()` or accessing `buildscript.configurations`, the returned collection is a **live view** that reflects changes to the underlying `ConfigurationContainer`. 

With Gradle 9.x and AGP 9.x, configurations are created lazily during dependency resolution. This causes `ConcurrentModificationException` when the `dependencyUpdates` task iterates over configurations while resolution triggers lazy creation of new configurations.

### The Fix

Add `.toSet()` to create a snapshot before iteration:

```kotlin
// Before (live view - causes CME)
it.configurations.matching(filterConfigurations)

// After (snapshot - safe to iterate)
it.configurations.matching(filterConfigurations).toSet()
```

### Testing

Tested successfully with:
- Gradle 9.2.1
- AGP 9.0.0-rc01
- Multi-module Android project with 15+ modules

### Related Issues

Fixes #966
Related to #968 (configuration cache compatibility - separate issue)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)