### PR TITLE
Read the declared set again after a configuration is first resolved

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -318,13 +318,25 @@ class Resolver(
       }
     }
 
+    // A resolution listener contributes dependencies when a configuration is first resolved, which
+    // is the resolution above, so they are missing from the declared set read before it. Read it
+    // again to pick up their declared version; otherwise only the query below sees them and their
+    // latest version is reported as the declared one, hiding the update.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/992
+    val contributed =
+      getResolvableDependencies(configuration)
+        .filterNot { declared.containsKey(it.key) }
+    for (coordinate in contributed) {
+      coordinates.putIfAbsent(coordinate.key, coordinate)
+    }
+
     // A substitution rule can replace a declared module with one of a different group or name, so
     // the resolved coordinates are in a different keyspace than the declared ones.
     // https://github.com/ben-manes/gradle-versions-plugin/issues/990
     val substitutions = getSubstitutions(copy, declared)
 
     // Ignore undeclared (hidden) dependencies that appear when resolving a configuration
-    coordinates.keys.retainAll(declared.keys + substitutions.values)
+    coordinates.keys.retainAll(declared.keys + contributed.map { it.key } + substitutions.values)
 
     return CurrentCoordinates(coordinates, substitutions)
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -282,7 +282,10 @@ class Resolver(
     val declared =
       getResolvableDependencies(configuration)
         .associateBy { it.key }
-    if (declared.isEmpty()) {
+    // An empty configuration is still resolved below, so that a listener contributing to it has
+    // run by the time the declared set is read again. That resolution costs nothing. One holding
+    // only project or file dependencies is skipped, as resolving it would not.
+    if (declared.isEmpty() && configuration.allDependencies.isNotEmpty()) {
       return CurrentCoordinates(emptyMap(), emptyMap())
     }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolutionListenerSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolutionListenerSpec.groovy
@@ -1,0 +1,101 @@
+package com.github.benmanes.gradle.versions
+
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
+
+import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.github.benmanes.gradle.versions.updates.DependencyUpdates
+import com.github.benmanes.gradle.versions.updates.OutputFormatterArgument
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
+import org.gradle.api.Action
+import org.gradle.api.artifacts.DependencyResolutionListener
+import org.gradle.api.artifacts.ResolvableDependencies
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for a dependency that a resolution listener contributes while the first
+ * configuration is being resolved.
+ * https://github.com/ben-manes/gradle-versions-plugin/issues/992
+ */
+final class ResolutionListenerSpec extends Specification {
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/992')
+  def 'A contributed dependency is reported against its declared version'() {
+    given:
+    def project = contributing('com.google.guava:guava:15.0')
+
+    when:
+    def result = evaluate(project, null)
+
+    then:
+    result.current.dependencies.isEmpty()
+    with(result.outdated.dependencies.toList()) {
+      it*.name == ['guava', 'guice']
+      it*.version == ['15.0', '2.0']
+      it*.available*.milestone == ['16.0-rc1', '3.1']
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/992')
+  def 'A component selection rule sees a contributed dependency'() {
+    given:
+    def project = contributing('com.google.guava:guava:15.0')
+    def seen = []
+
+    when:
+    evaluate(project, { selection ->
+      seen += "$selection.candidate.module:$selection.currentVersion -> $selection.candidate.version".toString()
+    })
+
+    then:
+    seen.contains('guava:15.0 -> 16.0-rc1')
+  }
+
+  /**
+   * A project whose declared set gains {@code contribution} only once a resolution has begun, which
+   * is how a build-scoped listener adds one. The anchor dependency keeps the declared set non-empty
+   * so that the resolver does not short-circuit before the listener has fired.
+   */
+  private static def contributing(String contribution) {
+    def project = ProjectBuilder.builder().withName('root').build()
+    project.repositories {
+      maven {
+        url ResolutionListenerSpec.getResource('/maven/').toURI()
+      }
+    }
+    project.configurations {
+      app
+    }
+    project.dependencies {
+      app 'com.google.inject:guice:2.0'
+    }
+    def contributed = false
+    project.gradle.addListener(new DependencyResolutionListener() {
+      @Override
+      void beforeResolve(ResolvableDependencies incoming) {
+        if (!contributed) {
+          contributed = true
+          project.dependencies.add('app', contribution)
+        }
+      }
+
+      @Override
+      void afterResolve(ResolvableDependencies incoming) {
+      }
+    })
+    return project
+  }
+
+  private static Result evaluate(project, Closure selectionRule) {
+    Result captured = null
+    def strategy = selectionRule == null ? null : { ResolutionStrategyWithCurrent it ->
+      it.componentSelection { rules -> rules.all(selectionRule) }
+    } as Action<ResolutionStrategyWithCurrent>
+    new DependencyUpdates(project, strategy, 'milestone',
+      new OutputFormatterArgument.CustomAction({ result -> captured = result } as Action<Result>),
+      'build', 'report', false, 'https://services.gradle.org/versions/', RELEASE_CANDIDATE.id)
+      .run().write()
+    return captured
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolutionListenerSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolutionListenerSpec.groovy
@@ -52,12 +52,27 @@ final class ResolutionListenerSpec extends Specification {
     seen.contains('guava:15.0 -> 16.0-rc1')
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/992')
+  def 'A dependency contributed to a configuration that declares nothing else is reported'() {
+    given:
+    def project = contributing('com.google.guava:guava:15.0', 'aaa')
+
+    when:
+    def result = evaluate(project, null)
+
+    then:
+    with(result.outdated.dependencies.toList().find { it.name == 'guava' }) {
+      it.version == '15.0'
+      it.available.milestone == '16.0-rc1'
+    }
+  }
+
   /**
    * A project whose declared set gains {@code contribution} only once a resolution has begun, which
-   * is how a build-scoped listener adds one. The anchor dependency keeps the declared set non-empty
-   * so that the resolver does not short-circuit before the listener has fired.
+   * is how a build-scoped listener adds one. The contribution goes to {@code target}, which is
+   * resolved before the anchor when it sorts first, so that the empty case is covered too.
    */
-  private static def contributing(String contribution) {
+  private static def contributing(String contribution, String target = 'app') {
     def project = ProjectBuilder.builder().withName('root').build()
     project.repositories {
       maven {
@@ -65,6 +80,7 @@ final class ResolutionListenerSpec extends Specification {
       }
     }
     project.configurations {
+      aaa
       app
     }
     project.dependencies {
@@ -76,7 +92,7 @@ final class ResolutionListenerSpec extends Specification {
       void beforeResolve(ResolvableDependencies incoming) {
         if (!contributed) {
           contributed = true
-          project.dependencies.add('app', contribution)
+          project.dependencies.add(target, contribution)
         }
       }
 


### PR DESCRIPTION
Fixes #992.

`getCurrentCoordinates` reads the declared dependencies, then resolves a copy of the configuration to find what they resolve to. A `DependencyResolutionListener` registered with `gradle.addListener` contributes its dependencies during that resolution, since it is the first one the build performs, so the contribution lands between the two. It is missing from the declared coordinates but present by the time `createLatestConfiguration` reads the configuration again, so the module is queried for its latest version with no declared version to compare against. `getStatus` then falls back to the resolved coordinate and reports the latest version as the declared one.

The first commit reads the declared set a second time after that resolution and takes the declared version of anything new. Modules that were already there are untouched.

The second commit stops skipping a configuration whose declared set is empty. That skip returned before the copy was resolved, so a listener contributing to such a configuration was never seen at all and the module was left out of the report entirely, which is the case a plain `java` project hits: `annotationProcessor` sorts first among the resolvable configurations and nothing extends it. Configurations holding only project or file dependencies are still skipped, since resolving those is not free.

Two symptoms go away: the module is reported at its declared version instead of always appearing up to date, and `rejectVersionIf` is invoked for it, since a current version now exists to pass to the rule.

Worth flagging as a behavior change: a `rejectVersionIf` rule that was silently inert on these modules now runs for them, so a rule that rejects everything moves such a module from "using the latest milestone version" to "failed to determine the latest version". That matches what an ordinarily declared module already does under the same rule.
