### PR TITLE
fix: resolve the aggregate results from a detached configuration

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -20,7 +20,6 @@ import java.util.concurrent.ConcurrentHashMap
 internal const val PARTIAL_TASK_NAME = "partialDependencyUpdates"
 private const val ELEMENTS_CONFIGURATION = "dependencyUpdatesElements"
 private const val AGGREGATION_CONFIGURATION = "dependencyUpdatesAggregation"
-private const val RESULTS_CONFIGURATION = "aggregateDependencyUpdatesResults"
 private const val PARAMETERS_SERVICE = "dependencyUpdatesParameters"
 private const val VERIFICATION_TYPE = "dependency-updates"
 
@@ -113,11 +112,20 @@ internal fun registerAggregation(
     project.configurations.dependencyScope(AGGREGATION_CONFIGURATION) { configuration ->
       configuration.description = "Collects the projects to aggregate dependency updates from."
     }
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/781
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/1004
+  // Detached, so that a build which locks all of its configurations does not lock this one, which
+  // holds only the project dependencies that the plugin declares and has no lock state of its own.
+  // A container configuration cannot opt out: deactivating the locking at creation is undone by the
+  // build's own `configurations.all` hook, and deactivating it afterwards has no moment that is
+  // late enough to win yet early enough for every build, as configure on demand and composite
+  // builds resolve this configuration before `projectsEvaluated` fires.
   val results =
-    project.configurations.resolvable(RESULTS_CONFIGURATION) { configuration ->
-      configuration.description = "Resolves the dependency update results to aggregate."
-      configuration.extendsFrom(aggregation.get())
-      configuration.attributes { attributes ->
+    project.configurations.detachedConfiguration().apply {
+      // A detached configuration is created in the legacy role, and this one resolves the results
+      // of the projects it depends on, the root project included, so it must not match itself.
+      isCanBeConsumed = false
+      attributes { attributes ->
         attributes.attribute(
           Category.CATEGORY_ATTRIBUTE,
           project.objects.named(Category::class.java, Category.VERIFICATION),
@@ -128,6 +136,9 @@ internal fun registerAggregation(
         )
       }
     }
+  // Mirrored rather than extended, which a detached configuration forbids, so that a project
+  // declared in the build's own dependencies block is still aggregated.
+  aggregation.get().dependencies.all { dependency -> results.dependencies.add(dependency) }
 
   // Reading the paths across projects is permitted under isolated projects, unlike configuring. A
   // project with no build script cannot apply the plugin there, so naming it in the completeness
@@ -135,29 +146,16 @@ internal fun registerAggregation(
   val aggregatedPaths =
     project.allprojects.filter { it.buildFile.exists() }.map { it.path }.toSet()
 
-  // https://github.com/ben-manes/gradle-versions-plugin/issues/781
-  // https://github.com/ben-manes/gradle-versions-plugin/issues/1004
-  // A build that locks all of its configurations would lock this one too, which holds only the
-  // project dependencies that the plugin declares and has no lock state of its own. Deactivated
-  // after every project is evaluated, so that a locking hook registered from a build script's own
-  // afterEvaluate does not win, and before the task graph is computed, which a composite build
-  // does while the strategy is still mutable.
-  project.gradle.projectsEvaluated {
-    results.get().resolutionStrategy.deactivateDependencyLocking()
-  }
-
   accumulator.configure { task ->
     task.projectPath = project.path
     task.aggregatedProjectPaths = aggregatedPaths
     task.projectDirectory.set(project.layout.projectDirectory)
     task.partialResults.from(
-      results.map { configuration ->
-        configuration.incoming
-          .artifactView { view ->
-            view.componentFilter { id -> id is ProjectComponentIdentifier }
-            view.lenient(true)
-          }.files
-      },
+      results.incoming
+        .artifactView { view ->
+          view.componentFilter { id -> id is ProjectComponentIdentifier }
+          view.lenient(true)
+        }.files,
     )
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -299,9 +299,25 @@ final class AggregationSpec extends Specification {
     given:
     new File(testProjectDir.root, 'build.gradle') <<
       """
+        // Declares the attribute pair the plugin's results configuration requests (Aggregation.kt),
+        // which is detached and so has no name to resolve it by here.
+        def probe = configurations.dependencyScope('probeAggregation')
+        def results = configurations.resolvable('probeAggregationResults') {
+          extendsFrom probe.get()
+          attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.VERIFICATION))
+            attribute(
+              VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
+              objects.named(VerificationType, 'dependency-updates'))
+          }
+        }
+        dependencies {
+          probeAggregation project(':app')
+          probeAggregation project(':lib')
+        }
+
         tasks.register('dumpAggregationGraph') {
-          def resolutionResult =
-            configurations.aggregateDependencyUpdatesResults.incoming.resolutionResult
+          def resolutionResult = results.get().incoming.resolutionResult
           doLast {
             resolutionResult.allDependencies.each {
               println "GRAPHEDGE \${it.class.simpleName} \${it.requested}"
@@ -315,6 +331,10 @@ final class AggregationSpec extends Specification {
 
     then:
     result.task(':dumpAggregationGraph').outcome == SUCCESS
+    // Both projects are edges of the graph, so that the absence of a traversal below them is the
+    // property under test rather than an empty graph.
+    result.output.contains('GRAPHEDGE DefaultResolvedDependencyResult project :app')
+    result.output.contains('GRAPHEDGE DefaultResolvedDependencyResult project :lib')
     !result.output.contains('UnresolvedDependencyResult')
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -208,6 +208,65 @@ final class CompositeBuildSpec extends Specification {
     'an afterEvaluate hook' | 'afterEvaluate { configurations.all { resolutionStrategy.activateDependencyLocking() } }'
   }
 
+  // The composite computes its task graph under configure on demand before projectsEvaluated
+  // fires, so no lifecycle callback can mutate the results strategy in time.
+  private void compositeUsingConfigureOnDemand() {
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    includedBuild('child')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1006')
+  def 'Reports the updates of a composite build with configure on demand'() {
+    given:
+    compositeUsingConfigureOnDemand()
+
+    when:
+    def result = run(':dependencyUpdates', '--configure-on-demand')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  // Gradle 9 requires JVM 17. The guard that rejects the mutation is worded differently there,
+  // and only this combination matches a build that sets all three properties in gradle.properties.
+  @Requires({ jvm.java17Compatible })
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1006')
+  def 'Reports the updates of a composite build with configure on demand in parallel'() {
+    given:
+    compositeUsingConfigureOnDemand()
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion('9.6.1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments(':dependencyUpdates', '--configure-on-demand', '--parallel',
+        '--configuration-cache')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
   def 'Reports the updates of an included build from the including build'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"


### PR DESCRIPTION
Fixes #1006.

The results configuration is created detached, so a build that locks all of its configurations never reaches it and nothing has to be deactivated afterwards. #781 and #1005 both deactivated the locking from a lifecycle callback, and no callback is both late enough to outlast the build's own locking hooks and early enough for every build: a composite build under configure on demand computes its task graph before `projectsEvaluated` fires. Deactivating at creation instead loses to the build's `configurations.all` hook.

`aggregateDependencyUpdatesResults` is no longer addressable by name, which is the one behavior change. `dependencyUpdatesAggregation` still works; its dependencies are mirrored into the detached configuration, since a detached configuration cannot extend another.
