### PR TITLE
Publish under the io.github.ben-manes namespace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Run examples
         run: |
           export VERSION_NAME=$(cat gradle.properties | grep -w "VERSION_NAME" | cut -d'=' -f2)
-          rm -rf ~/.m2/repository/com/github/ben-manes/gradle-versions-plugin/$VERSION_NAME
+          rm -rf ~/.m2/repository/io/github/ben-manes/gradle-versions-plugin/$VERSION_NAME
           ./gradlew publishToMavenLocal -x test -s
-          cat ~/.m2/repository/com/github/ben-manes/gradle-versions-plugin/$VERSION_NAME/gradle-versions-plugin-$VERSION_NAME.pom
+          cat ~/.m2/repository/io/github/ben-manes/gradle-versions-plugin/$VERSION_NAME/gradle-versions-plugin-$VERSION_NAME.pom
           cd examples/groovy/ && ../../gradlew dU && cd -
           cd examples/kotlin/ && ../../gradlew dU && cd -
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: deploy
 on:
   release:
     types: [ created ]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build](https://github.com/ben-manes/gradle-versions-plugin/workflows/build/badge.svg)](https://github.com/ben-manes/gradle-versions-plugin/actions)
-[![gradlePluginPortal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/ben-manes/versions/com.github.ben-manes.versions.gradle.plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/com.github.ben-manes.versions)
+[![gradlePluginPortal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/io/github/ben-manes/versions/io.github.ben-manes.versions.gradle.plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/io.github.ben-manes.versions)
 
 # Gradle Versions Plugin
 
@@ -35,14 +35,14 @@ You can add this plugin to your top-level build script using the following confi
 
 ```groovy
 plugins {
-  id "com.github.ben-manes.versions" version "$version"
+  id "io.github.ben-manes.versions" version "$version"
 }
 ```
 or via the
 
 ### `buildscript` block:
 ```groovy
-apply plugin: "com.github.ben-manes.versions"
+apply plugin: "io.github.ben-manes.versions"
 
 buildscript {
   repositories {
@@ -50,7 +50,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.github.ben-manes:gradle-versions-plugin:$version"
+    classpath "io.github.ben-manes:gradle-versions-plugin:$version"
   }
 }
 ```
@@ -69,7 +69,7 @@ initscript {
   }
 
   dependencies {
-    classpath 'com.github.ben-manes:gradle-versions-plugin:+'
+    classpath 'io.github.ben-manes:gradle-versions-plugin:+'
   }
 }
 
@@ -96,7 +96,7 @@ initscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("com.github.ben-manes:gradle-versions-plugin:+")
+    classpath("io.github.ben-manes:gradle-versions-plugin:+")
   }
 }
 
@@ -156,24 +156,24 @@ so configuring the root project's task covers every project unless a subproject 
 
 Under [isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html) a
 project plugin cannot register a task in another project, so a project only contributes to the
-aggregate report if it applies a plugin itself. Keep applying `com.github.ben-manes.versions` in
-the root project, and apply `com.github.ben-manes.versions.contributor` in every other project,
+aggregate report if it applies a plugin itself. Keep applying `io.github.ben-manes.versions` in
+the root project, and apply `io.github.ben-manes.versions.contributor` in every other project,
 typically from a convention plugin they already share:
 
 ```kotlin
 // buildSrc/src/main/kotlin/my-conventions.gradle.kts
 plugins {
-  id("com.github.ben-manes.versions.contributor")
+  id("io.github.ben-manes.versions.contributor")
 }
 ```
 
 The convention plugin's own build must have the plugin on its classpath, e.g. as an
-`implementation("com.github.ben-manes:gradle-versions-plugin:$version")` dependency in
+`implementation("io.github.ben-manes:gradle-versions-plugin:$version")` dependency in
 `buildSrc/build.gradle.kts`.
 
 The contributor plugin registers only the producer that feeds the aggregate report, so
 `dependencyUpdates` remains a single task in the root project. The main plugin is a superset of
-the contributor plugin: a project that applies `com.github.ben-manes.versions` instead still feeds
+the contributor plugin: a project that applies `io.github.ben-manes.versions` instead still feeds
 the aggregate report, and also gets its own `dependencyUpdates` task covering itself and its
 subprojects. So for a separate per-project report, apply the main plugin to that project—there is
 no need to apply both. Running `dependencyUpdates` by name then includes that project's report,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ checks for updates to Gradle itself.
 
 ## Usage
 
