### PR TITLE
fix: use copied configurations to workaround issues with plugins adding dynamic configs

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
@@ -41,13 +41,13 @@ class DependencyUpdates
     fun run(): DependencyUpdatesReporter {
       val projectConfigs =
         project.allprojects
-          .associateBy({ it }, { it.configurations.matching(filterConfigurations) })
+          .associateBy({ it }, { it.configurations.matching(filterConfigurations).toCollection(LinkedHashSet()) })
 
       val status: Set<DependencyStatus> = resolveProjects(projectConfigs, checkConstraints)
 
       val buildscriptProjectConfigs =
         project.allprojects
-          .associateBy({ it }, { it.buildscript.configurations })
+          .associateBy({ it }, { it.buildscript.configurations.toCollection(LinkedHashSet()) })
       val buildscriptStatus: Set<DependencyStatus> =
         resolveProjects(
           buildscriptProjectConfigs,


### PR DESCRIPTION
- fixes #930

Reverts to the earlier approach prior to #927, but without calling `.size` which seemingly causes the configurations to be resolved and the same side effect of adding new configurations, and triggers the same problem as earlier.

I did not specifically test it with pitest and Spring Dependency Management; just worked on the assumption that if the same small change broke them, then reverting to how it was before (minus the pre-sizing) is likely sufficient for them also.

I did actually have a test that failed with the `ConcurrentModificationException` before and passed afterwards (On Gradle 8.4; later plugin versions need later Gradle versions), but this Quarkus version requires Java 17, and this plugin seems to run tests only against Java 8 + 11 and doesn't currently seem to have any infrastructure to test against various Java versions and ignore tests on certain Java versions - so I removed it.

```groovy
  @Issue("https://github.com/ben-manes/gradle-versions-plugin/issues/930")
  def "plugins that add configurations dynamically are properly handled"() {
    given:
    testProjectDir.newFile('build.gradle') <<
      """
        plugins {
            id 'com.github.ben-manes.versions'
            id 'io.quarkus' version '3.25.4'
        }
      """.stripIndent()

    when:
    def result = GradleRunner.create()
      .withProjectDir(testProjectDir.root)
      .withArguments('dependencyUpdates', '--info')
      .withPluginClasspath()
      .build()

    then:
    result.task(':dependencyUpdates').outcome == SUCCESS
    result.output.find(/The following dependencies have later milestone versions:\n - io\.quarkus:io\.quarkus\.gradle\.plugin \[3\.25\.4 -> /)
  }
```