### PR TITLE
Prepare the 0.55.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.github.ben-manes
-VERSION_NAME=0.54.0
+VERSION_NAME=0.55.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps version to 0.55.0.

This is my first time through the release process here, so rather than just tagging, this is what I understand the remaining steps to be for review. Please point out anything I've missed or should do differently.

Once this merges, create a GitHub Release with tag `v0.55.0` targeting `master`. That triggers `deploy.yml`, which runs `publishPlugins` automatically. There's no `-SNAPSHOT` publishing setup, so no follow-up commit is required.

Draft body for that release:

```markdown
* Support parallel build, the configuration cache, and the incubating isolated projects feature by aggregating updates from per-project tasks instead of resolving them from the root project (#666, #910, #948, #994, #995)
* Report each declared version against the latest found for it (#348, #906, #989)
* Query the latest version of the module a dependency substitution resolves to (#990, #991)
* Run dependency actions before reading the declared set (#987, #988)
* Read the declared set again after a configuration is first resolved (#993)

> [!NOTE]
>
> The minimum supported Gradle version is now 8.4.
>
> On Gradle 9.0 and above, the `dependencyUpdates` task no longer needs to be run with the `--no-parallel` flag, and `--configuration-cache` is now fully supported.
>
> Gradle's incubating `--isolated-projects` is now supported (tested with [Gradle 9.7.0-rc-1](https://docs.gradle.org/9.7.0-rc-1/release-notes.html#isolated-projects)) with the following required migration: the new `com.github.ben-manes.versions.contributor` plugin must be applied to each subproject that should contribute its buildscript and project dependencies to the aggregate report (see [Isolated projects](https://github.com/ben-manes/gradle-versions-plugin#isolated-projects) in the README).
```
