### PR TITLE
Fix: only override an inherited target jvm version in the query copy

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -8,7 +8,6 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
 import org.gradle.api.internal.StartParameterInternal
-import org.gradle.api.plugins.JvmEcosystemPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -193,11 +192,6 @@ private fun registerProducer(
   project: Project,
   service: Provider<DependencyUpdatesParametersService>,
 ): TaskProvider<DependencyUpdatesPartialTask> {
-  // https://github.com/ben-manes/gradle-versions-plugin/issues/746
-  // The query copies request a target jvm version, which only this plugin's schema rules can
-  // interpret. Without it a project that applies no jvm plugin cannot resolve a jvm dependency.
-  project.pluginManager.apply(JvmEcosystemPlugin::class.java)
-
   val tasks = project.tasks
   if (tasks.names.contains(PARTIAL_TASK_NAME)) {
     return tasks.named(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -8,6 +8,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.plugins.JvmEcosystemPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -192,6 +193,11 @@ private fun registerProducer(
   project: Project,
   service: Provider<DependencyUpdatesParametersService>,
 ): TaskProvider<DependencyUpdatesPartialTask> {
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/746
+  // The query copies request a target jvm version, which only this plugin's schema rules can
+  // interpret. Without it a project that applies no jvm plugin cannot resolve a jvm dependency.
+  project.pluginManager.apply(JvmEcosystemPlugin::class.java)
+
   val tasks = project.tasks
   if (tasks.names.contains(PARTIAL_TASK_NAME)) {
     return tasks.named(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -234,9 +234,14 @@ class Resolver(
   }
 
   private fun disableAutoTargetJvm(configuration: Configuration) {
-    // Disable the auto target jvm for the configuration
+    // Disable the auto target jvm inherited from the copied configuration
     // https://github.com/ben-manes/gradle-versions-plugin/issues/727#issuecomment-1427132589
-    configuration.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.MAX_VALUE)
+    // Only override an inherited value: injecting the attribute where no jvm plugin registered its
+    // schema rules makes the request uninterpretable and fails variant selection.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/746
+    if (configuration.attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)) {
+      configuration.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.MAX_VALUE)
+    }
   }
 
   /** Adds the attributes from the source to the target. */

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/JvmEcosystemSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/JvmEcosystemSpec.groovy
@@ -1,0 +1,57 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+final class JvmEcosystemSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/746')
+  def 'Show updates for a jvm dependency in a project without a jvm plugin'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        def deps = configurations.dependencyScope('deps')
+        configurations.resolvable('depsClasspath') {
+          extendsFrom deps.get()
+        }
+
+        dependencies {
+          add('deps', 'com.example:jvm-library:1.0')
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/1.0/jvm-library-1.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/1.0/jvm-library-1.0.module
@@ -1,0 +1,33 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "jvm-library",
+    "version": "1.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      }
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      }
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/1.0/jvm-library-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/1.0/jvm-library-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>jvm-library</artifactId>
+  <version>1.0</version>
+  <name>Example JVM Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/2.0/jvm-library-2.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/2.0/jvm-library-2.0.module
@@ -1,0 +1,33 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "jvm-library",
+    "version": "2.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      }
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      }
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/2.0/jvm-library-2.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/2.0/jvm-library-2.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>jvm-library</artifactId>
+  <version>2.0</version>
+  <name>Example JVM Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/jvm-library/maven-metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>jvm-library</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Fixes #746.

The query copies unconditionally requested `org.gradle.jvm.version` to disable auto target jvm (#727), but Gradle registers the compatibility rule for that attribute only in `JvmEcosystemPlugin`. In a project that applies no jvm plugin the request is uninterpretable, so a jvm dependency fails variant selection and the report lists it under "Failed to determine the latest version". Overriding the attribute only where the copy inherited one keeps the behavior for jvm projects and stops injecting the request into projects that never asked for it. The regression test resolves a new fixture module published with Gradle metadata from a project with no jvm plugin applied.
