### PR TITLE
Add a contributor plugin that preserves named `dependencyUpdates` invocation under isolated projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ checks for updates to Gradle itself.
   - [Related plugins](#related-plugins)
 - [dependencyUpdates](#dependencyupdates)
   - [Multi-project build](#multi-project-build)
+  - [Isolated projects](#isolated-projects)
   - [Revisions](#revisions)
   - [RejectVersionsIf and componentSelection](#rejectversionsif-and-componentselection)
   - [Gradle Release Channel](#gradle-release-channel)
@@ -144,6 +145,39 @@ field explaining failures or missing information. The update check may be disabl
 In a multi-project build, running this task in the root project will generate a consolidated/merged
 report for dependency updates in all subprojects. Alternatively, you can run the task separately in
 each subproject to generate separate reports for each subproject.
+
+The report is aggregated from a task in each project, so it is compatible with parallel execution
+and the configuration cache. Each project takes the settings that control resolution (`revision`,
+`rejectVersionIf` or a full `resolutionStrategy`, `filterConfigurations`, `checkConstraints`, and
+`checkBuildEnvironmentConstraints`) from the nearest project up the hierarchy whose task set them,
+so configuring the root project's task covers every project unless a subproject configures its own.
+
+#### Isolated projects
+
+Under [isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html) a
+project plugin cannot register a task in another project, so a project only contributes to the
+aggregate report if it applies a plugin itself. Keep applying `com.github.ben-manes.versions` in
+the root project, and apply `com.github.ben-manes.versions.contributor` in every other project,
+typically from a convention plugin they already share:
+
+```kotlin
+// buildSrc/src/main/kotlin/my-conventions.gradle.kts
+plugins {
+  id("com.github.ben-manes.versions.contributor")
+}
+```
+
+The contributor plugin registers only the task that feeds the aggregate report, so
+`dependencyUpdates` remains a single task in the root project. The main plugin is a superset of
+the contributor plugin: a project that applies `com.github.ben-manes.versions` instead still feeds
+the aggregate report, and also gets its own `dependencyUpdates` task covering itself and its
+subprojects. So for a separate per-project report, apply the main plugin to that project—there is
+no need to apply both. Running `dependencyUpdates` by name then includes that project's report,
+as it always has when the plugin is applied to more than one project; run a single task by its
+path to get just that report (e.g., `:subproject:dependencyUpdates`).
+
+Under isolated projects, contributing projects that share a group and name are aggregated as one;
+the console warns about any project the report is missing.
 
 #### Revisions
 
@@ -371,8 +405,8 @@ Have a look at [`examples/groovy`](https://github.com/ben-manes/gradle-versions-
 $ ./gradlew publishToMavenLocal
 
 # Try out the samples
-$ ./gradlew -p examples/groovy dependencyUpdate
-$ ./gradlew -p examples/kotlin dependencyUpdate
+$ ./gradlew -p examples/groovy dependencyUpdates
+$ ./gradlew -p examples/kotlin dependencyUpdates
 ```
 
 ### Report format

--- a/README.md
+++ b/README.md
@@ -167,7 +167,11 @@ plugins {
 }
 ```
 
-The contributor plugin registers only the task that feeds the aggregate report, so
+The convention plugin's own build must have the plugin on its classpath, e.g. as an
+`implementation("com.github.ben-manes:gradle-versions-plugin:$version")` dependency in
+`buildSrc/build.gradle.kts`.
+
+The contributor plugin registers only the producer that feeds the aggregate report, so
 `dependencyUpdates` remains a single task in the root project. The main plugin is a superset of
 the contributor plugin: a project that applies `com.github.ben-manes.versions` instead still feeds
 the aggregate report, and also gets its own `dependencyUpdates` task covering itself and its

--- a/gradle-versions-plugin/build.gradle.kts
+++ b/gradle-versions-plugin/build.gradle.kts
@@ -53,5 +53,12 @@ gradlePlugin {
       description = properties["POM_DESCRIPTION"].toString()
       tags.set(listOf("dependencies", "versions", "updates"))
     }
+    create("versionsContributorPlugin") {
+      id = properties["PLUGIN_CONTRIBUTOR_NAME"].toString()
+      implementationClass = properties["PLUGIN_CONTRIBUTOR_NAME_CLASS"].toString()
+      displayName = properties["POM_CONTRIBUTOR_NAME"].toString()
+      description = properties["POM_CONTRIBUTOR_DESCRIPTION"].toString()
+      tags.set(listOf("dependencies", "versions", "updates"))
+    }
   }
 }

--- a/gradle-versions-plugin/gradle.properties
+++ b/gradle-versions-plugin/gradle.properties
@@ -1,3 +1,5 @@
 POM_ARTIFACT_ID=gradle-versions-plugin
 POM_NAME=Gradle Versions Plugin
 POM_DESCRIPTION=Gradle plugin that provides tasks for discovering dependency updates.
+POM_CONTRIBUTOR_NAME=Gradle Versions Contributor Plugin
+POM_CONTRIBUTOR_DESCRIPTION=Gradle plugin that contributes a project's dependency updates to the root report.

--- a/gradle-versions-plugin/gradle.properties
+++ b/gradle-versions-plugin/gradle.properties
@@ -2,4 +2,4 @@ POM_ARTIFACT_ID=gradle-versions-plugin
 POM_NAME=Gradle Versions Plugin
 POM_DESCRIPTION=Gradle plugin that provides tasks for discovering dependency updates.
 POM_CONTRIBUTOR_NAME=Gradle Versions Contributor Plugin
-POM_CONTRIBUTOR_DESCRIPTION=Gradle plugin that contributes a project's dependency updates to the root report.
+POM_CONTRIBUTOR_DESCRIPTION=Gradle plugin that contributes a project's dependency updates to the aggregate report.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
@@ -1,7 +1,5 @@
 package com.github.benmanes.gradle.versions
 
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesParametersService
-import com.github.benmanes.gradle.versions.updates.PARAMETERS_SERVICE
 import com.github.benmanes.gradle.versions.updates.registerProducer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -19,10 +17,6 @@ import org.gradle.api.Project
 class VersionsContributorPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     requireMinimumGradleVersion("com.github.ben-manes.versions.contributor")
-
-    val service =
-      project.gradle.sharedServices
-        .registerIfAbsent(PARAMETERS_SERVICE, DependencyUpdatesParametersService::class.java) { }
-    registerProducer(project, service)
+    registerProducer(project)
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
@@ -1,0 +1,28 @@
+package com.github.benmanes.gradle.versions
+
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesParametersService
+import com.github.benmanes.gradle.versions.updates.PARAMETERS_SERVICE
+import com.github.benmanes.gradle.versions.updates.registerProducer
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Contributes the project's dependency updates to the aggregate report without registering a
+ * `dependencyUpdates` task of its own.
+ *
+ * Under isolated projects a project plugin cannot register a task in another project, so every
+ * project must apply a plugin itself to be aggregated. Applying [VersionsPlugin] everywhere would
+ * register a `dependencyUpdates` task in every project, and running `dependencyUpdates` by name
+ * would then report per project instead of once from the root. Applying this plugin instead keeps
+ * the root's task the only one with that name, so the report is invoked the same way as before.
+ */
+class VersionsContributorPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    requireMinimumGradleVersion("com.github.ben-manes.versions.contributor")
+
+    val service =
+      project.gradle.sharedServices
+        .registerIfAbsent(PARAMETERS_SERVICE, DependencyUpdatesParametersService::class.java) { }
+    registerProducer(project, service)
+  }
+}

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
@@ -16,7 +16,7 @@ import javax.xml.parsers.SAXParserFactory
  */
 class VersionsPlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    requireMinimumGradleVersion()
+    requireMinimumGradleVersion("com.github.ben-manes.versions")
 
     val tasks = project.tasks
     if (!tasks.names.contains("dependencyUpdates")) {
@@ -31,12 +31,6 @@ class VersionsPlugin : Plugin<Project> {
           )
         }
       registerAggregation(project, task)
-    }
-  }
-
-  private fun requireMinimumGradleVersion() {
-    if (GradleVersion.current() < GradleVersion.version("8.4")) {
-      throw GradleException("Gradle 8.4 or greater is required to apply the com.github.ben-manes.versions plugin.")
     }
   }
 
@@ -60,5 +54,11 @@ class VersionsPlugin : Plugin<Project> {
         )
       }
     }
