### PR TITLE
Fix ConcurrentModificationException when iterating configurations

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
@@ -75,7 +75,7 @@ class DependencyUpdates
       val resultStatus = hashSetOf<DependencyStatus>()
       projectConfigs.forEach { (currentProject, currentConfigurations) ->
         val resolver = Resolver(currentProject, resolutionStrategy, checkConstraints)
-        for (currentConfiguration in currentConfigurations) {
+        for (currentConfiguration in currentConfigurations.toList()) {
           if (currentConfiguration.isCanBeResolved) {
             for (newStatus in resolve(resolver, currentProject, currentConfiguration)) {
               addValidatedDependencyStatus(resultStatus, newStatus)


### PR DESCRIPTION
## Summary
- Copies the configurations `Set` to a `List` before iterating in `DependencyUpdates.resolveProjects()` to prevent `ConcurrentModificationException` when configurations are modified during resolution.

## Test plan
- [ ] Verify existing tests pass with `./gradlew test`
- [ ] Confirm the fix prevents `ConcurrentModificationException` in projects where configurations are added during resolution