+The plugin was originally published under the `com.github.ben-manes.versions` id. That id is
+deprecated but keeps receiving releases, so existing builds continue to see updates; use
+`io.github.ben-manes.versions` in new builds.
+
 You can add this plugin to your top-level build script using the following configuration:
 
 ### `plugins` block:
@@ -170,6 +174,9 @@ plugins {
 The convention plugin's own build must have the plugin on its classpath, e.g. as an
 `implementation("io.github.ben-manes:gradle-versions-plugin:$version")` dependency in
 `buildSrc/build.gradle.kts`.
+
+Unlike the grandfathered main plugin, the contributor plugin has no `com.github.ben-manes` id: it
+is only available as `io.github.ben-manes.versions.contributor`.
 
 The contributor plugin registers only the producer that feeds the aggregate report, so
 `dependencyUpdates` remains a single task in the root project. The main plugin is a superset of

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ checks for updates to Gradle itself.
 
 The plugin was originally published under the `com.github.ben-manes.versions` id. That id is
 deprecated but keeps receiving releases, so existing builds continue to see updates; use
-`io.github.ben-manes.versions` in new builds.
+`io.github.ben-manes.versions` in new builds. If you apply the plugin through a `buildscript` or
+`initscript` `classpath` dependency rather than the `plugins` block, update the coordinate to
+`io.github.ben-manes:gradle-versions-plugin`—the old `com.github.ben-manes:gradle-versions-plugin`
+coordinate receives no further releases.
 
 You can add this plugin to your top-level build script using the following configuration:
 

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'com.github.ben-manes.versions'
+apply plugin: 'io.github.ben-manes.versions'
 apply plugin: 'jacoco'
 apply plugin: 'java'
 defaultTasks 'dependencyUpdates'
@@ -11,7 +11,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.github.ben-manes:gradle-versions-plugin:+'
+    classpath 'io.github.ben-manes:gradle-versions-plugin:+'
   }
 }
 

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -8,11 +8,11 @@ buildscript {
   }
 
   dependencies {
-    classpath("com.github.ben-manes:gradle-versions-plugin:+")
+    classpath("io.github.ben-manes:gradle-versions-plugin:+")
   }
 }
 
