### PR TITLE
Deactivate dependency locking before the task graph is computed (fixes #1004)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -134,16 +134,24 @@ internal fun registerAggregation(
   // warning would report what the user has no way to act on.
   val aggregatedPaths =
     project.allprojects.filter { it.buildFile.exists() }.map { it.path }.toSet()
+
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/781
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/1004
+  // A build that locks all of its configurations would lock this one too, which holds only the
+  // project dependencies that the plugin declares and has no lock state of its own. Deactivated
+  // after every project is evaluated, so that a locking hook registered from a build script's own
+  // afterEvaluate does not win, and before the task graph is computed, which a composite build
+  // does while the strategy is still mutable.
+  project.gradle.projectsEvaluated {
+    results.get().resolutionStrategy.deactivateDependencyLocking()
+  }
+
   accumulator.configure { task ->
     task.projectPath = project.path
     task.aggregatedProjectPaths = aggregatedPaths
     task.projectDirectory.set(project.layout.projectDirectory)
     task.partialResults.from(
       results.map { configuration ->
-        // https://github.com/ben-manes/gradle-versions-plugin/issues/781
-        // A build that locks all of its configurations would lock this one too, which holds only
-        // the project dependencies that the plugin declares and has no lock state of its own.
-        configuration.resolutionStrategy.deactivateDependencyLocking()
         configuration.incoming
           .artifactView { view ->
             view.componentFilter { id -> id is ProjectComponentIdentifier }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -1,0 +1,374 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1004')
+final class CompositeBuildSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String classpathString
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        'Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+    classpathString = pluginClasspathResource.readLines()
+      .collect { it.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { "'$it'" }
+      .join(', ')
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private def run(String... arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  private void includedBuild(String name, String buildScript = '') {
+    testProjectDir.newFolder(name)
+    testProjectDir.newFile("$name/settings.gradle") << "rootProject.name = '$name'"
+    testProjectDir.newFile("$name/build.gradle") << buildScript
+  }
+
+  def 'Reports the updates of a build that includes another build'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild('child')
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  def 'Aggregates the updates of every project in a build that includes another build'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        include 'app', 'lib'
+        includeBuild 'child'
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          apply plugin: 'java'
+
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+    includedBuild('child')
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+  }
+
+  def 'Reports the updates of a build that consumes the build it includes'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.example:child:1.0'
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild(
+      'child',
+      """
+        plugins {
+          id 'java-library'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  @Unroll
+  @Issue([
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/781',
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/1004',
+  ])
+  def 'Reports the updates of a composite build using strict locking activated by #activation'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencyLocking {
+          lockMode = LockMode.STRICT
+        }
+
+        ${script}
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild('child')
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+
+    where:
+    activation              | script
+    'a top-level hook'      | 'configurations.all { resolutionStrategy.activateDependencyLocking() }'
+    'an afterEvaluate hook' | 'afterEvaluate { configurations.all { resolutionStrategy.activateDependencyLocking() } }'
+  }
+
+  def 'Reports the updates of an included build from the including build'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') << ''
+    includedBuild(
+      'child',
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run(':child:dependencyUpdates')
+
+    then:
+    result.task(':child:dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+  }
+
+  def 'Reports the updates of both builds when each applies the plugin'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild(
+      'child',
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates', ':child:dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.task(':child:dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+  }
+
+  def 'Reuses the configuration cache across runs of a composite build'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild('child')
+
+    when:
+    run('dependencyUpdates', '--configuration-cache')
+    def result = run('dependencyUpdates', '--configuration-cache')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Configuration cache entry reused.')
+    // The report must survive the cache hit, not just the task outcome.
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  // Gradle 9 requires JVM 17.
+  @Requires({ jvm.java17Compatible })
+  @Unroll
+  def 'Reports the updates of a composite build on Gradle #gradleVersion'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild('child')
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion(gradleVersion)
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+
+    where:
+    gradleVersion << ['9.0.0', '9.6.1']
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyLockingSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyLockingSpec.groovy
@@ -7,12 +7,14 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Unroll
 
 final class DependencyLockingSpec extends Specification {
   @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
 
+  @Unroll
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/781')
-  def 'Show updates for a build using strict dependency locking'() {
+  def 'Show updates for a build using strict dependency locking activated by #activation'() {
     given:
     def mavenRepoUrl = getClass().getResource('/maven/').toURI()
     def buildFile = testProjectDir.newFile('build.gradle')
@@ -33,9 +35,7 @@ final class DependencyLockingSpec extends Specification {
           lockMode = LockMode.STRICT
         }
 
-        configurations.all {
-          resolutionStrategy.activateDependencyLocking()
-        }
+        ${script}
 
         dependencies {
           api 'com.google.inject:guice:2.0'
@@ -52,5 +52,11 @@ final class DependencyLockingSpec extends Specification {
     then:
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    activation               | script
+    'a top-level hook'       | 'configurations.all { resolutionStrategy.activateDependencyLocking() }'
+    'an afterEvaluate hook'  | 'afterEvaluate { configurations.all { resolutionStrategy.activateDependencyLocking() } }'
+    'lockAllConfigurations'  | 'dependencyLocking { lockAllConfigurations() }'
   }
 }


### PR DESCRIPTION
Fixes #1004.

`registerAggregation` deactivated dependency locking on `aggregateDependencyUpdatesResults` from inside the provider that supplies the task's partial results, which is late enough that a composite build has already resolved that configuration's dependencies and frozen its resolution strategy. The call moves to `gradle.projectsEvaluated`: after every locking hook a build script can register, including from its own `afterEvaluate`, and before any task graph is computed.

`CompositeBuildSpec` covers the reported shape plus a multi-project root, consuming the included build, strict locking in a composite, invoking the included build's task, configuration cache reuse, and Gradle 9. `DependencyLockingSpec` now activates locking three ways; every composite case fails on master, and the `afterEvaluate` variants are what rule out deactivating from the including project's `afterEvaluate` instead.
