### PR TITLE
Fix: stop the query copies inheriting constraints and dependency locking

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -140,6 +140,10 @@ internal fun registerAggregation(
     task.projectDirectory.set(project.layout.projectDirectory)
     task.partialResults.from(
       results.map { configuration ->
+        // https://github.com/ben-manes/gradle-versions-plugin/issues/781
+        // A build that locks all of its configurations would lock this one too, which holds only
+        // the project dependencies that the plugin declares and has no lock state of its own.
+        configuration.resolutionStrategy.deactivateDependencyLocking()
         configuration.incoming
           .artifactView { view ->
             view.componentFilter { id -> id is ProjectComponentIdentifier }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -165,6 +165,10 @@ class Resolver(
     // They are queried separately above as added dependencies.
     copy.dependencyConstraints.clear()
 
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/781
+    // The copy inherits activated dependency locking but has no lock state of its own.
+    copy.resolutionStrategy.deactivateDependencyLocking()
+
     addRevisionFilter(copy, revision)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, current.coordinates)
@@ -305,6 +309,9 @@ class Resolver(
 
     val coordinates = hashMapOf<Coordinate.Key, Coordinate>()
     val copy = configuration.copyRecursive().setTransitive(transitive)
+
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/781
+    copy.resolutionStrategy.deactivateDependencyLocking()
 
     disableAutoTargetJvm(copy)
     val root = copy.incoming.resolutionResult.root

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -160,6 +160,11 @@ class Resolver(
     copy.dependencies.addAll(latest)
     copy.dependencies.addAll(inheritedKotlin)
 
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/802
+    // The copy inherits the original constraints, which would reject the dynamic query versions.
+    // They are queried separately above as added dependencies.
+    copy.dependencyConstraints.clear()
+
     addRevisionFilter(copy, revision)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, current.coordinates)

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -5,6 +5,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
 import spock.lang.Specification
 
 final class ConstraintsSpec extends Specification {
@@ -198,6 +199,47 @@ final class ConstraintsSpec extends Specification {
 
     then:
     result.output.contains('org.apache.logging.log4j:log4j-core [2.16.0 -> ')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/802')
+  def 'Show updates for a dependency held to a strict version by a constraint'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+          constraints {
+            api('com.google.inject:guice') {
+              version {
+                strictly '2.0'
+              }
+            }
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyLockingSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyLockingSpec.groovy
@@ -1,0 +1,56 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+final class DependencyLockingSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/781')
+  def 'Show updates for a build using strict dependency locking'() {
+    given:
+    def mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    def buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencyLocking {
+          lockMode = LockMode.STRICT
+        }
+
+        configurations.all {
+          resolutionStrategy.activateDependencyLocking()
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+}


### PR DESCRIPTION
Fixes #802. Fixes #781.

`createLatestConfiguration` and `getCurrentCoordinates` resolve a `copyRecursive()` of each
configuration, and the copy carries over both the original dependency constraints and activated
dependency locking. A `strictly` constraint clamps the `+` query back to the declared version, so
the module reports as already current; a locked build fails the task outright, since the copy has no
lock state of its own. The aggregate results configuration needed the same treatment, as a build
that locks all of its configurations locks that one too.