-apply(plugin = "com.github.ben-manes.versions")
+apply(plugin = "io.github.ben-manes.versions")
 
 repositories {
   mavenCentral()

--- a/gradle-versions-plugin/build.gradle.kts
+++ b/gradle-versions-plugin/build.gradle.kts
@@ -56,7 +56,7 @@ gradlePlugin {
     create("legacyVersionsPlugin") {
       id = properties["PLUGIN_LEGACY_NAME"].toString()
       implementationClass = properties["PLUGIN_LEGACY_NAME_CLASS"].toString()
-      displayName = properties["POM_NAME"].toString()
+      displayName = properties["POM_LEGACY_NAME"].toString()
       description = properties["POM_LEGACY_DESCRIPTION"].toString()
       tags.set(listOf("dependencies", "versions", "updates"))
     }

--- a/gradle-versions-plugin/build.gradle.kts
+++ b/gradle-versions-plugin/build.gradle.kts
@@ -53,6 +53,13 @@ gradlePlugin {
       description = properties["POM_DESCRIPTION"].toString()
       tags.set(listOf("dependencies", "versions", "updates"))
     }
+    create("legacyVersionsPlugin") {
+      id = properties["PLUGIN_LEGACY_NAME"].toString()
+      implementationClass = properties["PLUGIN_LEGACY_NAME_CLASS"].toString()
+      displayName = properties["POM_NAME"].toString()
+      description = properties["POM_LEGACY_DESCRIPTION"].toString()
+      tags.set(listOf("dependencies", "versions", "updates"))
+    }
     create("versionsContributorPlugin") {
       id = properties["PLUGIN_CONTRIBUTOR_NAME"].toString()
       implementationClass = properties["PLUGIN_CONTRIBUTOR_NAME_CLASS"].toString()

--- a/gradle-versions-plugin/gradle.properties
+++ b/gradle-versions-plugin/gradle.properties
@@ -1,5 +1,6 @@
 POM_ARTIFACT_ID=gradle-versions-plugin
 POM_NAME=Gradle Versions Plugin
 POM_DESCRIPTION=Gradle plugin that provides tasks for discovering dependency updates.
+POM_LEGACY_DESCRIPTION=DEPRECATED: use io.github.ben-manes.versions instead. Gradle plugin that provides tasks for discovering dependency updates.
 POM_CONTRIBUTOR_NAME=Gradle Versions Contributor Plugin
 POM_CONTRIBUTOR_DESCRIPTION=Gradle plugin that contributes a project's dependency updates to the aggregate report.

--- a/gradle-versions-plugin/gradle.properties
+++ b/gradle-versions-plugin/gradle.properties
@@ -1,6 +1,7 @@
 POM_ARTIFACT_ID=gradle-versions-plugin
 POM_NAME=Gradle Versions Plugin
 POM_DESCRIPTION=Gradle plugin that provides tasks for discovering dependency updates.
+POM_LEGACY_NAME=Gradle Versions Plugin (deprecated id)
 POM_LEGACY_DESCRIPTION=DEPRECATED: use io.github.ben-manes.versions instead. Gradle plugin that provides tasks for discovering dependency updates.
 POM_CONTRIBUTOR_NAME=Gradle Versions Contributor Plugin
 POM_CONTRIBUTOR_DESCRIPTION=Gradle plugin that contributes a project's dependency updates to the aggregate report.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/LegacyVersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/LegacyVersionsPlugin.kt
@@ -8,7 +8,8 @@ import org.gradle.api.Project
  *
  * The Gradle Plugin Portal no longer accepts new plugin ids under a `com.github` group, so the
  * plugin moved to `io.github.ben-manes.versions`. The old id keeps receiving releases so that
- * existing builds continue to see updates.
+ * existing builds continue to see updates. Applying it logs a deprecation warning and delegates
+ * to [VersionsPlugin].
  */
 class LegacyVersionsPlugin : Plugin<Project> {
   override fun apply(project: Project) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/LegacyVersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/LegacyVersionsPlugin.kt
@@ -1,0 +1,21 @@
+package com.github.benmanes.gradle.versions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * The [VersionsPlugin] under its deprecated `com.github.ben-manes.versions` id.
+ *
+ * The Gradle Plugin Portal no longer accepts new plugin ids under a `com.github` group, so the
+ * plugin moved to `io.github.ben-manes.versions`. The old id keeps receiving releases so that
+ * existing builds continue to see updates.
+ */
+class LegacyVersionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    requireMinimumGradleVersion("com.github.ben-manes.versions")
+    project.logger.warn(
+      "The com.github.ben-manes.versions plugin id is deprecated; apply io.github.ben-manes.versions instead.",
+    )
+    project.pluginManager.apply(VersionsPlugin::class.java)
+  }
+}

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
@@ -16,7 +16,7 @@ import org.gradle.api.Project
  */
 class VersionsContributorPlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    requireMinimumGradleVersion("com.github.ben-manes.versions.contributor")
+    requireMinimumGradleVersion("io.github.ben-manes.versions.contributor")
     registerProducer(project)
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
@@ -16,7 +16,7 @@ import javax.xml.parsers.SAXParserFactory
  */
 class VersionsPlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    requireMinimumGradleVersion("com.github.ben-manes.versions")
+    requireMinimumGradleVersion("io.github.ben-manes.versions")
 
     val tasks = project.tasks
     if (!tasks.names.contains("dependencyUpdates")) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -192,7 +192,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     if (missing.isNotEmpty()) {
       logger.warn(
         "The dependency updates report is missing ${missing.sorted().joinToString(", ")}. A project " +
-          "must apply the com.github.ben-manes.versions or com.github.ben-manes.versions.contributor " +
+          "must apply the io.github.ben-manes.versions or io.github.ben-manes.versions.contributor " +
           "plugin to be aggregated when isolated projects is enabled, and projects that share a " +
           "group and name are aggregated as one.",
       )

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
@@ -35,7 +35,7 @@ final class AggregationConfigurationCacheSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         allprojects {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSettingsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSettingsSpec.groovy
@@ -22,7 +22,7 @@ final class AggregationSettingsSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         allprojects {
@@ -95,7 +95,7 @@ final class AggregationSettingsSpec extends Specification {
     new File(testProjectDir.root, 'build.gradle') <<
       """
         subprojects {
-          apply plugin: 'com.github.ben-manes.versions'
+          apply plugin: 'io.github.ben-manes.versions'
         }
 
         tasks.dependencyUpdates {
@@ -133,7 +133,7 @@ final class AggregationSettingsSpec extends Specification {
     new File(testProjectDir.root, 'build.gradle') <<
       """
         subprojects {
-          apply plugin: 'com.github.ben-manes.versions'
+          apply plugin: 'io.github.ben-manes.versions'
         }
 
         tasks.dependencyUpdates {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -22,7 +22,7 @@ final class AggregationSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         allprojects {
@@ -181,7 +181,7 @@ final class AggregationSpec extends Specification {
     new File(testProjectDir.root, 'build.gradle').text =
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         allprojects {
@@ -255,7 +255,7 @@ final class AggregationSpec extends Specification {
     new File(testProjectDir.root, 'build.gradle') <<
       """
         subprojects {
-          apply plugin: 'com.github.ben-manes.versions'
+          apply plugin: 'io.github.ben-manes.versions'
         }
       """.stripIndent()
     new File(testProjectDir.root, 'app/build.gradle') <<

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ComponentSelectionRuleSourceSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ComponentSelectionRuleSourceSpec.groovy
@@ -45,7 +45,7 @@ final class ComponentSelectionRuleSourceSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: "com.github.ben-manes.versions"
+        apply plugin: "io.github.ben-manes.versions"
 
         repositories {
           maven {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConfigureOnDemandAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConfigureOnDemandAggregationSpec.groovy
@@ -20,7 +20,7 @@ final class ConfigureOnDemandAggregationSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
       """.stripIndent()
     testProjectDir.newFolder('app')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -23,7 +23,7 @@ final class ConstraintsSpec extends Specification {
       """
         plugins {
           id 'java-library'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         tasks.dependencyUpdates {
@@ -62,7 +62,7 @@ final class ConstraintsSpec extends Specification {
       """
         plugins {
           id 'java-library'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         tasks.dependencyUpdates {
@@ -103,7 +103,7 @@ final class ConstraintsSpec extends Specification {
       """
         plugins {
           id 'java-library'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         repositories {
@@ -139,7 +139,7 @@ final class ConstraintsSpec extends Specification {
       """
         plugins {
             java
-            id("com.github.ben-manes.versions")
+            id("io.github.ben-manes.versions")
         }
 
         tasks.withType<com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask> {
@@ -170,7 +170,7 @@ final class ConstraintsSpec extends Specification {
       """
         plugins {
             java
-            id("com.github.ben-manes.versions")
+            id("io.github.ben-manes.versions")
         }
         repositories {
             maven {
@@ -210,7 +210,7 @@ final class ConstraintsSpec extends Specification {
       """
         plugins {
             java
-            id("com.github.ben-manes.versions")
+            id("io.github.ben-manes.versions")
         }
         repositories {
             maven {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -23,7 +23,7 @@ final class ContributorAggregationSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
       """.stripIndent()
     testProjectDir.newFolder('app')
@@ -31,7 +31,7 @@ final class ContributorAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions.contributor'
+          id 'io.github.ben-manes.versions.contributor'
         }
 
         repositories {
@@ -49,7 +49,7 @@ final class ContributorAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions.contributor'
+          id 'io.github.ben-manes.versions.contributor'
         }
 
         repositories {
@@ -122,8 +122,8 @@ final class ContributorAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions'
-          id 'com.github.ben-manes.versions.contributor'
+          id 'io.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions.contributor'
         }
 
         repositories {
@@ -181,7 +181,7 @@ final class ContributorAggregationSpec extends Specification {
     new File(testProjectDir.root, 'build.gradle').text =
       """
         plugins {
-          id 'com.github.ben-manes.versions.contributor'
+          id 'io.github.ben-manes.versions.contributor'
         }
       """.stripIndent()
 
@@ -227,7 +227,7 @@ final class ContributorAggregationSpec extends Specification {
     new File(testProjectDir.root, 'build.gradle').text =
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
       """.stripIndent()
     ['a', 'b'].each { parent ->
@@ -237,7 +237,7 @@ final class ContributorAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions.contributor'
+          id 'io.github.ben-manes.versions.contributor'
         }
 
         group = 'com.example'
@@ -256,7 +256,7 @@ final class ContributorAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions.contributor'
+          id 'io.github.ben-manes.versions.contributor'
         }
 
         group = 'com.example'

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -43,7 +43,7 @@ final class DependencyUpdatesSpec extends Specification {
     given:
     def project = singleProject()
     project.layout.buildDirectory.set(project.layout.projectDirectory)
-    project.pluginManager.apply('com.github.ben-manes.versions')
+    project.pluginManager.apply('io.github.ben-manes.versions')
 
     expect:
     // An empty relative path would default the report to the filesystem root.

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -46,7 +46,7 @@ final class DifferentGradleVersionsSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: "com.github.ben-manes.versions"
+        apply plugin: "io.github.ben-manes.versions"
 
         repositories {
           maven {
@@ -106,7 +106,7 @@ final class DifferentGradleVersionsSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: "com.github.ben-manes.versions"
+        apply plugin: "io.github.ben-manes.versions"
 
         repositories {
           maven {
@@ -154,7 +154,7 @@ final class DifferentGradleVersionsSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: "com.github.ben-manes.versions"
+        apply plugin: "io.github.ben-manes.versions"
 
         repositories {
           maven {
@@ -264,7 +264,7 @@ final class DifferentGradleVersionsSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: "com.github.ben-manes.versions"
+        apply plugin: "io.github.ben-manes.versions"
 
         repositories {
           maven {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -22,7 +22,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
       """.stripIndent()
     testProjectDir.newFolder('app')
@@ -30,7 +30,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         repositories {
@@ -48,7 +48,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         repositories {
@@ -172,7 +172,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
       """
         plugins {
           id 'java'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
       """.stripIndent()
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
@@ -23,7 +23,7 @@ final class JavaLibrarySpec extends Specification {
       """
         plugins {
           id 'java-library'
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
         }
 
         repositories {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDependencyUpdatesSpec.groovy
@@ -32,7 +32,7 @@ final class KotlinDependencyUpdatesSpec extends Specification {
         }
 
         plugins {
-            id 'com.github.ben-manes.versions' version '0.51.0'
+            id 'io.github.ben-manes.versions' version '0.51.0'
             id 'java-gradle-plugin'
             ${applyJvmPlugin ? "id 'org.jetbrains.kotlin.jvm' version \"\$kotlin_version\"" : ''}
         }
@@ -76,7 +76,7 @@ final class KotlinDependencyUpdatesSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-            id 'com.github.ben-manes.versions' version '0.51.0'
+            id 'io.github.ben-manes.versions' version '0.51.0'
             id 'java-gradle-plugin'
         }
 
@@ -110,7 +110,7 @@ final class KotlinDependencyUpdatesSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-            id 'com.github.ben-manes.versions' version '0.51.0'
+            id 'io.github.ben-manes.versions' version '0.51.0'
             id 'org.jetbrains.kotlin.jvm' version '$DECLARED_KOTLIN_VERSION'
         }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -22,10 +22,10 @@ final class KotlinDslUsageSpec extends Specification {
 
         plugins {
           java
-          id("com.github.ben-manes.versions")
+          id("io.github.ben-manes.versions")
         }
 
-        apply(plugin = "com.github.ben-manes.versions")
+        apply(plugin = "io.github.ben-manes.versions")
 
         repositories {
           maven(url = "${mavenRepoUrl}")

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinMultiplatformAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinMultiplatformAggregationSpec.groovy
@@ -24,7 +24,7 @@ final class KotlinMultiplatformAggregationSpec extends Specification {
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
-          id 'com.github.ben-manes.versions'
+          id 'io.github.ben-manes.versions'
           id 'org.jetbrains.kotlin.multiplatform' version '${KOTLIN_VERSION}' apply false
         }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LazyDependencySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LazyDependencySpec.groovy
@@ -52,7 +52,7 @@ final class LazyDependencySpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -108,7 +108,7 @@ final class LazyDependencySpec extends Specification {
           }
         }
 
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LegacyPluginIdSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LegacyPluginIdSpec.groovy
@@ -1,0 +1,75 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+final class LegacyPluginIdSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String classpathString
+
+  def 'setup'() {
+    def pluginClasspathResource = getClass().classLoader.getResource("plugin-classpath.txt")
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        "Did not find plugin classpath resource, run `testClasses` build task.")
+    }
+
+    classpathString = pluginClasspathResource.readLines()
+      .collect { it.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { "'$it'" }
+      .join(", ")
+  }
+
+  def 'deprecated com.github id still works and warns'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'com.github.ben-manes.versions'
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .build()
+
+    then:
+    result.output.contains(
+      'The com.github.ben-manes.versions plugin id is deprecated; apply io.github.ben-manes.versions instead.')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'applying both the deprecated and the current id is harmless'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .build()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LegacyPluginIdSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LegacyPluginIdSpec.groovy
@@ -49,6 +49,30 @@ final class LegacyPluginIdSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  def 'current io.github id does not warn'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'io.github.ben-manes.versions'
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .build()
+
+    then:
+    !result.output.contains('is deprecated')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def 'applying both the deprecated and the current id is harmless'() {
     given:
     testProjectDir.newFile('build.gradle') <<

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
@@ -45,7 +45,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -86,7 +86,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -126,7 +126,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -168,7 +168,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -228,7 +228,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -355,7 +355,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -469,7 +469,7 @@ final class OutputFormatterSpec extends Specification {
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {
@@ -549,7 +549,7 @@ Failed to determine the latest version for the following dependencies (use --inf
         }
 
         apply plugin: 'java'
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
 
         repositories {
           maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,7 @@ POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin
 
 PLUGIN_NAME=io.github.ben-manes.versions
 PLUGIN_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsPlugin
+PLUGIN_LEGACY_NAME=com.github.ben-manes.versions
+PLUGIN_LEGACY_NAME_CLASS=com.github.benmanes.gradle.versions.LegacyVersionsPlugin
 PLUGIN_CONTRIBUTOR_NAME=io.github.ben-manes.versions.contributor
 PLUGIN_CONTRIBUTOR_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsContributorPlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
-GROUP=com.github.ben-manes
+GROUP=io.github.ben-manes
 VERSION_NAME=0.55.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin
 
-PLUGIN_NAME=com.github.ben-manes.versions
+PLUGIN_NAME=io.github.ben-manes.versions
 PLUGIN_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsPlugin
-PLUGIN_CONTRIBUTOR_NAME=com.github.ben-manes.versions.contributor
+PLUGIN_CONTRIBUTOR_NAME=io.github.ben-manes.versions.contributor
 PLUGIN_CONTRIBUTOR_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsContributorPlugin


### PR DESCRIPTION
Fixes #997.

Moves the group id and both plugin ids from `com.github.ben-manes` to `io.github.ben-manes`, since the portal rejects new plugin ids under `com.github`—which is what failed the 0.55.0 release (details in the issue).

Per the discussion in #997, the old `com.github.ben-manes.versions` id stays published: a third plugin declaration backed by a thin wrapper class that logs a deprecation warning and applies `VersionsPlugin`. Its marker keeps its grandfathered com.github coordinates and depends on the `io.github.ben-manes` artifact, so existing builds keep resolving new releases and the rename is non-breaking for them (the com.diffplug.gradle.spotless playbook). The contributor plugin is io.github-only, since its com.github id is the one the portal rejected and it has no published users.

Deliberately unchanged:

- The Kotlin package `com.github.benmanes.gradle.versions`: a Java package is independent of the Maven group id, and renaming it would be a large source break for no portal benefit.
- The dogfooded plugin id in `gradle/libs.versions.toml`: it can move to the new id once a release under it exists on the portal.
- The `com.github.ben-manes:unresolvable` entries in the examples, specs, and README samples, which are deliberately unresolvable placeholders.

One prerequisite outside the code: publish with a Plugin Portal account linked to the ben-manes GitHub account—that is how the portal verifies ownership of `io.github.*` ids. There is no pre-approval UI: the first version of each new id goes through the portal's manual review after publishing (the grandfathered id skips it), so the new ids may take a while to appear on the first release.