+  }
+}
+
+internal fun requireMinimumGradleVersion(pluginId: String) {
+  if (GradleVersion.current() < GradleVersion.version("8.4")) {
+    throw GradleException("Gradle 8.4 or greater is required to apply the $pluginId plugin.")
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -21,7 +21,7 @@ internal const val PARTIAL_TASK_NAME = "partialDependencyUpdates"
 private const val ELEMENTS_CONFIGURATION = "dependencyUpdatesElements"
 private const val AGGREGATION_CONFIGURATION = "dependencyUpdatesAggregation"
 private const val RESULTS_CONFIGURATION = "aggregateDependencyUpdatesResults"
-private const val PARAMETERS_SERVICE = "dependencyUpdatesParameters"
+internal const val PARAMETERS_SERVICE = "dependencyUpdatesParameters"
 private const val VERIFICATION_TYPE = "dependency-updates"
 
 /** The filter applied when a task leaves the configurations unrestricted. */
@@ -178,7 +178,7 @@ internal fun registerAggregation(
 }
 
 /** Registers the task and outgoing variant that publish a single project's statuses. */
-private fun registerProducer(
+internal fun registerProducer(
   project: Project,
   service: Provider<DependencyUpdatesParametersService>,
 ): TaskProvider<DependencyUpdatesPartialTask> {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -21,7 +21,7 @@ internal const val PARTIAL_TASK_NAME = "partialDependencyUpdates"
 private const val ELEMENTS_CONFIGURATION = "dependencyUpdatesElements"
 private const val AGGREGATION_CONFIGURATION = "dependencyUpdatesAggregation"
 private const val RESULTS_CONFIGURATION = "aggregateDependencyUpdatesResults"
-internal const val PARAMETERS_SERVICE = "dependencyUpdatesParameters"
+private const val PARAMETERS_SERVICE = "dependencyUpdatesParameters"
 private const val VERIFICATION_TYPE = "dependency-updates"
 
 /** The filter applied when a task leaves the configurations unrestricted. */
@@ -103,9 +103,7 @@ internal fun registerAggregation(
   project: Project,
   accumulator: TaskProvider<DependencyUpdatesTask>,
 ) {
-  val service =
-    project.gradle.sharedServices
-      .registerIfAbsent(PARAMETERS_SERVICE, DependencyUpdatesParametersService::class.java) { }
+  val service = parametersService(project)
   accumulator.configure { task -> service.get().register(project.path, task.parameters) }
   // Realizes the task, so that a configuration block on a task that nothing else realizes is still
   // applied before the producers read the settings.
@@ -178,7 +176,15 @@ internal fun registerAggregation(
 }
 
 /** Registers the task and outgoing variant that publish a single project's statuses. */
-internal fun registerProducer(
+internal fun registerProducer(project: Project): TaskProvider<DependencyUpdatesPartialTask> =
+  registerProducer(project, parametersService(project))
+
+/** Returns the build's shared parameters service, registering it if this is the first use. */
+private fun parametersService(project: Project): Provider<DependencyUpdatesParametersService> =
+  project.gradle.sharedServices
+    .registerIfAbsent(PARAMETERS_SERVICE, DependencyUpdatesParametersService::class.java) { }
+
+private fun registerProducer(
   project: Project,
   service: Provider<DependencyUpdatesParametersService>,
 ): TaskProvider<DependencyUpdatesPartialTask> {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -15,7 +15,9 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskProvider
 import java.util.concurrent.ConcurrentHashMap
 
-internal const val PARTIAL_TASK_NAME = "dependencyUpdatesPartial"
+// Not prefixed with "dependencyUpdates": a project with only a producer would otherwise let
+// Gradle's task abbreviation match "dependencyUpdates" to it and silently succeed with no report.
+internal const val PARTIAL_TASK_NAME = "partialDependencyUpdates"
 private const val ELEMENTS_CONFIGURATION = "dependencyUpdatesElements"
 private const val AGGREGATION_CONFIGURATION = "dependencyUpdatesAggregation"
 private const val RESULTS_CONFIGURATION = "aggregateDependencyUpdatesResults"

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -192,8 +192,9 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     if (missing.isNotEmpty()) {
       logger.warn(
         "The dependency updates report is missing ${missing.sorted().joinToString(", ")}. A project " +
-          "must apply the com.github.ben-manes.versions plugin to be aggregated when isolated " +
-          "projects is enabled, and projects that share a group and name are aggregated as one.",
+          "must apply the com.github.ben-manes.versions or com.github.ben-manes.versions.contributor " +
+          "plugin to be aggregated when isolated projects is enabled, and projects that share a " +
+          "group and name are aggregated as one.",
       )
     }
     val statuses =

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -139,8 +139,8 @@ final class AggregationSpec extends Specification {
       .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
 
     then:
-    result.task(':app:dependencyUpdatesPartial').outcome == SUCCESS
-    result.task(':lib:dependencyUpdatesPartial').outcome == SUCCESS
+    result.task(':app:partialDependencyUpdates').outcome == SUCCESS
+    result.task(':lib:partialDependencyUpdates').outcome == SUCCESS
     report.outdated.dependencies*.name.containsAll(['guice', 'guava'])
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -80,6 +80,9 @@ final class ContributorAggregationSpec extends Specification {
 
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
+    // Guards the flag itself: the property is a silent no-op on a Gradle whose spelling differs
+    // (pre-9.7 uses org.gradle.unsafe.isolated-projects), which would pass the non-isolated branch.
+    result.output.contains('Isolated Projects is an incubating feature.')
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
     !result.output.contains('The dependency updates report is missing')
@@ -275,6 +278,8 @@ final class ContributorAggregationSpec extends Specification {
 
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
+    // The eviction only occurs on the isolated path, so prove the flag engaged before asserting it.
+    result.output.contains('Isolated Projects is an incubating feature.')
     // Colliding projects aggregate as one, so a warning names the dropped project by group and name.
     result.output.contains('The dependency updates report is missing')
     result.output.contains('share a group and name')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -1,0 +1,194 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+
+// Gradle 9 requires JVM 17.
+@Requires({ jvm.java17Compatible })
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/948')
+final class ContributorAggregationSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    testProjectDir.newFile('settings.gradle') << "include 'app', 'lib'"
+    // Only the root applies the reporting plugin, so 'dependencyUpdates' by name matches one task.
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'com.github.ben-manes.versions'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'com.github.ben-manes.versions.contributor'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'com.github.ben-manes.versions.contributor'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+  }
+
+  private def run(String... arguments) {
+    return GradleRunner.create()
+      .withGradleVersion('9.7.0-rc-1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Aggregates by name under isolated projects with only the root reporting'() {
+    when:
+    def result = run('dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache', '--parallel')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('The dependency updates report is missing')
+    // The contributor plugin registers no task with this name, so a bare invocation matches neither.
+    result.task(':app:dependencyUpdates') == null
+    result.task(':lib:dependencyUpdates') == null
+  }
+
+  def 'Honors the root task settings in every contributor producer'() {
+    given:
+    new File(testProjectDir.root, 'build.gradle') <<
+      """
+        dependencyUpdates.resolutionStrategy {
+          componentSelection {
+            all {
+              if (candidate.version == '3.1') {
+                reject('unstable')
+              }
+            }
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache', '--parallel')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // guice lives in the contributor-only :app project, so honoring 3.0 proves the reject reached it.
+    result.output.contains('com.google.inject:guice [2.0 -> 3.0]')
+  }
+
+  def 'Aggregates once when a project applies both plugins'() {
+    given:
+    new File(testProjectDir.root, 'app/build.gradle').text =
+      """
+        plugins {
+          id 'java'
+          id 'com.github.ben-manes.versions'
+          id 'com.github.ben-manes.versions.contributor'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(':dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache', '--parallel')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    // A shared partial producer means the doubly-applied project is reported exactly once.
+    result.output.count('com.google.inject:guice [2.0 -> 3.1]') == 1
+  }
+
+  def 'Aggregates by name without isolated projects'() {
+    when:
+    def result = run('dependencyUpdates', '--configuration-cache', '--parallel')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    result.task(':app:dependencyUpdates') == null
+    result.task(':lib:dependencyUpdates') == null
+  }
+
+  def 'Reuses the configuration cache across runs'() {
+    when:
+    run('dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache', '--parallel')
+    def result = run('dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache', '--parallel')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Configuration cache entry reused.')
+  }
+
+  def 'Fails to match dependencyUpdates when only the contributor plugin is applied'() {
+    given:
+    new File(testProjectDir.root, 'build.gradle').text =
+      """
+        plugins {
+          id 'com.github.ben-manes.versions.contributor'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion('9.7.0-rc-1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments(':dependencyUpdates')
+      .withPluginClasspath()
+      .buildAndFail()
+
+    then:
+    // The producer's name must not let task abbreviation resolve 'dependencyUpdates' to it, which
+    // would run the internal task and succeed with no report.
+    result.output.contains("Cannot locate tasks that match ':dependencyUpdates'")
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -167,6 +167,10 @@ final class ContributorAggregationSpec extends Specification {
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('Configuration cache entry reused.')
+    // The aggregated content must survive the cache hit, not just the task outcome.
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('The dependency updates report is missing')
   }
 
   def 'Fails to match dependencyUpdates when only the contributor plugin is applied'() {
@@ -190,5 +194,93 @@ final class ContributorAggregationSpec extends Specification {
     // The producer's name must not let task abbreviation resolve 'dependencyUpdates' to it, which
     // would run the internal task and succeed with no report.
     result.output.contains("Cannot locate tasks that match ':dependencyUpdates'")
+  }
+
+  def 'Fails to match dependencyUpdates in a contributor-only subproject'() {
+    when:
+    // :app applies only the contributor plugin in the setup fixture, so its producer must exist.
+    def producer = run(':app:partialDependencyUpdates')
+
+    then:
+    producer.task(':app:partialDependencyUpdates').outcome == SUCCESS
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion('9.7.0-rc-1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments(':app:dependencyUpdates')
+      .withPluginClasspath()
+      .buildAndFail()
+
+    then:
+    // The producer's name must not let task abbreviation resolve 'dependencyUpdates' to it, which
+    // would run the internal task and succeed with no report.
+    result.output.contains("Cannot locate tasks that match ':app:dependencyUpdates'")
+  }
+
+  def 'Aggregates projects that share a group and name as one'() {
+    given:
+    new File(testProjectDir.root, 'settings.gradle').text = "include 'a:api', 'b:api'"
+    new File(testProjectDir.root, 'build.gradle').text =
+      """
+        plugins {
+          id 'com.github.ben-manes.versions'
+        }
+      """.stripIndent()
+    ['a', 'b'].each { parent ->
+      testProjectDir.newFolder(parent, 'api')
+    }
+    new File(testProjectDir.root, 'a/api/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'com.github.ben-manes.versions.contributor'
+        }
+
+        group = 'com.example'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    new File(testProjectDir.root, 'b/api/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'com.github.ben-manes.versions.contributor'
+        }
+
+        group = 'com.example'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // Colliding projects aggregate as one, so a warning names the dropped project by group and name.
+    result.output.contains('The dependency updates report is missing')
+    result.output.contains('share a group and name')
+    // Exactly one survives module conflict resolution; which one wins is not guaranteed.
+    def guiceLine = 'com.google.inject:guice [2.0 -> 3.1]'
+    def guavaLine = 'com.google.guava:guava [15.0 -> 16.0-rc1]'
+    result.output.contains(guiceLine) != result.output.contains(guavaLine)
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinMultiplatformAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinMultiplatformAggregationSpec.groovy
@@ -90,8 +90,8 @@ final class KotlinMultiplatformAggregationSpec extends Specification {
     def reused = report()
 
     then:
-    aggregateRun.task(':kmp:dependencyUpdatesPartial').outcome == SUCCESS
-    aggregateRun.task(':jvm:dependencyUpdatesPartial').outcome == SUCCESS
+    aggregateRun.task(':kmp:partialDependencyUpdates').outcome == SUCCESS
+    aggregateRun.task(':jvm:partialDependencyUpdates').outcome == SUCCESS
     hitRun.output.contains('Reusing configuration cache')
     !hitRun.output.contains('The dependency updates report is missing')
     aggregated.outdated.dependencies*.name.contains('kotlinx-coroutines-core')

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin
 
 PLUGIN_NAME=com.github.ben-manes.versions
 PLUGIN_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsPlugin
+PLUGIN_CONTRIBUTOR_NAME=com.github.ben-manes.versions.contributor
+PLUGIN_CONTRIBUTOR_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsContributorPlugin


### PR DESCRIPTION
Follow-up to #994 from testing it against real builds under isolated projects. Isolated projects needs every project to apply the plugin itself, but applying `com.github.ben-manes.versions` everywhere puts a `dependencyUpdates` task in every project, so running `dependencyUpdates` by name produces a report per project instead of the single merged report people run today.

Adds `com.github.ben-manes.versions.contributor`, a producer-only project plugin that registers just the partial task and its outgoing variant. Under isolated projects the root keeps `com.github.ben-manes.versions` and every other project applies the contributor id, typically from a shared convention plugin. `dependencyUpdates` then matches only the root task, so build users invoke it exactly as before and get the single merged report.

The main plugin is unchanged and is a superset of the contributor plugin: applying it per project still creates a per-project `dependencyUpdates` task for separate reports and still feeds the aggregate, so no project needs both. Also renames the partial task to `partialDependencyUpdates`: in a project with only a producer, task abbreviation would otherwise match `dependencyUpdates` to the old name and silently succeed with no report. A regression test covers it. Documents the setup in a new "Isolated projects" README section, along with the aggregation compatibility notes and the settings-inheritance behavior from #994 that weren't written up yet.

Verified against three real multi-project builds (19, 12, and 45 projects) with isolated projects, configuration cache, configure on demand, and parallel build all on: one merged report from bare `dependencyUpdates`, configuration cache reused on the second run.

When existing projects without isolated projects enabled take up the new version of this plugin (i.e. only applying `com.github.ben-manes.versions` at the root), they continue to work as they did before, except now with configuration cache and parallel build support.

Prior art for the split: Gradle's own [jacoco-report-aggregation](https://docs.gradle.org/current/userguide/jacoco_report_aggregation_plugin.html) and [test-report-aggregation](https://docs.gradle.org/current/userguide/test_report_aggregation_plugin.html) aggregate the same way—one project resolves `Category.VERIFICATION` variants that the others expose, which is the mechanism #994 already mirrors. The [Baseline Profile plugin](https://developer.android.com/topic/performance/baselineprofiles/create-baselineprofile) ships explicit `androidx.baselineprofile.producer`/`.consumer` ids for the same producer/consumer split, and the [Dependency Analysis Gradle Plugin](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) puts the aggregate `buildHealth` task at the root while `projectHealth` is the per-project surface.

This doesn't preclude the settings plugin floated on #994: if apply-once demand shows up, one can sit on top of this, applying the contributor plugin to every project and the main plugin to the root, with the same invocation. I've closed ianbrandt/gradle-versions-plugin#1 unmerged accordingly—as written it applied the main plugin everywhere, which recreates the invocation change this PR avoids.

The plugin id is provisional—happy to rename.
