### PR TITLE
Report each declared version against the latest found for it (fixes #348) (fixes #906)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdates.kt
@@ -104,15 +104,11 @@ class DependencyUpdates
       unresolved: Set<UnresolvedDependency>,
       projectUrls: Map<Map<String, String>, String>,
     ): DependencyUpdatesReporter {
-      val currentVersions =
-        versions.current
-          .associateBy({ mapOf("group" to it.groupId, "name" to it.artifactId) }, { it })
+      val currentVersions = toMap(versions.current)
       val latestVersions =
         versions.latest
           .associateBy({ mapOf("group" to it.groupId, "name" to it.artifactId) }, { it })
-      val upToDateVersions =
-        versions.upToDate
-          .associateBy({ mapOf("group" to it.groupId, "name" to it.artifactId) }, { it })
+      val upToDateVersions = toMap(versions.upToDate)
       val downgradeVersions = toMap(versions.downgrade)
       val upgradeVersions = toMap(versions.upgrade)
 
@@ -123,7 +119,7 @@ class DependencyUpdates
         project, revision, outputFormatterArgument, outputDir,
         reportfileName, currentVersions, latestVersions, upToDateVersions, downgradeVersions,
         upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
-        gradleReleaseChannel,
+        gradleReleaseChannel, versions.latestByCurrent,
       )
     }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -188,26 +188,20 @@ class DependencyUpdatesReporter(
 
   private fun buildCurrentGroup(): MutableSet<Dependency> {
     return sortByGroupAndName(upToDateVersions)
-      .map { dep ->
-        updateKey(dep.key as HashMap)
-        buildDependency(dep.value, dep.key)
-      }.toSortedSet()
+      .map { dep -> buildDependency(dep.value, strippedKey(dep.key)) }
+      .toSortedSet()
   }
 
   private fun buildOutdatedGroup(): MutableSet<DependencyOutdated> {
     return sortByGroupAndName(upgradeVersions)
-      .map { dep ->
-        updateKey(dep.key as HashMap)
-        buildOutdatedDependency(dep.value, dep.key)
-      }.toSortedSet()
+      .map { dep -> buildOutdatedDependency(dep.value, strippedKey(dep.key)) }
+      .toSortedSet()
   }
 
   private fun buildExceededGroup(): MutableSet<DependencyLatest> {
     return sortByGroupAndName(downgradeVersions)
-      .map { dep ->
-        updateKey(dep.key as HashMap)
-        buildExceededDependency(dep.value, dep.key)
-      }.toSortedSet()
+      .map { dep -> buildExceededDependency(dep.value, strippedKey(dep.key)) }
+      .toSortedSet()
   }
 
   private fun buildUndeclaredGroup(): MutableSet<Dependency> {
@@ -301,13 +295,11 @@ class DependencyUpdatesReporter(
   }
 
   companion object {
-    private fun updateKey(existingKey: HashMap<String, String>) {
-      val index = existingKey["name"]?.lastIndexOf("[") ?: -1
-      if (index == -1) {
-        existingKey["name"] = existingKey["name"].orEmpty()
-      } else {
-        existingKey["name"] = existingKey["name"].orEmpty().substring(0, index)
-      }
+    /** Returns the key with the disambiguating suffix that [toMap] appended removed. */
+    private fun strippedKey(existingKey: Map<String, String>): Map<String, String> {
+      val name = existingKey["name"].orEmpty()
+      val index = name.lastIndexOf("[")
+      return if (index == -1) existingKey else existingKey + ("name" to name.substring(0, index))
     }
 
     private fun buildObject(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -44,6 +44,7 @@ import java.util.TreeSet
  * @property gradleUpdateChecker Facade object to access information about running gradle versions
  * and gradle updates.
  * @property gradleReleaseChannel The gradle release channel to use for reporting.
+ * @property latestByCurrent The latest version found for each declared version.
  *
  */
 class DependencyUpdatesReporter(
@@ -62,6 +63,7 @@ class DependencyUpdatesReporter(
   val projectUrls: Map<Map<String, String>, String>,
   val gradleUpdateChecker: GradleUpdateChecker,
   val gradleReleaseChannel: String,
+  val latestByCurrent: Map<Coordinate, Coordinate> = emptyMap(),
 ) {
   @Synchronized
   fun write() {
@@ -251,8 +253,16 @@ class DependencyUpdatesReporter(
       version = coordinate.version,
       projectUrl = projectUrls[key],
       userReason = coordinate.userReason,
-      latest = latestVersions[key]?.version.orEmpty(),
+      latest = latestFor(coordinate, key).orEmpty(),
     )
+  }
+
+  /** Returns the latest version found for the declared version, if it was paired with one. */
+  private fun latestFor(
+    coordinate: Coordinate,
+    key: Map<String, String>,
+  ): String? {
+    return (latestByCurrent[coordinate] ?: latestVersions[key])?.version
   }
 
   private fun buildUnresolvedDependency(
@@ -273,7 +283,7 @@ class DependencyUpdatesReporter(
     coordinate: Coordinate,
     key: Map<String, String>,
   ): DependencyOutdated {
-    val laterVersion = latestVersions[key]?.version
+    val laterVersion = latestFor(coordinate, key)
     val available =
       when (revision) {
         "milestone" -> VersionAvailable(milestone = laterVersion)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
@@ -15,13 +15,19 @@ class VersionMapping(val project: Project, statuses: Set<DependencyStatus>) {
   val unresolved = sortedSetOf<Coordinate>()
   val current = sortedSetOf<Coordinate>()
   val latest = sortedSetOf<Coordinate>()
+  val latestByCurrent = hashMapOf<Coordinate, Coordinate>()
   private var comparator = makeVersionComparator()
 
   init {
     for (status in statuses) {
       current.add(status.coordinate)
       if (status.unresolved == null) {
-        latest.add(status.getLatestCoordinate())
+        val latestCoordinate = status.getLatestCoordinate()
+        latest.add(latestCoordinate)
+        val previous = latestByCurrent[status.coordinate]
+        if (previous == null || comparator.compare(previous.version, latestCoordinate.version) < 0) {
+          latestByCurrent[status.coordinate] = latestCoordinate
+        }
       } else {
         unresolved.add(status.coordinate)
       }
@@ -33,7 +39,7 @@ class VersionMapping(val project: Project, statuses: Set<DependencyStatus>) {
   private fun organize() {
     val latestByKey = latest.associateBy({ it.key }, { it })
     for (coordinate in current) {
-      val latestCoordinate = latestByKey[coordinate.key]
+      val latestCoordinate = latestByCurrent[coordinate] ?: latestByKey[coordinate.key]
       val version = latestCoordinate?.version
       project.logger
         .info("Comparing dependency (current: {}, latest: {})", coordinate, version ?: "unresolved")

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
@@ -5,6 +5,7 @@ import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseCh
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.updates.DependencyUpdates
 import com.github.benmanes.gradle.versions.updates.OutputFormatterArgument
+import groovy.json.JsonSlurper
 import org.gradle.api.Action
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Issue
@@ -53,6 +54,23 @@ final class ReportJoinSpec extends Specification {
     result.outdated.dependencies.isEmpty()
   }
 
+  @Issue([
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/348',
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/906',
+  ])
+  def 'Multiple up to date versions of a module all survive into the report file'() {
+    given:
+    def root = twoProjects('org.apache.logging.log4j', 'log4j-core', '2\\.17\\.0', '2.16.0', '2.17.0')
+
+    when:
+    writeReport(root, 'json')
+
+    then:
+    def report = new JsonSlurper().parse(new File(root.projectDir, 'build/report.json'))
+    report.current.dependencies*.version == ['2.16.0', '2.17.0']
+    report.count == 2
+  }
+
   /**
    * A root project whose two children declare the same module, where the first child's repository
    * hides the versions matching {@code hiddenVersionRegex}. The latest version found therefore
@@ -93,10 +111,17 @@ final class ReportJoinSpec extends Specification {
 
   private static Result evaluate(project) {
     Result captured = null
-    def formatter =
-      new OutputFormatterArgument.CustomAction({ result -> captured = result } as Action<Result>)
+    reportWith(project,
+      new OutputFormatterArgument.CustomAction({ result -> captured = result } as Action<Result>))
+    return captured
+  }
+
+  private static void writeReport(project, String outputFormat) {
+    reportWith(project, new OutputFormatterArgument.BuiltIn(outputFormat))
+  }
+
+  private static void reportWith(project, OutputFormatterArgument formatter) {
     new DependencyUpdates(project, null, 'milestone', formatter, 'build', 'report', false,
       'https://services.gradle.org/versions/', RELEASE_CANDIDATE.id).run().write()
-    return captured
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
@@ -1,0 +1,102 @@
+package com.github.benmanes.gradle.versions
+
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
+
+import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.github.benmanes.gradle.versions.updates.DependencyUpdates
+import com.github.benmanes.gradle.versions.updates.OutputFormatterArgument
+import org.gradle.api.Action
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for reporting each declared version against the latest version found for it.
+ */
+final class ReportJoinSpec extends Specification {
+
+  @Issue([
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/348',
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/906',
+  ])
+  def 'An outdated version is reported against the latest version found for it'() {
+    given:
+    def root = twoProjects('com.google.inject', 'guice', '3\\.1', '2.0', '3.0')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.current.dependencies.isEmpty()
+    with(result.outdated.dependencies.toList()) {
+      it*.version == ['2.0', '3.0']
+      it*.available*.milestone == ['3.0', '3.1']
+    }
+  }
+
+  @Issue([
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/348',
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/906',
+  ])
+  def 'Multiple up to date versions of a module all survive into the report'() {
+    given:
+    def root = twoProjects('org.apache.logging.log4j', 'log4j-core', '2\\.17\\.0', '2.16.0', '2.17.0')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.current.dependencies*.version == ['2.16.0', '2.17.0']
+    result.current.dependencies.every {
+      it.group == 'org.apache.logging.log4j' && it.name == 'log4j-core'
+    }
+    result.outdated.dependencies.isEmpty()
+  }
+
+  /**
+   * A root project whose two children declare the same module, where the first child's repository
+   * hides the versions matching {@code hiddenVersionRegex}. The latest version found therefore
+   * differs between the children, which a report keyed on the group and name alone cannot express.
+   */
+  private def twoProjects(String group, String artifact, String hiddenVersionRegex,
+      String pinnedVersion, String openVersion) {
+    def root = ProjectBuilder.builder().withName('root').build()
+    def pinned = ProjectBuilder.builder().withName('pinned').withParent(root).build()
+    def open = ProjectBuilder.builder().withName('open').withParent(root).build()
+    def localMavenRepo = getClass().getResource('/maven/')
+    pinned.repositories {
+      maven {
+        url localMavenRepo.toURI()
+        content {
+          excludeVersionByRegex(group.replace('.', '\\.'), artifact, hiddenVersionRegex)
+        }
+      }
+    }
+    open.repositories {
+      maven {
+        url localMavenRepo.toURI()
+      }
+    }
+    for (project in [pinned, open]) {
+      project.configurations {
+        app
+      }
+    }
+    pinned.dependencies {
+      app "$group:$artifact:$pinnedVersion"
+    }
+    open.dependencies {
+      app "$group:$artifact:$openVersion"
+    }
+    return root
+  }
+
+  private static Result evaluate(project) {
+    Result captured = null
+    def formatter =
+      new OutputFormatterArgument.CustomAction({ result -> captured = result } as Action<Result>)
+    new DependencyUpdates(project, null, 'milestone', formatter, 'build', 'report', false,
+      'https://services.gradle.org/versions/', RELEASE_CANDIDATE.id).run().write()
+    return captured
+  }
+}


### PR DESCRIPTION
Fixes #348 and fixes #906.

`VersionMapping.organize()` joins declared versions to latest versions with `latest.associateBy { it.key }`, keyed on group and name alone, so a module declared at two versions gets one latest for both. That mis-buckets the older declaration and prints another declaration's upgrade target on its row, though each `DependencyStatus` already carries the right latest. First commit keeps the per-declaration pairing and uses it for the bucket and the printed target, and routes `currentVersions`/`upToDateVersions` through the same multi-map as upgrade/downgrade so both rows survive to the reporter (per #65 / 486024f).

Second commit fixes a latent bug this exposed: `updateKey` deduplicated the multi-map keys by mutating them in place, and the result is rebuilt per output sink, so file reports collapsed rows that stdout printed.

When the same declared version has two different latests (the missing-repository case from #348), the greater one still wins.
