### PR TITLE
Run dependency actions before reading the declared set (fixes #987)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -53,6 +53,12 @@ class Resolver(
     configuration: Configuration,
     revision: String,
   ): Set<DependencyStatus> {
+    // Runs the actions that contribute dependencies lazily, so that the declared set below is read
+    // after them rather than before. A contribution missing from that set is discarded as an
+    // undeclared dependency, or reported with the resolved version as its declared one.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/987
+    configuration.incoming.dependencies
+
     val coordinates = getCurrentCoordinates(configuration)
     val latestConfiguration = createLatestConfiguration(configuration, revision, coordinates)
     val lenient = latestConfiguration.resolvedConfiguration.lenientConfiguration

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDependencyUpdatesSpec.groovy
@@ -56,7 +56,14 @@ final class KotlinDependencyUpdatesSpec extends Specification {
       .build()
 
     then:
-    result.output.find(/The following dependencies have later milestone versions:\n - org\.jetbrains\.kotlin:kotlin-gradle-plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]/)
+    def inheritedByJvmPlugin =
+      / - org\.jetbrains\.kotlin:kotlin-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n/
+    result.output.find(/The following dependencies have later milestone versions:\n/ +
+      (applyJvmPlugin ? inheritedByJvmPlugin : '') +
+      / - org\.jetbrains\.kotlin:kotlin-gradle-plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]/)
+    // Sorts after kotlin-gradle-plugin, so it falls past the tail of the match above.
+    !applyJvmPlugin ||
+      result.output.contains("org.jetbrains.kotlin:kotlin-stdlib-jdk8 [$DECLARED_KOTLIN_VERSION -> 2.")
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
@@ -124,7 +131,7 @@ final class KotlinDependencyUpdatesSpec extends Specification {
       .build()
 
     then:
-    result.output.find(/The following dependencies have later milestone versions:\n - org\.jetbrains\.kotlin:kotlin-scripting-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-stdlib \[${explicitStdLibVersion ? DECLARED_KOTLIN_STD_VERSION : DECLARED_KOTLIN_VERSION} -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin\.jvm:org\.jetbrains\.kotlin\.jvm\.gradle\.plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n/)
+    result.output.find(/The following dependencies have later milestone versions:\n - org\.jetbrains\.kotlin:kotlin-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-klib-commonizer-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-scripting-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-stdlib \[${explicitStdLibVersion ? DECLARED_KOTLIN_STD_VERSION : DECLARED_KOTLIN_VERSION} -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin\.jvm:org\.jetbrains\.kotlin\.jvm\.gradle\.plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n/)
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LazyDependencySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LazyDependencySpec.groovy
@@ -1,0 +1,150 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A configuration's declared dependency set is read before {@code withDependencies} and
+ * {@code defaultDependencies} actions contribute to it, so a lazily-added dependency is
+ * discarded as undeclared, or reported with its resolved version as its declared one.
+ * https://github.com/ben-manes/gradle-versions-plugin/issues/987
+ */
+final class LazyDependencySpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile
+  private List<File> pluginClasspath
+  private String reportFolder
+  private String classpathString
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    def pluginClasspathResource = getClass().classLoader.getResource("plugin-classpath.txt")
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        "Did not find plugin classpath resource, run `testClasses` build task.")
+    }
+
+    pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+    classpathString = pluginClasspath
+      .collect { it.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { "'$it'" }
+      .join(", ")
+    reportFolder = "${testProjectDir.root.path.replaceAll("\\\\", '/')}/build/dependencyUpdates"
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/987')
+  def 'dependency added via withDependencies on a bucket configuration is not discarded'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'com.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.implementation.withDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+
+        def isNonStable = { String version ->
+          def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+          def regex = /^[0-9,.v-]+(-r)?\$/
+          return !stableKeyword && !(version ==~ regex)
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          outputFormatter = 'json'
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            isNonStable(it.candidate.version) && !isNonStable(it.currentVersion)
+          }
+        }
+        """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.count == 1
+    report.current.dependencies*.name == ['guava']
+    report.current.dependencies[0].version == '15.0'
+    report.outdated.dependencies.isEmpty()
+    report.undeclared.dependencies.isEmpty()
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/987')
+  def 'dependency added via defaultDependencies on an undeclared configuration is not discarded'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'com.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        configurations.tool.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          outputFormatter = 'json'
+          checkForGradleUpdate = false
+        }
+        """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.count == 1
+    report.outdated.dependencies*.name == ['guava']
+    report.outdated.dependencies[0].version == '15.0'
+    report.outdated.dependencies[0].available.milestone == '16.0-rc1'
+    report.current.dependencies.isEmpty()
+    report.undeclared.dependencies.isEmpty()
+  }
+}


### PR DESCRIPTION
Fixes #987.

`Resolver.resolve` reads the declared set through `getCurrentCoordinates` before anything resolves, but `withDependencies` and `defaultDependencies` actions run at resolution time. A dependency contributed that way is missing from `declared`, gets dropped by `coordinates.keys.retainAll(declared.keys)`, and then reaches two places that tolerate a missing current coordinate: `wrapComponentSelection` returns null, so `rejectVersionIf` never runs for it, and `getStatus`'s `originalCoordinate ?: resolvedCoordinate` reports the resolved version as the declared one.

One statement at the top of `resolve`:

```kotlin
configuration.incoming.dependencies
```

`getDependencies()` runs the dependency actions across the `extendsFrom` hierarchy without triggering graph resolution.

### Report output changes

Coordinates the Kotlin plugin contributes lazily were previously compared against themselves, so they read as up to date. They now get a real latest-version query. With Kotlin 1.7.0 declared:

- `kotlin-compiler-embeddable` and `kotlin-klib-commonizer-embeddable` move from current to outdated. They were the only current entries in that scenario, so its "using the latest milestone version" section disappears.
- `kotlin-stdlib-jdk8` shows up as outdated; previously it was absent from the report.

Nobody updates these coordinates directly; they follow the KGP version. But KGP declares them on the project's configurations, they are genuinely stale, and `rejectVersionIf` now runs for them, so builds that consider them noise can filter them like any other dependency, which previously wasn't possible. That last part is what #987 grew out of: reports listing beta versions for `kotlin-stdlib` in a build whose `rejectVersionIf` rejects unstable candidates, because the rule was silently skipped for it. Tool versions from `defaultDependencies` (jacoco, checkstyle, pmd) change the same way: previously pinned at the default and never queried, now resolved like anything else.

Two `KotlinDependencyUpdatesSpec` expectations widen to match. `LazyDependencySpec` is new and covers both contribution routes. Five of the seven cases across the two specs are red without the `Resolver` change.

Let me know if the output changes are acceptable, or if you want it handled differently.
