### PR TITLE
Declare configuration cache compatibility on the Plugin Portal

### DIFF
--- a/gradle-versions-plugin/build.gradle.kts
+++ b/gradle-versions-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.plugin.compatibility.compatibility
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.dokka)
@@ -52,6 +54,11 @@ gradlePlugin {
       displayName = properties["POM_NAME"].toString()
       description = properties["POM_DESCRIPTION"].toString()
       tags.set(listOf("dependencies", "versions", "updates"))
+      compatibility {
+        features {
+          configurationCache = true
+        }
+      }
     }
     create("legacyVersionsPlugin") {
       id = properties["PLUGIN_LEGACY_NAME"].toString()
@@ -59,6 +66,11 @@ gradlePlugin {
       displayName = properties["POM_LEGACY_NAME"].toString()
       description = properties["POM_LEGACY_DESCRIPTION"].toString()
       tags.set(listOf("dependencies", "versions", "updates"))
+      compatibility {
+        features {
+          configurationCache = true
+        }
+      }
     }
     create("versionsContributorPlugin") {
       id = properties["PLUGIN_CONTRIBUTOR_NAME"].toString()
@@ -66,6 +78,11 @@ gradlePlugin {
       displayName = properties["POM_CONTRIBUTOR_NAME"].toString()
       description = properties["POM_CONTRIBUTOR_DESCRIPTION"].toString()
       tags.set(listOf("dependencies", "versions", "updates"))
+      compatibility {
+        features {
+          configurationCache = true
+        }
+      }
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.0.21"
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.2.0" }
-plugin-publish = { id = "com.gradle.plugin-publish", version = "1.3.1" }
+plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.1" }
 versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }
 
 [libraries]


### PR DESCRIPTION
Publishing 0.55.0 logged: "Consider declaring compatibility of your plugin with the following Gradle features: Configuration cache."

This bumps plugin-publish to 2.1.1 (the `compatibility` DSL needs 2.1.0+) and declares `configurationCache = true` on all three plugin ids, which lands in each plugin descriptor as `compatibility.feature.configuration-cache=DECLARED_SUPPORTED`. The portal reads that at publish time and shows a compatibility badge on the plugin page; it also warns that publishing without the declaration is deprecated.
