### PR TITLE
Test: run with warnings fatal where the copy deprecation is absent (fixes #749)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         java-version:
           - 8
           - 11
+          - 17
 
     permissions:
       checks: write

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -8,6 +8,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -33,6 +34,9 @@ final class DifferentGradleVersionsSpec extends Specification {
     mavenRepoUrl = getClass().getResource('/maven/').toURI()
   }
 
+  // On JVMs below 17, Gradle 8.11+ emits its own deprecation for running on that JVM, so the
+  // rows with warnings fatal only run on Java 17, and Gradle 9 requires it anyway.
+  @IgnoreIf({ data.warningMode == 'fail' && !jvm.java17Compatible })
   @Unroll
   def 'dependencyUpdates task completes without errors with Gradle #gradleVersion'() {
     given:
@@ -70,12 +74,15 @@ final class DifferentGradleVersionsSpec extends Specification {
         """.stripIndent()
 
     when:
-    // --warning-mode=fail is not used: resolving through copied configurations warns that they are
-    // deprecated for removal in 9.0.
+    // Gradle 8.3 through 8.10 warns that the copied query configurations are deprecated for
+    // dependency declaration, so those versions cannot run under --warning-mode=fail. The
+    // configuration role that emitted it was dropped in 8.11, and the copies are the only
+    // deprecation the plugin produces, so later versions run with warnings fatal.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/749
     def result = GradleRunner.create()
       .withGradleVersion(gradleVersion)
       .withProjectDir(testProjectDir.root)
-      .withArguments('dependencyUpdates', '-S')
+      .withArguments('dependencyUpdates', '-S', "--warning-mode=$warningMode")
       .build()
 
     then:
@@ -83,14 +90,15 @@ final class DifferentGradleVersionsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    gradleVersion << [
-      '8.4',
-      '8.5',
-      '8.6',
-      '8.7',
-      '8.8',
-      '8.9',
-    ]
+    gradleVersion | warningMode
+    '8.4'         | 'all'
+    '8.5'         | 'all'
+    '8.6'         | 'all'
+    '8.7'         | 'all'
+    '8.8'         | 'all'
+    '8.9'         | 'all'
+    '8.10'        | 'all'
+    '8.11.1'      | 'fail'
   }
 
   @Unroll

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -54,7 +54,7 @@ final class DifferentGradleVersionsSpec extends Specification {
 
         repositories {
           maven {
-            url '${mavenRepoUrl}'
+            url = '${mavenRepoUrl}'
           }
         }
 
@@ -99,6 +99,7 @@ final class DifferentGradleVersionsSpec extends Specification {
     '8.9'         | 'all'
     '8.10'        | 'all'
     '8.11.1'      | 'fail'
+    '9.6.1'       | 'fail'
   }
 
   @Unroll


### PR DESCRIPTION
Fixes #749.

The deprecation #749 was about is gone as of Gradle 8.11.

This PR turns `--warning-mode=fail` on in `DifferentGradleVersionsSpec` for 8.11 and up, keeps 8.4 through 8.10 exempt, and extends the version matrix to Gradle 9.6.1 with warnings fatal. The copies were the only deprecation the plugin emitted, so nothing else was in the way.

The warnings-fatal rows need Java 17: Gradle 8.11+ deprecates running on older JVMs, and that warning is itself fatal under `--warning-mode=fail`, so those rows skip on the 8 and 11 legs and a new Java 17 CI leg runs them. That leg also un-skips the existing `@Requires({ jvm.java17Compatible })` specs.

That leaves the question of whether to replace the copied query configurations anyway. The deprecation argument is gone, but there is a maintenance one: #802 (copy inherits constraints), #781 (copy inherits dependency locking), #592 (copy inherits `failOnDynamicVersions`) and #746 (copy inherits a target JVM attribute) are all the same shape, subtracting something the copy should not have inherited. Building the query configuration up from nothing instead would retire that class of bug. It is a bigger change though, and detached configurations do not carry the resolution strategy, so substitution rules would need handling. I'll try a spike to see how it looks, and file a separate PR if it works out.