### PR TITLE
feat: report the plugin versions declared in the settings script

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,9 @@ plugins {
 </details>
 
 The root project receives the `dependencyUpdates` task and every other project contributes to its
-report, so no project applies a plugin itself and a root build script is not required. Because
-the settings plugin puts the plugin on every project's classpath, a
+report, so no project applies a plugin itself and a root build script is not required. It also
+reports the versions of the plugins that the settings script declares, which no project's
+buildscript carries. Because the settings plugin puts the plugin on every project's classpath, a
 project that applies `io.github.ben-manes.versions` as well must request it without a version.
 
 The report is aggregated from a task in each project, so it is compatible with parallel execution

--- a/README.md
+++ b/README.md
@@ -198,8 +198,37 @@ field explaining failures or missing information. The update check may be disabl
 #### Multi-project build
 
 In a multi-project build, running this task in the root project will generate a consolidated/merged
-report for dependency updates in all subprojects. Alternatively, you can run the task separately in
-each subproject to generate separate reports for each subproject.
+report for dependency updates in all subprojects. The recommended setup is to apply the settings
+plugin once in the settings script, which covers every project of the build:
+
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+// settings.gradle.kts
+plugins {
+  id("io.github.ben-manes.versions.settings")
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+// settings.gradle
+plugins {
+  id 'io.github.ben-manes.versions.settings'
+}
+```
+
+</details>
+
+The root project receives the `dependencyUpdates` task and every other project contributes to its
+report, so no project applies a plugin itself and a root build script is not required. Because
+the settings plugin puts the plugin on every project's classpath, a
+project that applies `io.github.ben-manes.versions` as well must request it without a version.
 
 The report is aggregated from a task in each project, so it is compatible with parallel execution
 and the configuration cache. Each project takes the settings that control resolution (`revision`,
@@ -207,11 +236,26 @@ and the configuration cache. Each project takes the settings that control resolu
 `checkBuildEnvironmentConstraints`) from the nearest project up the hierarchy whose task set them,
 so configuring the root project's task covers every project unless a subproject configures its own.
 
+Two limitations. An **included build** is a separate build with its own settings, so its projects
+are not covered—apply the settings plugin in its `settings.gradle` too. This is not new to the
+settings plugin, and `buildSrc` is likewise excluded. And a **root project that registers its own
+task named `dependencyUpdates`** conflicts with the task the plugin registers, because the settings
+plugin is applied before the root build script and the task name is then taken; rename that task.
+
+Alternatively, apply `io.github.ben-manes.versions` to a project to give it a `dependencyUpdates`
+task of its own, reporting on itself and its subprojects—alongside the settings plugin for a
+separate per-project report, or in every project as the traditional setup that predates it. Run a
+single task by its path to get just that report (e.g., `:subproject:dependencyUpdates`).
+
 #### Isolated projects
 
 Under [isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html) a
 project plugin cannot register a task in another project, so a project only contributes to the
-aggregate report if it applies a plugin itself. Keep applying `io.github.ben-manes.versions` in
+aggregate report if it applies a plugin itself. The settings plugin covers this: it applies a
+plugin to each project as the project is evaluated, so the recommended setup above works
+unchanged.
+
+A build that cannot apply the settings plugin can keep applying `io.github.ben-manes.versions` in
 the root project, and apply `io.github.ben-manes.versions.contributor` in every other project,
 typically from a convention plugin they already share:
 
@@ -250,10 +294,7 @@ The contributor plugin registers only the producer that feeds the aggregate repo
 `dependencyUpdates` remains a single task in the root project. The main plugin is a superset of
 the contributor plugin: a project that applies `io.github.ben-manes.versions` instead still feeds
 the aggregate report, and also gets its own `dependencyUpdates` task covering itself and its
-subprojects. So for a separate per-project report, apply the main plugin to that project—there is
-no need to apply both. Running `dependencyUpdates` by name then includes that project's report,
-as it always has when the plugin is applied to more than one project; run a single task by its
-path to get just that report (e.g., `:subproject:dependencyUpdates`).
+subprojects.
 
 Under isolated projects, contributing projects that share a group and name are aggregated as one;
 the console warns about any project the report is missing.

--- a/README.md
+++ b/README.md
@@ -3,50 +3,64 @@
 
 # Gradle Versions Plugin
 
-In the spirit of the [Maven Versions Plugin](https://www.mojohaus.org/versions-maven-plugin),
-this plugin provides a task to determine which dependencies have updates. Additionally, the plugin
-checks for updates to Gradle itself.
+This plugin reports which of your build's dependencies, plugins, and Gradle
+itself have newer versions available, in the spirit of the [Maven Versions
+Plugin](https://www.mojohaus.org/versions-maven-plugin).
 
 **Table of contents**
 <!-- TOC -->
-- [Usage](#usage)
-  - [plugins block](#plugins-block)
-  - [buildscript block](#buildscript-block)
-  - [Using a Gradle init script](#using-a-gradle-init-script)
-  - [Related plugins](#related-plugins)
-- [dependencyUpdates](#dependencyupdates)
-  - [Multi-project build](#multi-project-build)
+- [Getting Started](#getting-started)
+  - [Applying the plugin](#applying-the-plugin)
+  - [Running the task](#running-the-task)
+  - [Configuring the task](#configuring-the-task)
+- [The `dependencyUpdates` task](#the-dependencyupdates-task)
+  - [Cache invalidation](#cache-invalidation)
+  - [Task properties](#task-properties)
+    - [Revisions](#revisions)
+    - [RejectVersionsIf and componentSelection](#rejectversionsif-and-componentselection)
+    - [Constraints](#constraints)
+    - [Configuration filter](#configuration-filter)
+    - [Optional parameters](#optional-parameters)
+    - [Gradle release channel](#gradle-release-channel)
+    - [Gradle versions API base URL](#gradle-versions-api-base-url)
+    - [Report format](#report-format)
+  - [Multi-project builds](#multi-project-builds)
+    - [Shared task settings](#shared-task-settings)
+    - [Composite builds](#composite-builds)
+    - [Per-project reports](#per-project-reports)
   - [Isolated projects](#isolated-projects)
-  - [Revisions](#revisions)
-  - [RejectVersionsIf and componentSelection](#rejectversionsif-and-componentselection)
-  - [Gradle Release Channel](#gradle-release-channel)
-  - [Gradle Versions Api Base URL](#gradle-versions-api-base-url)
-  - [Constraints](#constraints)
-  - [Optional parameters](#optional-parameters)
-  - [Configuration filter](#configuration-filter)
-  - [Try out the samples](#try-out-the-samples)
-  - [Report format](#report-format)
+- [Other ways to apply the plugin](#other-ways-to-apply-the-plugin)
+  - [The `plugins` block](#the-plugins-block)
+  - [Legacy plugin application](#legacy-plugin-application)
+  - [Contributor plugin](#contributor-plugin)
+  - [Initialization script](#initialization-script)
+- [Samples](#samples)
+- [Compatibility](#compatibility)
+- [Migrating from prior versions](#migrating-from-prior-versions)
+  - [v0.55.0](#v0550)
+  - [v0.54.0 and earlier](#v0540-and-earlier)
+- [Related plugins](#related-plugins)
 <!-- /TOC -->
 
-## Usage
+## Getting Started
 
-The plugin was originally published under the `com.github.ben-manes.versions` id. That id is
-deprecated but keeps receiving releases, so existing builds continue to see updates; use
-`io.github.ben-manes.versions` in new builds. If you apply the plugin through a `buildscript` or
-`initscript` `classpath` dependency rather than the `plugins` block, update the coordinate to
-`io.github.ben-manes:gradle-versions-plugin`—the old `com.github.ben-manes:gradle-versions-plugin`
-coordinate receives no further releases.
+### Applying the plugin
 
-You can add this plugin to your top-level build script using the following configuration:
-
-### `plugins` block:
+The recommended way to add the Gradle Versions Plugin to any build is to apply
+the settings plugin once in the settings script. This approach allows the plugin
+to report updates for the plugins and buildscript dependencies that the settings
+script declares, in addition to each project's own plugins, buildscript
+dependencies, and dependencies. It also automatically covers every
+subproject in a multi-project build (see [Multi-project
+builds](#multi-project-builds)).
 
 <details open>
 <summary>Kotlin</summary>
 
+"settings.gradle.kts":
 ```kotlin
 plugins {
-  id("io.github.ben-manes.versions") version "$version"
+  id("io.github.ben-manes.versions.settings") version "$version"
 }
 ```
 
@@ -55,86 +69,61 @@ plugins {
 <details>
 <summary>Groovy</summary>
 
+"settings.gradle":
 ```groovy
 plugins {
-  id "io.github.ben-manes.versions" version "$version"
+  id 'io.github.ben-manes.versions.settings' version '$version'
 }
 ```
 
 </details>
 
-or via the
+> [!IMPORTANT]
+> Replace `$version` with the current release, shown in the badge at the top of
+> this page.
 
-### `buildscript` block:
+### Running the task
+
+After adding the settings plugin to your build, run the `dependencyUpdates` task
+to get the report of up-to-date and outdated dependencies (see [The
+dependencyUpdates task](#the-dependencyupdates-task)):
+
+```text
+./gradlew dependencyUpdates
+```
+
+The report prints to the console and is written to
+`build/dependencyUpdates/report.txt`:
+
+```text
+------------------------------------------------------------
+: Project Dependency Updates (report to plain text file)
+------------------------------------------------------------
+
+The following dependencies have later milestone versions:
+ - com.google.inject:guice [2.0 -> 7.0.0]
+     https://github.com/google/guice
+ - org.springframework.boot:spring-boot-dependencies [1.5.8.RELEASE -> 4.1.0]
+     https://spring.io/projects/spring-boot
+
+Gradle release-candidate updates:
+ - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-1]
+```
+
+### Configuring the task
+
+The task is configured in the root project's build script:
 
 <details open>
 <summary>Kotlin</summary>
 
+"build.gradle.kts":
 ```kotlin
-buildscript {
-  repositories {
-    gradlePluginPortal()
-  }
-
-  dependencies {
-    classpath("io.github.ben-manes:gradle-versions-plugin:$version")
-  }
-}
-
-apply(plugin = "io.github.ben-manes.versions")
-```
-
-</details>
-
-<details>
-<summary>Groovy</summary>
-
-```groovy
-buildscript {
-  repositories {
-    gradlePluginPortal()
-  }
-
-  dependencies {
-    classpath "io.github.ben-manes:gradle-versions-plugin:$version"
-  }
-}
-
-apply plugin: "io.github.ben-manes.versions"
-```
-
-</details>
-
-Prefer the `plugins` block: it is the modern replacement for `buildscript`-based plugin
-application.
-
-### Using a Gradle init script ###
-You can also transparently add the plugin to every Gradle project that you run via a [Gradle init script](https://docs.gradle.org/current/userguide/init_scripts.html):
-
-<details open>
-<summary>Kotlin</summary>
-
-`$HOME/.gradle/init.d/add-versions-plugin.init.gradle.kts`
-```kotlin
-import com.github.benmanes.gradle.versions.VersionsPlugin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-initscript {
-  repositories {
-    gradlePluginPortal()
-  }
-
-  dependencies {
-    classpath("io.github.ben-manes:gradle-versions-plugin:+")
-  }
-}
-
-allprojects {
-  apply<VersionsPlugin>()
-
-  tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-    // configure the task, for example wrt. resolution strategies
-  }
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  revision = "release"
+  outputFormatter = "json"
 }
 ```
 
@@ -143,71 +132,31 @@ allprojects {
 <details>
 <summary>Groovy</summary>
 
-`$HOME/.gradle/init.d/add-versions-plugin.gradle`
+"build.gradle":
 ```groovy
-initscript {
-  repositories {
-    gradlePluginPortal()
-  }
-
-  dependencies {
-    classpath 'io.github.ben-manes:gradle-versions-plugin:+'
-  }
-}
-
-allprojects {
-  apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
-
-  tasks.named("dependencyUpdates").configure {
-    // configure the task, for example wrt. resolution strategies
-  }
+tasks.named("dependencyUpdates").configure {
+  revision = 'release'
+  outputFormatter = 'json'
 }
 ```
 
 </details>
 
-### Related Plugins ###
-You may also wish to explore additional functionality provided by,
- - [version-catalog-update-plugin](https://github.com/littlerobots/version-catalog-update-plugin)
- - [gradle-versions-filter-plugin](https://github.com/janderssonse/gradle-versions-filter-plugin)
- - [gradle-upgrade-interactive](https://github.com/kevcodez/gradle-upgrade-interactive)
- - [gradle-use-latest-versions](https://github.com/patrikerdes/gradle-use-latest-versions-plugin)
- - [gradle-update-checker](https://github.com/marketplace/actions/gradle-update-checker)
- - [gradle-libraries-plugin](https://github.com/fkorotkov/gradle-libraries-plugin)
- - [gradle-update-notifier](https://github.com/y-yagi/gradle-update-notifier)
- - [refreshVersions](https://github.com/jmfayard/refreshVersions)
- - [update-versions-gradle-plugin](https://github.com/tomasbjerre/update-versions-gradle-plugin)
- - [caupain](https://github.com/deezer/caupain/)
-
-## Tasks
-
-### `dependencyUpdates`
-
-Displays a report of the project dependencies that are up-to-date, exceed the latest version found,
-have upgrades, or failed to be resolved. When a dependency cannot be resolved the exception is
-logged at the `info` level.
-
-To refresh the cache (i.e. fetch the new releases/versions of the dependencies), use flag `--refresh-dependencies`.
-
-Gradle updates are checked for on the `current`, `release-candidate` and `nightly` release channels. The plaintext
-report displays gradle updates as a separate category in breadcrumb style (excluding nightly builds). The xml and json
-reports include information about all three release channels, whether a release is considered an update with respect to
-the running (executing) gradle instance, whether an update check on a release channel has failed, as well as a reason
-field explaining failures or missing information. The update check may be disabled using the `checkForGradleUpdate` flag.
-
-#### Multi-project build
-
-In a multi-project build, running this task in the root project will generate a consolidated/merged
-report for dependency updates in all subprojects. The recommended setup is to apply the settings
-plugin once in the settings script, which covers every project of the build:
+A build with no root build script can configure the task from the settings
+script instead:
 
 <details open>
 <summary>Kotlin</summary>
 
+"settings.gradle.kts":
 ```kotlin
-// settings.gradle.kts
-plugins {
-  id("io.github.ben-manes.versions.settings")
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+gradle.rootProject {
+  tasks.withType(DependencyUpdatesTask::class.java).configureEach {
+    revision = "release"
+    outputFormatter = "json"
+  }
 }
 ```
 
@@ -216,110 +165,92 @@ plugins {
 <details>
 <summary>Groovy</summary>
 
+"settings.gradle":
 ```groovy
-// settings.gradle
-plugins {
-  id 'io.github.ben-manes.versions.settings'
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+gradle.rootProject {
+  tasks.withType(DependencyUpdatesTask).configureEach {
+    revision = 'release'
+    outputFormatter = 'json'
+  }
 }
 ```
 
 </details>
 
-The root project receives the `dependencyUpdates` task and every other project contributes to its
-report, so no project applies a plugin itself and a root build script is not required. It also
-reports the versions of the plugins that the settings script declares, which no project's
-buildscript carries. Because the settings plugin puts the plugin on every project's classpath, a
-project that applies `io.github.ben-manes.versions` as well must request it without a version.
+Every task property is covered in [Task properties](#task-properties). Most
+builds want a stability filter next, so that a pre-release version is not
+offered as an update (see [RejectVersionsIf and
+componentSelection](#rejectversionsif-and-componentselection)).
 
-The report is aggregated from a task in each project, so it is compatible with parallel execution
-and the configuration cache. Each project takes the settings that control resolution (`revision`,
-`rejectVersionIf` or a full `resolutionStrategy`, `filterConfigurations`, `checkConstraints`, and
-`checkBuildEnvironmentConstraints`) from the nearest project up the hierarchy whose task set them,
-so configuring the root project's task covers every project unless a subproject configures its own.
+## The `dependencyUpdates` task
 
-Two limitations. An **included build** is a separate build with its own settings, so its projects
-are not covered—apply the settings plugin in its `settings.gradle` too. This is not new to the
-settings plugin, and `buildSrc` is likewise excluded. And a **root project that registers its own
-task named `dependencyUpdates`** conflicts with the task the plugin registers, because the settings
-plugin is applied before the root build script and the task name is then taken; rename that task.
+Displays a report of the project dependencies that are up-to-date, exceed the
+latest version found, have upgrades, or failed to be resolved. When a dependency
+cannot be resolved the exception is logged at the `info` level.
 
-Alternatively, apply `io.github.ben-manes.versions` to a project to give it a `dependencyUpdates`
-task of its own, reporting on itself and its subprojects—alongside the settings plugin for a
-separate per-project report, or in every project as the traditional setup that predates it. Run a
-single task by its path to get just that report (e.g., `:subproject:dependencyUpdates`).
+The report includes dependencies declared through a version catalog, but the
+plugin only reports—it never edits build files or the catalog. See [Related
+plugins](#related-plugins) for tools that apply updates automatically.
 
-#### Isolated projects
+Gradle updates are checked for on the `current`, `release-candidate` and
+`nightly` release channels. The plain-text report displays Gradle updates as a
+separate category in breadcrumb style, excluding nightly builds. The XML and
+JSON reports cover all three release channels: whether a release is an update
+with respect to the Gradle instance running the build, whether an update check
+failed, and a reason field explaining failures or missing information. The
+update check may be disabled using the `checkForGradleUpdate` flag.
 
-Under [isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html) a
-project plugin cannot register a task in another project, so a project only contributes to the
-aggregate report if it applies a plugin itself. The settings plugin covers this: it applies a
-plugin to each project as the project is evaluated, so the recommended setup above works
-unchanged.
+### Cache invalidation
 
-A build that cannot apply the settings plugin can keep applying `io.github.ben-manes.versions` in
-the root project, and apply `io.github.ben-manes.versions.contributor` in every other project,
-typically from a convention plugin they already share:
+To find the latest version of a dependency, the task asks each repository which
+versions exist. Gradle caches that answer for 24 hours, so a version published
+within the last day may be missing from the report even though the repository
+already has it. Re-run with `--refresh-dependencies` to bypass the cache and
+query the repositories again:
 
-<details open>
-<summary>Kotlin</summary>
-
-```kotlin
-// buildSrc/src/main/kotlin/my-conventions.gradle.kts
-plugins {
-  id("io.github.ben-manes.versions.contributor")
-}
+```bash
+./gradlew dependencyUpdates --refresh-dependencies
 ```
 
-</details>
+> [!TIP]
+> The `--refresh-dependencies` flag applies to the whole build rather than to
+> this task alone, so it also re-checks every other dependency the build
+> resolves and is slower than a normal run. Use it when a release you are
+> expecting does not appear, not routinely.
 
-<details>
-<summary>Groovy</summary>
-
-```groovy
-// buildSrc/src/main/groovy/my-conventions.gradle
-plugins {
-  id 'io.github.ben-manes.versions.contributor'
-}
-```
-
-</details>
-
-The convention plugin's own build must have the plugin on its classpath, e.g. as an
-`implementation("io.github.ben-manes:gradle-versions-plugin:$version")` dependency in
-`buildSrc/build.gradle.kts`.
-
-Unlike the grandfathered main plugin, the contributor plugin has no `com.github.ben-manes` id: it
-is only available as `io.github.ben-manes.versions.contributor`.
-
-The contributor plugin registers only the producer that feeds the aggregate report, so
-`dependencyUpdates` remains a single task in the root project. The main plugin is a superset of
-the contributor plugin: a project that applies `io.github.ben-manes.versions` instead still feeds
-the aggregate report, and also gets its own `dependencyUpdates` task covering itself and its
-subprojects.
-
-Under isolated projects, contributing projects that share a group and name are aggregated as one;
-the console warns about any project the report is missing.
+### Task properties
 
 #### Revisions
 
-The `revision` task property controls the [Ivy resolution strategy][ivy_resolution_strategy] for determining what constitutes
-the latest version of a dependency. Maven's dependency metadata does not distinguish between milestone and release versions.
+The `revision` task property controls the [Ivy resolution
+strategy](https://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html#Latest%20%28Status%29%20Matcher)
+for determining what constitutes the latest version of a dependency. Maven's
+dependency metadata does not distinguish between milestone and release versions.
 The following strategies are natively supported by Gradle:
 
-  * release: selects the latest release
-  * milestone: select the latest version being either a milestone or a release (default)
-  * integration: selects the latest revision of the dependency module (such as SNAPSHOT)
+* release: selects the latest release
+* milestone: select the latest version being either a milestone or a release (default)
+* integration: selects the latest revision of the dependency module (such as SNAPSHOT)
 
-The strategy can be specified either on the task or as a system property for ad hoc usage:
+The strategy can be specified either on the task or as a system property for ad
+hoc usage:
 
 ```bash
-gradle dependencyUpdates -Drevision=release
+./gradlew dependencyUpdates -Drevision=release
 ```
+
+Because Maven repositories do not mark pre-release versions, an alpha or release
+candidate can still appear as the latest version under any revision. To only be
+offered stable updates, reject pre-release candidates (see
+[RejectVersionsIf and componentSelection](#rejectversionsif-and-componentselection)).
 
 #### RejectVersionsIf and componentSelection
 
-To further define which version to accept, you need to define what means an unstable version. Sadly, there are
-no agreed standard on this, but this is a good starting point:
+To further control which versions are accepted, define what counts as an
+unstable version. There is no agreed standard, but this is a good starting
+point:
 
 <details open>
 <summary>Kotlin</summary>
@@ -348,23 +279,23 @@ def isNonStable = { String version ->
 
 </details>
 
-You can then configure [Component Selection Rules][component_selection_rules].
-The current version of a component can be retrieved with the `currentVersion` property.
-You can either use the simplified syntax `rejectVersionIf { ... }` or configure a complete resolution strategy.
-Multiple registrations compose, so a candidate is rejected if any registered filter rejects it.
-
+You can then configure [Component Selection
+Rules](https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:component_selection_rules).
+The current version of a component can be retrieved with the `currentVersion`
+property. You can either use the simplified syntax `rejectVersionIf { ... }` or
+configure a complete resolution strategy. Multiple registrations compose, so a
+candidate is rejected if any registered filter rejects it.
 
 <details open>
 <summary>Kotlin</summary>
 
 <!--  Always modify first examples/kotlin and make sure that it works. THEN modify the README -->
 
-Example 1: reject all non stable versions
+Example 1: reject all non-stable versions
 
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-// https://github.com/ben-manes/gradle-versions-plugin
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
   rejectVersionIf {
     candidate.version.isNonStable()
@@ -372,12 +303,12 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 }
 ```
 
-Example 2: disallow release candidates as upgradable versions from stable versions
+Example 2: disallow release candidates as upgradable versions from stable
+versions
 
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-// https://github.com/ben-manes/gradle-versions-plugin
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
   rejectVersionIf {
     candidate.version.isNonStable() && !currentVersion.isNonStable()
@@ -390,7 +321,6 @@ Example 3: using the full syntax
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-// https://github.com/ben-manes/gradle-versions-plugin
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
   resolutionStrategy {
     componentSelection {
@@ -411,10 +341,9 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 
 <!--  Always modify first examples/groovy and make sure that it works. THEN modify the README -->
 
-Example 1: reject all non stable versions
+Example 1: reject all non-stable versions
 
 ```groovy
-// https://github.com/ben-manes/gradle-versions-plugin
 tasks.named("dependencyUpdates").configure {
   rejectVersionIf {
     isNonStable(candidate.version)
@@ -422,10 +351,10 @@ tasks.named("dependencyUpdates").configure {
 }
 ```
 
-Example 2: disallow release candidates as upgradable versions from stable versions
+Example 2: disallow release candidates as upgradable versions from stable
+versions
 
 ```groovy
-// https://github.com/ben-manes/gradle-versions-plugin
 tasks.named("dependencyUpdates").configure {
   rejectVersionIf {
     isNonStable(candidate.version) && !isNonStable(currentVersion)
@@ -436,7 +365,6 @@ tasks.named("dependencyUpdates").configure {
 Example 3: using the full syntax
 
 ```groovy
-// https://github.com/ben-manes/gradle-versions-plugin
 tasks.named("dependencyUpdates").configure {
   resolutionStrategy {
     componentSelection {
@@ -452,53 +380,16 @@ tasks.named("dependencyUpdates").configure {
 
 </details>
 
-#### Gradle Release Channel
-
-The `gradleReleaseChannel` task property controls which release channel of the Gradle project is used to check for available Gradle updates. Options are:
-
-  * `current`
-  * `release-candidate`
-  * `nightly`
-
-The default is `release-candidate`. The value can be changed as shown below:
-
-<details open>
-<summary>Kotlin</summary>
-
-```kotlin
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-  gradleReleaseChannel = "current"
-}
-```
-
-</details>
-
-<details>
-<summary>Groovy</summary>
-
-```groovy
-tasks.named("dependencyUpdates").configure {
-  gradleReleaseChannel = "current"
-}
-```
-
-</details>
-
-#### Gradle Versions Api Base URL
-
-The `gradleVersionsApiBaseUrl` task property provides an option for customization of the Gradle versions service URL.
-If not specified, the default value https://services.gradle.org/versions/ is used.
-The customization can be useful in restricted environments without direct internet access and proxy availability.
-
 #### Constraints
 
-If you use constraints, for example to define a BOM using the [`java-platform`](https://docs.gradle.org/current/userguide/java_platform_plugin.html)
-plugin or to [manage](https://docs.gradle.org/current/userguide/dependency_constraints.html)
-transitive dependency versions, you can enable checking of constraints by specifying the `checkConstraints`
-attribute of the `dependencyUpdates` task.
-If you want to check external constraints (defined in init scripts or by Gradle since 7.3.2) you can do so by specifying the `checkBuildEnvironmentConstraints`
+If you use constraints, for example to define a BOM using the
+[`java-platform`](https://docs.gradle.org/current/userguide/java_platform_plugin.html)
+plugin or to
+[manage](https://docs.gradle.org/current/userguide/dependency_constraints.html)
+transitive dependency versions, you can enable checking of constraints by
+specifying the `checkConstraints` attribute of the `dependencyUpdates` task. If
+you want to check external constraints (defined in init scripts or by Gradle
+itself) you can do so by specifying the `checkBuildEnvironmentConstraints`
 attribute of the `dependencyUpdates` task.
 
 <details open>
@@ -522,47 +413,15 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 tasks.named("dependencyUpdates").configure {
   checkConstraints = true
   checkBuildEnvironmentConstraints = true
-}
-```
-
-</details>
-
-#### Optional parameters
-
-The `dependencyUpdates` task takes several optional parameters to adjust its behavior:
-
-<details open>
-<summary>Kotlin</summary>
-
-```kotlin
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-  checkForGradleUpdate = true
-  outputFormatter = "json"
-  outputDir = "build/dependencyUpdates"
-  reportfileName = "report"
-}
-```
-
-</details>
-
-<details>
-<summary>Groovy</summary>
-
-```groovy
-tasks.named("dependencyUpdates").configure {
-  checkForGradleUpdate = true
-  outputFormatter = "json"
-  outputDir = "build/dependencyUpdates"
-  reportfileName = "report"
 }
 ```
 
 </details>
 
 #### Configuration filter
-You can change which dependency configurations the plugin checks for updates like this:
+
+You can change which dependency configurations the plugin checks for updates
+like this:
 
 <details open>
 <summary>Kotlin</summary>
@@ -592,331 +451,569 @@ tasks.named("dependencyUpdates").configure {
 
 </details>
 
+#### Optional parameters
 
-#### Try out the samples
+The `dependencyUpdates` task takes several optional parameters to adjust its
+behavior. The `revision`, `gradleReleaseChannel`, `outputFormatter`,
+`outputDir`, and `reportfileName` properties may also be set as system
+properties, which override the task configuration for ad hoc runs (e.g.
+`-Drevision=release`):
 
-Have a look at [`examples/groovy`](https://github.com/ben-manes/gradle-versions-plugin/tree/master/examples/groovy) and [`examples/kotlin`](https://github.com/ben-manes/gradle-versions-plugin/tree/master/examples/kotlin)
+<details open>
+<summary>Kotlin</summary>
 
-```bash
-# Publish the latest version of the plugin to mavenLocal()
-$ ./gradlew publishToMavenLocal
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
-# Try out the samples
-$ ./gradlew -p examples/groovy dependencyUpdates
-$ ./gradlew -p examples/kotlin dependencyUpdates
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  checkForGradleUpdate = true
+  outputFormatter = "json"
+  outputDir = "build/dependencyUpdates"
+  reportfileName = "report"
+}
 ```
 
-### Report format
+</details>
 
-The task property `outputFormatter` controls the report output format. The following values are supported:
+<details>
+<summary>Groovy</summary>
 
-  * `"plain"`: format output file as plain text (default)
-  * `"json"`: format output file as json text
-  * `"xml"`: format output file as xml text, can be used by other plugins (e.g. sonar)
-  * `"html"`: format output file as html
-  * `Closure`: will be called with the result of the dependency update analysis
+```groovy
+tasks.named("dependencyUpdates").configure {
+  checkForGradleUpdate = true
+  outputFormatter = "json"
+  outputDir = "build/dependencyUpdates"
+  reportfileName = "report"
+}
+```
+
+</details>
+
+#### Gradle release channel
+
+The `gradleReleaseChannel` task property controls which release channel of the
+Gradle project is used to check for available Gradle updates. Options are:
+
+* `current`
+* `release-candidate`
+* `nightly`
+
+The default is `release-candidate`. The value can be changed as shown below:
+
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  gradleReleaseChannel = "current"
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+tasks.named("dependencyUpdates").configure {
+  gradleReleaseChannel = "current"
+}
+```
+
+</details>
+
+#### Gradle versions API base URL
+
+The `gradleVersionsApiBaseUrl` task property provides an option for
+customization of the Gradle versions service URL. If not specified, the default
+value https://services.gradle.org/versions/ is used. The customization can be
+useful in restricted environments without direct internet access and proxy
+availability.
+
+#### Report format
+
+The task property `outputFormatter` controls the report output format. The
+following values are supported:
+
+* `"plain"`: format output file as plain text (default)
+* `"json"`: format output file as json text
+* `"xml"`: format output file as xml text, can be used by other plugins (e.g. sonar)
+* `"html"`: format output file as html
+* `Closure`: will be called with the result of the dependency update analysis
+  (from Kotlin, use the `outputFormatter(Action<Result>)` function instead)
 
 You can also set multiple output formats using comma as the separator:
 
 ```bash
-gradle dependencyUpdates -Drevision=release -DoutputFormatter=json,xml,html
+./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json,xml,html
 ```
 
-The task property `outputDir` controls the output directory for the report  file(s). The directory will be created if it does not exist.
-The default value is set to `build/dependencyUpdates`
+The task property `outputDir` controls the output directory for the report
+file(s). The directory will be created if it does not exist. The default value
+is set to `build/dependencyUpdates`
 
 ```bash
-gradle dependencyUpdates -Drevision=release -DoutputFormatter=json -DoutputDir=/any/path/with/permission
+./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json -DoutputDir=/any/path/with/permission
 ```
 
-Last the property `reportfileName` sets the filename (without extension) of the generated report. It defaults to `report`.
-The extension will be set according to the used output format.
+Last the property `reportfileName` sets the filename (without extension) of the
+generated report. It defaults to `report`. The extension will be set according
+to the used output format.
 
 ```bash
-gradle dependencyUpdates -Drevision=release -DoutputFormatter=json -DreportfileName=myCustomReport
+./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json -DreportfileName=myCustomReport
 ```
 
-This displays a report to the console.
-
+Sample output in each format:
 
 <details open>
-<summary>Text Report</summary>
+<summary>Text report</summary>
 
 ```
 ------------------------------------------------------------
 : Project Dependency Updates (report to plain text file)
 ------------------------------------------------------------
 
-The following dependencies are using the latest integration version:
+The following dependencies are using the latest milestone version:
  - backport-util-concurrent:backport-util-concurrent:3.1
  - backport-util-concurrent:backport-util-concurrent-java12:3.1
+ - io.github.ben-manes:gradle-versions-plugin:0.55.0
 
-The following dependencies exceed the version found at the integration revision level:
- - com.google.guava:guava [99.0-SNAPSHOT <- 16.0-rc1]
-     https://code.google.com/p/guava-libraries
- - com.google.guava:guava-tests [99.0-SNAPSHOT <- 16.0-rc1]
-     https://code.google.com/p/guava-libraries
+The following dependencies exceed the version found at the milestone revision level:
+ - com.google.guava:guava-tests [99.0-SNAPSHOT <- 23.3-jre]
+     https://github.com/google/guava
 
-The following dependencies have later integration versions:
- - com.google.inject:guice [2.0 -> 3.0]
-     https://code.google.com/p/google-guice/
- - com.google.inject.extensions:guice-multibindings [2.0 -> 3.0]
-     https://code.google.com/p/google-guice/
+The following dependencies have later milestone versions:
+ - com.google.guava:guava [15.0 -> 23.0]
+     https://github.com/google/guava
+ - com.google.inject:guice [2.0 -> 7.0.0]
+     https://github.com/google/guice
+ - com.google.inject.extensions:guice-multibindings [2.0 -> 4.2.3]
+     https://github.com/google/guice
+ - com.linecorp.armeria:armeria [0.90.0 -> 1.40.0]
+     https://armeria.dev/
+ - io.zipkin.brave:brave [5.7.0 -> 6.3.1]
+     https://github.com/openzipkin/brave/brave
+ - org.springframework.boot:spring-boot-dependencies [1.5.8.RELEASE -> 4.1.0]
+     https://spring.io/projects/spring-boot
 
-Gradle updates:
- - Gradle: [4.6 -> 4.7 -> 4.8-rc-2]
+Failed to compare versions for the following dependencies because they were declared without version:
+ - com.google.code.gson:gson
+
+Failed to determine the latest version for the following dependencies (use --info for details):
+ - com.github.ben-manes:unresolvable
+ - com.github.ben-manes:unresolvable2
+ - com.google.guava:guava
+     23.0
+ - dom4j:dom4j
+
+Gradle release-candidate updates:
+ - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-1]
 ```
+
 </details>
 
 Alternatively, the report may be output to a structured file.
 
 <details>
-<summary>Json report</summary>
+<summary>JSON report</summary>
 
 ```json
 {
-  "current": {
-    "dependencies": [
-      {
-        "group": "backport-util-concurrent",
-        "version": "3.1",
-        "name": "backport-util-concurrent",
-        "projectUrl": "https://backport-jsr166.sourceforge.net/"
-      },
-      {
-        "group": "backport-util-concurrent",
-        "version": "3.1",
-        "name": "backport-util-concurrent-java12",
-        "projectUrl": "https://backport-jsr166.sourceforge.net/"
-      }
-    ],
-    "count": 2
-  },
-  "gradle": {
-    "enabled": true,
-    "current": {
-      "version": "4.7",
-      "reason": "",
-      "isUpdateAvailable": true,
-      "isFailure": false
-    },
-    "nightly": {
-      "version": "4.9-20180526235939+0000",
-      "reason": "",
-      "isUpdateAvailable": true,
-      "isFailure": false
-    },
-    "releaseCandidate": {
-      "version": "4.8-rc-2",
-      "reason": "",
-      "isUpdateAvailable": true,
-      "isFailure": false
-    },
-    "running": {
-      "version": "4.6",
-      "reason": "",
-      "isUpdateAvailable": false,
-      "isFailure": false
+ "count": 15,
+ "current": {
+  "count": 3,
+  "dependencies": [
+   {
+    "group": "backport-util-concurrent",
+    "name": "backport-util-concurrent",
+    "version": "3.1",
+    "projectUrl": "http://backport-jsr166.sourceforge.net/",
+    "userReason": null
+   },
+   {
+    "group": "backport-util-concurrent",
+    "name": "backport-util-concurrent-java12",
+    "version": "3.1",
+    "projectUrl": "http://backport-jsr166.sourceforge.net/",
+    "userReason": null
+   },
+   {
+    "group": "io.github.ben-manes",
+    "name": "gradle-versions-plugin",
+    "version": "0.55.0",
+    "projectUrl": null,
+    "userReason": null
+   }
+  ]
+ },
+ "outdated": {
+  "count": 6,
+  "dependencies": [
+   {
+    "group": "com.google.guava",
+    "name": "guava",
+    "version": "15.0",
+    "projectUrl": "https://github.com/google/guava",
+    "userReason": null,
+    "available": {
+     "release": null,
+     "milestone": "23.0",
+     "integration": null
     }
+   },
+   {
+    "group": "com.google.inject",
+    "name": "guice",
+    "version": "2.0",
+    "projectUrl": "https://github.com/google/guice",
+    "userReason": null,
+    "available": {
+     "release": null,
+     "milestone": "7.0.0",
+     "integration": null
+    }
+   },
+   {
+    "group": "com.google.inject.extensions",
+    "name": "guice-multibindings",
+    "version": "2.0",
+    "projectUrl": "https://github.com/google/guice",
+    "userReason": null,
+    "available": {
+     "release": null,
+     "milestone": "4.2.3",
+     "integration": null
+    }
+   },
+   {
+    "group": "com.linecorp.armeria",
+    "name": "armeria",
+    "version": "0.90.0",
+    "projectUrl": "https://armeria.dev/",
+    "userReason": null,
+    "available": {
+     "release": null,
+     "milestone": "1.40.0",
+     "integration": null
+    }
+   },
+   {
+    "group": "io.zipkin.brave",
+    "name": "brave",
+    "version": "5.7.0",
+    "projectUrl": "https://github.com/openzipkin/brave/brave",
+    "userReason": null,
+    "available": {
+     "release": null,
+     "milestone": "6.3.1",
+     "integration": null
+    }
+   },
+   {
+    "group": "org.springframework.boot",
+    "name": "spring-boot-dependencies",
+    "version": "1.5.8.RELEASE",
+    "projectUrl": "https://spring.io/projects/spring-boot",
+    "userReason": null,
+    "available": {
+     "release": null,
+     "milestone": "4.1.0",
+     "integration": null
+    }
+   }
+  ]
+ },
+ "exceeded": {
+  "count": 1,
+  "dependencies": [
+   {
+    "group": "com.google.guava",
+    "name": "guava-tests",
+    "version": "99.0-SNAPSHOT",
+    "projectUrl": "https://github.com/google/guava",
+    "userReason": null,
+    "latest": "23.3-jre"
+   }
+  ]
+ },
+ "undeclared": {
+  "count": 1,
+  "dependencies": [
+   {
+    "group": "com.google.code.gson",
+    "name": "gson",
+    "version": null,
+    "projectUrl": null,
+    "userReason": null
+   }
+  ]
+ },
+ "unresolved": {
+  "count": 4,
+  "dependencies": [
+   {
+    "group": "com.github.ben-manes",
+    "name": "unresolvable",
+    "version": "1.0",
+    "projectUrl": null,
+    "userReason": null,
+    "reason": "Could not find any matches for com.github.ben-manes:unresolvable:+ as no versions of com.github.ben-manes:unresolvable are available.\nSearched in the following locations:\n  - https://repo.maven.apache.org/maven2/com/github/ben-manes/unresolvable/maven-metadata.xml"
+   },
+   {
+    "group": "com.github.ben-manes",
+    "name": "unresolvable2",
+    "version": "1.0",
+    "projectUrl": null,
+    "userReason": null,
+    "reason": "Could not find any matches for com.github.ben-manes:unresolvable2:+ as no versions of com.github.ben-manes:unresolvable2 are available.\nSearched in the following locations:\n  - https://repo.maven.apache.org/maven2/com/github/ben-manes/unresolvable2/maven-metadata.xml"
+   },
+   {
+    "group": "com.google.guava",
+    "name": "guava",
+    "version": "15.0",
+    "projectUrl": "23.0",
+    "userReason": null,
+    "reason": "Could not resolve com.google.guava:guava:+."
+   },
+   {
+    "group": "dom4j",
+    "name": "dom4j",
+    "version": "none",
+    "projectUrl": null,
+    "userReason": null,
+    "reason": "Could not resolve dom4j:dom4j:+."
+   }
+  ]
+ },
+ "gradle": {
+  "enabled": true,
+  "running": {
+   "isFailure": false,
+   "isUpdateAvailable": false,
+   "reason": "",
+   "version": "8.4"
   },
-  "exceeded": {
-    "dependencies": [
-      {
-        "group": "com.google.guava",
-        "latest": "16.0-rc1",
-        "version": "99.0-SNAPSHOT",
-        "name": "guava",
-        "projectUrl": "https://code.google.com/p/guava-libraries"
-      },
-      {
-        "group": "com.google.guava",
-        "latest": "16.0-rc1",
-        "version": "99.0-SNAPSHOT",
-        "name": "guava-tests",
-        "projectUrl": "https://code.google.com/p/guava-libraries"
-      }
-    ],
-    "count": 2
+  "current": {
+   "isFailure": false,
+   "isUpdateAvailable": true,
+   "reason": "",
+   "version": "9.6.1"
   },
-  "outdated": {
-    "dependencies": [
-      {
-        "group": "com.google.inject",
-        "available": {
-          "release": "3.0",
-          "milestone": null,
-          "integration": null
-        },
-        "version": "2.0",
-        "name": "guice",
-        "projectUrl": "https://code.google.com/p/google-guice/"
-      },
-      {
-        "group": "com.google.inject.extensions",
-        "available": {
-          "release": "3.0",
-          "milestone": null,
-          "integration": null
-        },
-        "version": "2.0",
-        "name": "guice-multibindings",
-        "projectUrl": "https://code.google.com/p/google-guice/"
-      }
-    ],
-    "count": 2
+  "releaseCandidate": {
+   "isFailure": false,
+   "isUpdateAvailable": true,
+   "reason": "",
+   "version": "9.7.0-rc-1"
   },
-  "unresolved": {
-    "dependencies": [
-      {
-        "group": "com.github.ben-manes",
-        "version": "1.0",
-        "reason": "Could not find any version that matches com.github.ben-manes:unresolvable:latest.milestone.",
-        "name": "unresolvable"
-      },
-      {
-        "group": "com.github.ben-manes",
-        "version": "1.0",
-        "reason": "Could not find any version that matches com.github.ben-manes:unresolvable2:latest.milestone.",
-        "name": "unresolvable2"
-      }
-    ],
-    "count": 2
-  },
-  "count": 8
+  "nightly": {
+   "isFailure": false,
+   "isUpdateAvailable": false,
+   "reason": "update check disabled",
+   "version": ""
+  }
+ }
 }
 ```
+
 </details>
 
 <details>
 <summary>XML report</summary>
 
-
 ```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <response>
-  <count>8</count>
-  <current>
-    <count>2</count>
-    <dependencies>
-      <dependency>
-        <name>backport-util-concurrent</name>
-        <group>backport-util-concurrent</group>
-        <version>3.1</version>
-        <projectUrl>https://backport-jsr166.sourceforge.net/</projectUrl>
-      </dependency>
-      <dependency>
-        <name>backport-util-concurrent-java12</name>
-        <group>backport-util-concurrent</group>
-        <version>3.1</version>
-        <projectUrl>https://backport-jsr166.sourceforge.net/</projectUrl>
-      </dependency>
-    </dependencies>
-  </current>
-  <outdated>
-    <count>2</count>
-    <dependencies>
-      <outdatedDependency>
-        <name>guice</name>
-        <group>com.google.inject</group>
-        <version>2.0</version>
-        <available>
-          <release>3.0</release>
-        </available>
-        <projectUrl>https://code.google.com/p/google-guice/</projectUrl>
-      </outdatedDependency>
-      <outdatedDependency>
-        <name>guice-multibindings</name>
-        <group>com.google.inject.extensions</group>
-        <version>2.0</version>
-        <available>
-          <release>3.0</release>
-        </available>
-        <projectUrl>https://code.google.com/p/guava-libraries</projectUrl>
-      </outdatedDependency>
-    </dependencies>
-  </outdated>
-  <exceeded>
-    <count>2</count>
-    <dependencies>
-      <exceededDependency>
-        <name>guava</name>
-        <group>com.google.guava</group>
-        <version>99.0-SNAPSHOT</version>
-        <latest>16.0-rc1</latest>
-        <projectUrl>https://code.google.com/p/guava-libraries</projectUrl>
-      </exceededDependency>
-      <exceededDependency>
-        <name>guava-tests</name>
-        <group>com.google.guava</group>
-        <version>99.0-SNAPSHOT</version>
-        <latest>16.0-rc1</latest>
-        <projectUrl>https://code.google.com/p/guava-libraries</projectUrl>
-      </exceededDependency>
-    </dependencies>
-  </exceeded>
-  <unresolved>
-    <count>2</count>
-    <dependencies>
-      <unresolvedDependency>
-        <name>unresolvable</name>
-        <group>com.github.ben-manes</group>
-        <version>1.0</version>
-        <reason>Could not find any version that matches com.github.ben-manes:unresolvable:latest.release.</reason>
-      </unresolvedDependency>
-      <unresolvedDependency>
-        <name>unresolvable2</name>
-        <group>com.github.ben-manes</group>
-        <version>1.0</version>
-        <reason>Could not find any version that matches com.github.ben-manes:unresolvable2:latest.release.</reason>
-      </unresolvedDependency>
-    </dependencies>
-  </unresolved>
-  <gradle>
-    <enabled>true</enabled>
-    <running>
-      <version>4.6</version>
-      <isUpdateAvailable>false</isUpdateAvailable>
-      <isFailure>false</isFailure>
-      <reason></reason>
-    </running>
+    <count>15</count>
     <current>
-      <version>4.7</version>
-      <isUpdateAvailable>true</isUpdateAvailable>
-      <isFailure>false</isFailure>
-      <reason></reason>
+        <count>3</count>
+        <dependencies>
+            <dependency>
+                <group>backport-util-concurrent</group>
+                <name>backport-util-concurrent</name>
+                <version>3.1</version>
+                <projectUrl>http://backport-jsr166.sourceforge.net/</projectUrl>
+            </dependency>
+            <dependency>
+                <group>backport-util-concurrent</group>
+                <name>backport-util-concurrent-java12</name>
+                <version>3.1</version>
+                <projectUrl>http://backport-jsr166.sourceforge.net/</projectUrl>
+            </dependency>
+            <dependency>
+                <group>io.github.ben-manes</group>
+                <name>gradle-versions-plugin</name>
+                <version>0.55.0</version>
+            </dependency>
+        </dependencies>
     </current>
-    <releaseCandidate>
-      <version>4.8-rc-2</version>
-      <isUpdateAvailable>true</isUpdateAvailable>
-      <isFailure>false</isFailure>
-      <reason></reason>
-    </releaseCandidate>
-    <nightly>
-      <version>4.9-20180526235939+0000</version>
-      <isUpdateAvailable>true</isUpdateAvailable>
-      <isFailure>false</isFailure>
-      <reason></reason>
-    </nightly>
-  </gradle>
+    <outdated>
+        <count>6</count>
+        <dependencies>
+            <outdatedDependency>
+                <group>com.google.guava</group>
+                <name>guava</name>
+                <version>15.0</version>
+                <projectUrl>https://github.com/google/guava</projectUrl>
+                <available>
+                    <milestone>23.0</milestone>
+                </available>
+            </outdatedDependency>
+            <outdatedDependency>
+                <group>com.google.inject</group>
+                <name>guice</name>
+                <version>2.0</version>
+                <projectUrl>https://github.com/google/guice</projectUrl>
+                <available>
+                    <milestone>7.0.0</milestone>
+                </available>
+            </outdatedDependency>
+            <outdatedDependency>
+                <group>com.google.inject.extensions</group>
+                <name>guice-multibindings</name>
+                <version>2.0</version>
+                <projectUrl>https://github.com/google/guice</projectUrl>
+                <available>
+                    <milestone>4.2.3</milestone>
+                </available>
+            </outdatedDependency>
+            <outdatedDependency>
+                <group>com.linecorp.armeria</group>
+                <name>armeria</name>
+                <version>0.90.0</version>
+                <projectUrl>https://armeria.dev/</projectUrl>
+                <available>
+                    <milestone>1.40.0</milestone>
+                </available>
+            </outdatedDependency>
+            <outdatedDependency>
+                <group>io.zipkin.brave</group>
+                <name>brave</name>
+                <version>5.7.0</version>
+                <projectUrl>https://github.com/openzipkin/brave/brave</projectUrl>
+                <available>
+                    <milestone>6.3.1</milestone>
+                </available>
+            </outdatedDependency>
+            <outdatedDependency>
+                <group>org.springframework.boot</group>
+                <name>spring-boot-dependencies</name>
+                <version>1.5.8.RELEASE</version>
+                <projectUrl>https://spring.io/projects/spring-boot</projectUrl>
+                <available>
+                    <milestone>4.1.0</milestone>
+                </available>
+            </outdatedDependency>
+        </dependencies>
+    </outdated>
+    <exceeded>
+        <count>1</count>
+        <dependencies>
+            <exceededDependency>
+                <group>com.google.guava</group>
+                <name>guava-tests</name>
+                <version>99.0-SNAPSHOT</version>
+                <projectUrl>https://github.com/google/guava</projectUrl>
+                <latest>23.3-jre</latest>
+            </exceededDependency>
+        </dependencies>
+    </exceeded>
+    <undeclared>
+        <count>1</count>
+        <dependencies>
+            <dependency>
+                <group>com.google.code.gson</group>
+                <name>gson</name>
+            </dependency>
+        </dependencies>
+    </undeclared>
+    <unresolved>
+        <count>4</count>
+        <dependencies>
+            <unresolvedDependency>
+                <group>com.github.ben-manes</group>
+                <name>unresolvable</name>
+                <version>1.0</version>
+                <reason>Could not find any matches for com.github.ben-manes:unresolvable:+ as no versions of com.github.ben-manes:unresolvable are available.
+Searched in the following locations:
+  - https://repo.maven.apache.org/maven2/com/github/ben-manes/unresolvable/maven-metadata.xml</reason>
+            </unresolvedDependency>
+            <unresolvedDependency>
+                <group>com.github.ben-manes</group>
+                <name>unresolvable2</name>
+                <version>1.0</version>
+                <reason>Could not find any matches for com.github.ben-manes:unresolvable2:+ as no versions of com.github.ben-manes:unresolvable2 are available.
+Searched in the following locations:
+  - https://repo.maven.apache.org/maven2/com/github/ben-manes/unresolvable2/maven-metadata.xml</reason>
+            </unresolvedDependency>
+            <unresolvedDependency>
+                <group>com.google.guava</group>
+                <name>guava</name>
+                <version>15.0</version>
+                <projectUrl>23.0</projectUrl>
+                <reason>Could not resolve com.google.guava:guava:+.</reason>
+            </unresolvedDependency>
+            <unresolvedDependency>
+                <group>dom4j</group>
+                <name>dom4j</name>
+                <version>none</version>
+                <reason>Could not resolve dom4j:dom4j:+.</reason>
+            </unresolvedDependency>
+        </dependencies>
+    </unresolved>
+    <gradle>
+        <enabled>true</enabled>
+        <running>
+            <version>8.4</version>
+            <isUpdateAvailable>false</isUpdateAvailable>
+            <isFailure>false</isFailure>
+            <reason/>
+        </running>
+        <current>
+            <version>9.6.1</version>
+            <isUpdateAvailable>true</isUpdateAvailable>
+            <isFailure>false</isFailure>
+            <reason/>
+        </current>
+        <releaseCandidate>
+            <version>9.7.0-rc-1</version>
+            <isUpdateAvailable>true</isUpdateAvailable>
+            <isFailure>false</isFailure>
+            <reason/>
+        </releaseCandidate>
+        <nightly>
+            <version/>
+            <isUpdateAvailable>false</isUpdateAvailable>
+            <isFailure>false</isFailure>
+            <reason>update check disabled</reason>
+        </nightly>
+    </gradle>
 </response>
 ```
+
 </details>
 
 <details>
 <summary>HTML report</summary>
 
 [<img src="examples/html-report.png"/>](examples/html-report.png)
+
 </details>
 
 <details>
 <summary>Custom report</summary>
 
-If you need to create a report in a custom format, you can provide a formatter function to the
-`dependencyUpdates` task's `outputFormatter`. The formatter receives the analysis as an instance
-of [com.github.benmanes.gradle.versions.reporter.result.Result](gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt):
-in the Kotlin DSL it is the receiver of the formatter block, and in Groovy it is passed as the
-closure argument.
+If you need to create a report in a custom format, you can provide a formatter
+function to the `dependencyUpdates` task's `outputFormatter`. The formatter
+receives the analysis as an instance of
+[com.github.benmanes.gradle.versions.reporter.result.Result](gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt):
+in the Kotlin DSL it is the receiver of the formatter block, and in Groovy it is
+passed as the closure argument.
 
-For example, if you wanted to create an html table for the upgradable dependencies, you could use:
+For example, if you wanted to create an html table for the upgradable
+dependencies, you could use:
 
 <details open>
 <summary>Kotlin</summary>
@@ -952,7 +1049,7 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 
 </details>
 
-<details open>
+<details>
 <summary>Groovy</summary>
 
 ```groovy
@@ -997,5 +1094,387 @@ tasks.named("dependencyUpdates").configure {
 
 </details>
 
-[ivy_resolution_strategy]: https://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html#Latest%20(Status)%20Matcher
-[component_selection_rules]: https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:component_selection_rules
+### Multi-project builds
+
+Running the task in the root project generates one merged report covering every
+project. The report is aggregated from a task in each project, so it works with
+parallel execution, the configuration cache, and configure on demand. Under the
+configuration cache the dependency metadata read during resolution is tracked as
+an input, so a newly published version invalidates the cached entry rather than
+serving a stale report.
+
+With the settings plugin applied (see [Applying the
+plugin](#applying-the-plugin)), the root project receives the
+`dependencyUpdates` task and every other project contributes to it. No project
+applies a plugin itself, and a root build script is not required—add one only if
+you want to configure the task. The report also covers the plugins the settings
+script declares, which no project's buildscript carries; a version pinned in
+`pluginManagement` for a plugin the build never applies is not reported.
+
+The settings plugin registers the root project's `dependencyUpdates` task
+before the root build script runs, so a build script that registers its own
+task by that name now fails with a duplicate-task error—rename yours.
+
+#### Shared task settings
+
+Each project takes the settings that control resolution (`revision`,
+`rejectVersionIf` or a full `resolutionStrategy`, `filterConfigurations`,
+`checkConstraints`, and `checkBuildEnvironmentConstraints`) from the nearest
+project up the hierarchy whose task set them. Configuring the root project's
+task therefore covers every project, unless a subproject configures its own (see
+[Task properties](#task-properties)).
+
+#### Composite builds
+
+An included build is a separate build with its own settings script, so its
+projects are not part of this build's report. Apply the settings plugin in the
+included build's settings script as well, and run its `dependencyUpdates` task
+separately. `buildSrc` is a separate build too, and is likewise excluded. This
+is not specific to the settings plugin—an included build has never been covered.
+
+To report on every build in one invocation, register a lifecycle task that
+depends on each included build's task. Each build still writes its own report;
+there is no merged report across builds:
+
+<details open>
+<summary>Kotlin</summary>
+
+"build.gradle.kts":
+```kotlin
+tasks.register("allDependencyUpdates") {
+  gradle.includedBuilds.forEach { dependsOn(it.task(":dependencyUpdates")) }
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+"build.gradle":
+```groovy
+tasks.register("allDependencyUpdates") {
+  gradle.includedBuilds.each { dependsOn(it.task(':dependencyUpdates')) }
+}
+```
+
+</details>
+
+Every included build needs the plugin applied for its `dependencyUpdates` task
+to exist. A build that must stay unmodified can have the plugin injected by an
+[init script](#initialization-script) instead.
+
+#### Per-project reports
+
+A project can have a `dependencyUpdates` task of its own, reporting on itself
+and its subprojects (see [Other ways to apply the
+plugin](#other-ways-to-apply-the-plugin)). Run it by its path to get just that
+report:
+
+```bash
+./gradlew :subproject:dependencyUpdates
+```
+
+### Isolated projects
+
+Under [isolated
+projects](https://docs.gradle.org/current/userguide/isolated_projects.html) a
+project plugin cannot register a task in another project, so a project only
+contributes to the aggregate report if it applies a plugin itself. The settings
+plugin covers this: it applies a plugin to each project as the project is
+evaluated, so the recommended setup works unchanged (see [Applying the
+plugin](#applying-the-plugin)).
+
+A build that cannot apply the settings plugin can still cover every project (see
+[Contributor plugin](#contributor-plugin)).
+
+Under isolated projects, contributing projects that share a group and name are
+aggregated as one; the console warns about any project the report is missing.
+
+## Other ways to apply the plugin
+
+The settings plugin is the recommended way to apply the plugin (see
+[Applying the plugin](#applying-the-plugin)). The options below cover builds that need something
+different:
+
+* apply the plugin to a single project—for a separate per-project report,
+  alongside or instead of the settings plugin (see [The `plugins`
+  block](#the-plugins-block) and [legacy plugin application](#legacy-plugin-application));
+* contribute every project to the root report without a settings plugin (see
+  [Contributor plugin](#contributor-plugin));
+* apply the plugin to every build you run on your machine (see [Initialization
+  script](#initialization-script)).
+
+In the snippets below, replace `$version` with the current release, shown in the
+badge at the top of this page.
+
+> [!IMPORTANT]
+> When the settings plugin is also applied, request the per-project plugin
+> *without* a version—the settings plugin already puts it on every project's
+> classpath, and a versioned request fails to resolve. This includes a version
+> catalog alias, which always carries a version.
+
+### The `plugins` block
+
+<details open>
+<summary>Kotlin</summary>
+
+"build.gradle.kts":
+```kotlin
+plugins {
+  id("io.github.ben-manes.versions") version "$version"
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+"build.gradle":
+```groovy
+plugins {
+  id "io.github.ben-manes.versions" version "$version"
+}
+```
+
+</details>
+
+### Legacy plugin application
+
+> [!TIP]
+> Prefer the `plugins` block—it is the modern replacement for
+> `buildscript`-based plugin application.
+
+<details open>
+<summary>Kotlin</summary>
+
+"build.gradle.kts":
+```kotlin
+buildscript {
+  repositories {
+    gradlePluginPortal()
+  }
+
+  dependencies {
+    classpath("io.github.ben-manes:gradle-versions-plugin:$version")
+  }
+}
+
+apply(plugin = "io.github.ben-manes.versions")
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+"build.gradle":
+```groovy
+buildscript {
+  repositories {
+    gradlePluginPortal()
+  }
+
+  dependencies {
+    classpath "io.github.ben-manes:gradle-versions-plugin:$version"
+  }
+}
+
+apply plugin: "io.github.ben-manes.versions"
+```
+
+</details>
+
+### Contributor plugin
+
+A build that cannot apply the settings plugin—under isolated projects, where a
+project plugin cannot register a task in another project (see [Isolated
+projects](#isolated-projects))—can keep applying `io.github.ben-manes.versions`
+in the root project, and apply `io.github.ben-manes.versions.contributor` in
+every other project, typically from a convention plugin they already share:
+
+<details open>
+<summary>Kotlin</summary>
+
+"buildSrc/src/main/kotlin/my-conventions.gradle.kts":
+```kotlin
+plugins {
+  id("io.github.ben-manes.versions.contributor")
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+"buildSrc/src/main/groovy/my-conventions.gradle":
+```groovy
+plugins {
+  id 'io.github.ben-manes.versions.contributor'
+}
+```
+
+</details>
+
+The convention plugin's own build must have the plugin on its classpath, e.g. as
+an `implementation("io.github.ben-manes:gradle-versions-plugin:$version")`
+dependency in `buildSrc/build.gradle.kts`.
+
+The contributor plugin registers only the producer that feeds the aggregate
+report, so `dependencyUpdates` remains a single task in the root project. The
+main plugin is a superset of the contributor plugin: a project that applies
+`io.github.ben-manes.versions` instead still feeds the aggregate report, and
+also gets its own `dependencyUpdates` task covering itself and its subprojects.
+
+### Initialization script
+
+You can also transparently add the plugin to every Gradle project that you run
+via a
+[Gradle init script](https://docs.gradle.org/current/userguide/init_scripts.html):
+
+<details open>
+<summary>Kotlin</summary>
+
+"$HOME/.gradle/init.d/add-versions-plugin.init.gradle.kts":
+```kotlin
+import com.github.benmanes.gradle.versions.VersionsPlugin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+initscript {
+  repositories {
+    gradlePluginPortal()
+  }
+
+  dependencies {
+    classpath("io.github.ben-manes:gradle-versions-plugin:+")
+  }
+}
+
+allprojects {
+  apply<VersionsPlugin>()
+
+  tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+    // configure the task, for example wrt. resolution strategies
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+"$HOME/.gradle/init.d/add-versions-plugin.gradle":
+```groovy
+initscript {
+  repositories {
+    gradlePluginPortal()
+  }
+
+  dependencies {
+    classpath 'io.github.ben-manes:gradle-versions-plugin:+'
+  }
+}
+
+allprojects {
+  apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
+
+  tasks.named("dependencyUpdates").configure {
+    // configure the task, for example wrt. resolution strategies
+  }
+}
+```
+
+</details>
+
+## Samples
+
+Have a look at
+[`examples/kotlin`](https://github.com/ben-manes/gradle-versions-plugin/tree/master/examples/kotlin)
+and
+[`examples/groovy`](https://github.com/ben-manes/gradle-versions-plugin/tree/master/examples/groovy)
+
+```bash
+# Publish the latest version of the plugin to mavenLocal()
+$ ./gradlew publishToMavenLocal
+
+# Try out the samples
+$ ./gradlew -p examples/kotlin dependencyUpdates
+$ ./gradlew -p examples/groovy dependencyUpdates
+```
+
+## Compatibility
+
+The plugin requires Gradle 8.4 or later, checked when the plugin is applied. It
+targets Java 8 bytecode, so it runs on any JVM that can run Gradle itself.
+Parallel execution, the configuration cache, configure on demand, and isolated
+projects (see [Isolated projects](#isolated-projects)) are supported.
+
+## Migrating from prior versions
+
+Start at the subsection for the version your build is on and work upward: each
+subsection migrates to the version covered by the subsection above it, and the
+topmost migrates to the current release.
+
+### v0.55.0
+
+v0.56.0 adds the settings plugin and makes it the recommended setup:
+
+* Apply `io.github.ben-manes.versions.settings` in the settings script (see
+  [Applying the plugin](#applying-the-plugin)) and remove `io.github.ben-manes.versions` from your build
+  scripts. A project that keeps the main plugin for a separate per-project
+  report must request it without a version, because the settings plugin
+  already puts the plugin on every project's classpath.
+* A build that applied `io.github.ben-manes.versions.contributor` from a
+  convention plugin for isolated projects support no longer needs it: the
+  settings plugin covers every project. The contributor plugin remains
+  available for builds that cannot apply a settings plugin.
+
+Task configuration is unchanged: configure `dependencyUpdates` in the root build
+script as before.
+
+### v0.54.0 and earlier
+
+v0.55.0 moves the plugin from the `com.github.ben-manes` namespace to
+`io.github.ben-manes` and raises the minimum supported Gradle version to 8.4:
+
+* Switch the plugin ID from `com.github.ben-manes.versions` to
+  `io.github.ben-manes.versions`. The legacy ID is deprecated but keeps
+  receiving releases, so this can happen at your convenience; only the main
+  plugin has a legacy ID.
+* Move a `buildscript` or `initscript` `classpath` dependency to the
+  `io.github.ben-manes:gradle-versions-plugin` coordinate. v0.54.0 is the last
+  release published under `com.github.ben-manes:gradle-versions-plugin`, so
+  the old coordinate no longer sees updates.
+
+v0.55.0 also reworks how the merged report of a multi-project build is
+produced: it is aggregated from a task in each project, which adds support for
+parallel execution, the configuration cache, and isolated projects (see
+[Multi-project builds](#multi-project-builds)). The report content and task
+configuration are unchanged. Then continue with the v0.55.0 steps above.
+
+## Related plugins
+
+This plugin only reports. To apply the updates it finds automatically:
+
+* [version-catalog-update-plugin](https://github.com/littlerobots/version-catalog-update-plugin):
+  updates the versions in your version catalog (`libs.versions.toml`) based on
+  this plugin's report
+* [gradle-use-latest-versions](https://github.com/patrikerdes/gradle-use-latest-versions-plugin):
+  updates versions declared directly in build scripts based on this plugin's
+  report
+* [gradle-upgrade-interactive](https://github.com/kevcodez/gradle-upgrade-interactive):
+  interactive CLI that applies the updates you select from this plugin's
+  report
+
+Other related tools:
+
+* [gradle-versions-filter-plugin](https://github.com/janderssonse/gradle-versions-filter-plugin)
+* [gradle-update-checker](https://github.com/marketplace/actions/gradle-update-checker)
+* [gradle-libraries-plugin](https://github.com/fkorotkov/gradle-libraries-plugin)
+* [gradle-update-notifier](https://github.com/y-yagi/gradle-update-notifier)
+* [refreshVersions](https://github.com/jmfayard/refreshVersions)
+* [update-versions-gradle-plugin](https://github.com/tomasbjerre/update-versions-gradle-plugin)
+* [caupain](https://github.com/deezer/caupain/)

--- a/gradle-versions-plugin/build.gradle.kts
+++ b/gradle-versions-plugin/build.gradle.kts
@@ -84,5 +84,17 @@ gradlePlugin {
         }
       }
     }
+    create("versionsSettingsPlugin") {
+      id = properties["PLUGIN_SETTINGS_NAME"].toString()
+      implementationClass = properties["PLUGIN_SETTINGS_NAME_CLASS"].toString()
+      displayName = properties["POM_SETTINGS_NAME"].toString()
+      description = properties["POM_SETTINGS_DESCRIPTION"].toString()
+      tags.set(listOf("dependencies", "versions", "updates"))
+      compatibility {
+        features {
+          configurationCache = true
+        }
+      }
+    }
   }
 }

--- a/gradle-versions-plugin/gradle.properties
+++ b/gradle-versions-plugin/gradle.properties
@@ -5,3 +5,5 @@ POM_LEGACY_NAME=Gradle Versions Plugin (deprecated id)
 POM_LEGACY_DESCRIPTION=DEPRECATED: use io.github.ben-manes.versions instead. Gradle plugin that provides tasks for discovering dependency updates.
 POM_CONTRIBUTOR_NAME=Gradle Versions Contributor Plugin
 POM_CONTRIBUTOR_DESCRIPTION=Gradle plugin that contributes a project's dependency updates to the aggregate report.
+POM_SETTINGS_NAME=Gradle Versions Settings Plugin
+POM_SETTINGS_DESCRIPTION=Gradle settings plugin that discovers dependency updates in every project of the build and in the settings script.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsSettingsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsSettingsPlugin.kt
@@ -1,15 +1,22 @@
 package com.github.benmanes.gradle.versions
 
+import com.github.benmanes.gradle.versions.updates.publishSettingsClasspath
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 
 /**
  * Applies [VersionsPlugin] to the root project and [VersionsContributorPlugin] to every other
- * project of the build, but not of an included build.
+ * project of the build, but not of an included build, and reports the versions of the plugins
+ * that the settings script declares.
  */
 class VersionsSettingsPlugin : Plugin<Settings> {
   override fun apply(settings: Settings) {
     requireMinimumGradleVersion("io.github.ben-manes.versions.settings")
+
+    // The settings script's classpath carries the versions of the plugins that its own plugins
+    // block declares, which no project's buildscript does.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/367
+    publishSettingsClasspath(settings.gradle, settings.buildscript.configurations.toList())
 
     // Isolated projects isolates the action of gradle.lifecycle.beforeProject so that the state it
     // captures cannot be shared between the projects it configures. This action captures nothing,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsSettingsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsSettingsPlugin.kt
@@ -1,0 +1,28 @@
+package com.github.benmanes.gradle.versions
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
+/**
+ * Applies [VersionsPlugin] to the root project and [VersionsContributorPlugin] to every other
+ * project of the build, but not of an included build.
+ */
+class VersionsSettingsPlugin : Plugin<Settings> {
+  override fun apply(settings: Settings) {
+    requireMinimumGradleVersion("io.github.ben-manes.versions.settings")
+
+    // Isolated projects isolates the action of gradle.lifecycle.beforeProject so that the state it
+    // captures cannot be shared between the projects it configures. This action captures nothing,
+    // so the older hook is equivalent and does not require Gradle 8.8. Capturing the settings or a
+    // field here would no longer be safe.
+    settings.gradle.beforeProject { project ->
+      // Only the root receives the reporting task, so that invoking dependencyUpdates by name runs
+      // one task and writes one merged report rather than one per project.
+      if (project.path == ":") {
+        project.pluginManager.apply(VersionsPlugin::class.java)
+      } else {
+        project.pluginManager.apply(VersionsContributorPlugin::class.java)
+      }
+    }
+  }
+}

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -8,6 +8,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.invocation.Gradle
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -60,6 +61,14 @@ internal abstract class DependencyUpdatesParametersService :
   BuildService<BuildServiceParameters.None> {
   private val byPath = ConcurrentHashMap<String, DependencyUpdatesParameters>()
 
+  /**
+   * The settings script's own classpath, which the settings plugin publishes here rather than
+   * capturing in the hook that reaches each project, as isolated projects forbids sharing that
+   * state between the projects a hook configures.
+   */
+  @Volatile
+  var settingsConfigurations: List<Configuration> = emptyList()
+
   /** Publishes the settings of the given project's task to the projects that resolve with them. */
   fun register(
     path: String,
@@ -102,7 +111,7 @@ internal fun registerAggregation(
   project: Project,
   accumulator: TaskProvider<DependencyUpdatesTask>,
 ) {
-  val service = parametersService(project)
+  val service = parametersService(project.gradle)
   accumulator.configure { task -> service.get().register(project.path, task.parameters) }
   // Realizes the task, so that a configuration block on a task that nothing else realizes is still
   // applied before the producers read the settings.
@@ -187,11 +196,19 @@ internal fun registerAggregation(
 
 /** Registers the task and outgoing variant that publish a single project's statuses. */
 internal fun registerProducer(project: Project): TaskProvider<DependencyUpdatesPartialTask> =
-  registerProducer(project, parametersService(project))
+  registerProducer(project, parametersService(project.gradle))
+
+/** Publishes the settings script's classpath to the project that accumulates the report. */
+internal fun publishSettingsClasspath(
+  gradle: Gradle,
+  configurations: List<Configuration>,
+) {
+  parametersService(gradle).get().settingsConfigurations = configurations
+}
 
 /** Returns the build's shared parameters service, registering it if this is the first use. */
-private fun parametersService(project: Project): Provider<DependencyUpdatesParametersService> =
-  project.gradle.sharedServices
+private fun parametersService(gradle: Gradle): Provider<DependencyUpdatesParametersService> =
+  gradle.sharedServices
     .registerIfAbsent(PARAMETERS_SERVICE, DependencyUpdatesParametersService::class.java) { }
 
 private fun registerProducer(
@@ -216,9 +233,18 @@ private fun registerProducer(
             project.configurations
               .toList()
               .filter { it.isCanBeResolved && parameters.filterConfigurations.isSatisfiedBy(it) }
+          // The settings script's classpath holds the plugins its own plugins block declares, which
+          // no project's buildscript does. It is reported once, from the project that accumulates.
+          // https://github.com/ben-manes/gradle-versions-plugin/issues/367
+          val settingsConfigurations =
+            // Compared by path rather than to project.rootProject, which isolated projects forbids.
+            if (project.path == ":") {
+              service.get().settingsConfigurations
+            } else {
+              emptyList()
+            }
           val buildscriptConfigurations =
-            project.buildscript.configurations
-              .toList()
+            (project.buildscript.configurations.toList() + settingsConfigurations)
               .filter { it.isCanBeResolved }
 
           PartialResult(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
@@ -1,0 +1,297 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/367')
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/720')
+final class SettingsClasspathSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    testProjectDir.newFile('build.gradle') << ''
+  }
+
+  private void settings(String body) {
+    testProjectDir.newFile('settings.gradle') << body.stripIndent()
+  }
+
+  private def run(String... arguments) {
+    return runner(arguments).build()
+  }
+
+  private def runOn(String gradleVersion, String... arguments) {
+    return runner(arguments).withGradleVersion(gradleVersion).build()
+  }
+
+  private GradleRunner runner(String... arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(['dependencyUpdates'] + arguments.toList())
+      .withPluginClasspath()
+  }
+
+  def 'Reports the dependencies of the settings buildscript'() {
+    given:
+    settings(
+      """
+        buildscript {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+
+          dependencies {
+            classpath 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+  }
+
+  def 'Reports the plugins the settings script declares'() {
+    given:
+    settings(
+      """
+        pluginManagement {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+          id 'com.example.settings-demo' version '1.0' apply false
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+  }
+
+  // Gradle 9 requires JVM 17.
+  @Requires({ jvm.java17Compatible })
+  def 'Reports the settings plugins under isolated projects on a configuration cache hit'() {
+    given:
+    settings(
+      """
+        pluginManagement {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+          id 'com.example.settings-demo' version '1.0' apply false
+        }
+      """)
+    def arguments = ['-Dorg.gradle.isolated-projects=true', '--configuration-cache'] as String[]
+    def expected =
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]'
+
+    when:
+    def stored = runOn('9.7.0-rc-1', arguments)
+
+    then:
+    stored.task(':dependencyUpdates').outcome == SUCCESS
+    stored.output.contains('Configuration cache entry stored')
+    stored.output.contains(expected)
+
+    when:
+    def hit = runOn('9.7.0-rc-1', arguments)
+
+    then:
+    hit.task(':dependencyUpdates').outcome == SUCCESS
+    hit.output.contains('Configuration cache entry reused')
+    hit.output.contains(expected)
+  }
+
+  def 'Reports the settings plugins once in a multi-project build'() {
+    given:
+    settings(
+      """
+        pluginManagement {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+          id 'com.example.settings-demo' version '1.0' apply false
+        }
+
+        include 'app'
+      """)
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    // Held by the settings, not by any project, so the accumulator reports it exactly once.
+    result.output.count(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]') == 1
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/533')
+  def 'Reports the merged result without a root build script'() {
+    given:
+    new File(testProjectDir.root, 'build.gradle').delete()
+    settings(
+      """
+        pluginManagement {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+          id 'com.example.settings-demo' version '1.0' apply false
+        }
+
+        include 'app'
+      """)
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+  }
+
+  def 'Does not report a plugin pinned in pluginManagement but never applied'() {
+    given:
+    settings(
+      """
+        pluginManagement {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+
+          plugins {
+            id 'com.example.settings-demo' version '1.0'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // A pin is a constraint on whoever applies the plugin, not an applied plugin, so it never
+    // reaches the settings classpath and reporting it would claim a dependency the build lacks.
+    !result.output.contains('com.example.settings-demo')
+  }
+
+  def 'Reports nothing from the settings when the plugin is applied to the project only'() {
+    given:
+    settings(
+      """
+        buildscript {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+
+          dependencies {
+            classpath 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+          }
+        }
+      """)
+    new File(testProjectDir.root, 'build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.example.settings-demo')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -8,6 +8,7 @@ import org.junit.rules.TemporaryFolder
 import spock.lang.Issue
 import spock.lang.Requires
 import spock.lang.Specification
+import spock.lang.Unroll
 
 // Gradle 9 requires JVM 17.
 @Requires({ jvm.java17Compatible })
@@ -68,10 +69,14 @@ final class SettingsPluginAggregationSpec extends Specification {
   }
 
   private def run(List<String> arguments) {
+    return runWith([':dependencyUpdates'] + arguments)
+  }
+
+  private def runWith(List<String> arguments) {
     return GradleRunner.create()
       .withGradleVersion('9.7.0-rc-1')
       .withProjectDir(testProjectDir.root)
-      .withArguments([':dependencyUpdates'] + arguments)
+      .withArguments(arguments)
       .withPluginClasspath()
       .build()
   }
@@ -146,18 +151,41 @@ final class SettingsPluginAggregationSpec extends Specification {
     settingsApplying(true)
 
     when:
-    def result = GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
-      .withProjectDir(testProjectDir.root)
-      .withArguments(['dependencyUpdates'] + ISOLATED)
-      .withPluginClasspath()
-      .build()
+    def result = runWith(['dependencyUpdates'] + ISOLATED)
 
     then:
     // Only the root has the reporting task, so the bare name runs one task and one merged report.
     result.tasks.findAll { it.path.endsWith(':dependencyUpdates') }*.path == [':dependencyUpdates']
     result.output.count('com.google.inject:guice [2.0 -> 3.1]') == 1
     !result.output.contains('The dependency updates report is missing')
+  }
+
+  @Unroll
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1006')
+  def 'Aggregates every project with configure on demand when invoked #invocation'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+    // An included build computes the task graph while the aggregate's configuration is still being
+    // set up, which is what configure on demand then resolves too early. Single threaded, which a
+    // root-only application survives: every project has a producer here, so there is no ordering
+    // left that hides it.
+    testProjectDir.newFolder('included')
+    new File(testProjectDir.root, 'included/settings.gradle').text = ''
+    new File(testProjectDir.root, 'included/build.gradle').text = ''
+    new File(testProjectDir.root, 'settings.gradle') << "includeBuild 'included'\n"
+
+    when:
+    def result = runWith([invocation, '--configure-on-demand', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('The dependency updates report is missing')
+
+    where:
+    invocation << [':dependencyUpdates', 'dependencyUpdates']
   }
 
   def 'Applies once when a project also applies the plugin itself'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -1,0 +1,182 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+
+// Gradle 9 requires JVM 17.
+@Requires({ jvm.java17Compatible })
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/948')
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/666')
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/533')
+final class SettingsPluginAggregationSpec extends Specification {
+  private static final List<String> ISOLATED =
+    ['-Dorg.gradle.isolated-projects=true', '--configuration-cache']
+
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFolder('lib')
+  }
+
+  /** Writes the build, applying the versions plugin to the named projects. */
+  private void createBuild(List<String> appliedTo) {
+    write('build.gradle', appliedTo.contains(':'), null)
+    write('app/build.gradle', appliedTo.contains(':app'), 'com.google.inject:guice:2.0')
+    write('lib/build.gradle', appliedTo.contains(':lib'), 'com.google.guava:guava:15.0')
+  }
+
+  private void write(String path, boolean applied, String dependency) {
+    def plugins = dependency == null ? [] : ['java']
+    if (applied) {
+      plugins += 'io.github.ben-manes.versions'
+    }
+    new File(testProjectDir.root, path).text =
+      """
+        plugins {
+          ${plugins.collect { "id '${it}'" }.join('\n  ')}
+        }
+      """.stripIndent()
+    if (dependency != null) {
+      new File(testProjectDir.root, path) <<
+        """
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+
+          dependencies {
+            implementation '${dependency}'
+          }
+        """.stripIndent()
+    }
+  }
+
+  private void settingsApplying(boolean applied) {
+    new File(testProjectDir.root, 'settings.gradle').text =
+      (applied ? "plugins {\n  id 'io.github.ben-manes.versions.settings'\n}\n\n" : '') +
+        "include 'app', 'lib'\n"
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withGradleVersion('9.7.0-rc-1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments([':dependencyUpdates'] + arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Aggregates every project when applied once from settings with isolated projects'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+
+    when:
+    def result = run(ISOLATED)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    // The project plugin cannot register a producer in a project that does not apply it, so a
+    // root-only project application omits the subprojects and warns. Applying from the settings
+    // reaches every project, so the report is complete without asking the user to.
+    !result.output.contains('The dependency updates report is missing')
+  }
+
+  def 'Reports the latest versions on a configuration cache hit with isolated projects'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+
+    when:
+    def stored = run(ISOLATED + ['--parallel'])
+
+    then:
+    stored.task(':dependencyUpdates').outcome == SUCCESS
+    stored.output.contains('Configuration cache entry stored')
+
+    when:
+    def hit = run(ISOLATED + ['--parallel'])
+
+    then:
+    hit.task(':dependencyUpdates').outcome == SUCCESS
+    hit.output.contains('Configuration cache entry reused')
+    hit.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    hit.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+  }
+
+  def 'Reports the same as applying the plugin to each project'() {
+    given:
+    createBuild([':', ':app', ':lib'])
+    settingsApplying(false)
+
+    when:
+    run(['-DoutputFormatter=json'])
+    def fromProjects = report()
+
+    then:
+    fromProjects.contains('com.google.inject')
+    fromProjects.contains('com.google.guava')
+
+    when:
+    createBuild([])
+    settingsApplying(true)
+    new File(testProjectDir.root, 'build/dependencyUpdates/report.json').delete()
+    run(['-DoutputFormatter=json'])
+    def fromSettings = report()
+
+    then:
+    fromSettings == fromProjects
+  }
+
+  def 'Reports once from the root when invoked by name'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion('9.7.0-rc-1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments(['dependencyUpdates'] + ISOLATED)
+      .withPluginClasspath()
+      .build()
+
+    then:
+    // Only the root has the reporting task, so the bare name runs one task and one merged report.
+    result.tasks.findAll { it.path.endsWith(':dependencyUpdates') }*.path == [':dependencyUpdates']
+    result.output.count('com.google.inject:guice [2.0 -> 3.1]') == 1
+    !result.output.contains('The dependency updates report is missing')
+  }
+
+  def 'Applies once when a project also applies the plugin itself'() {
+    given:
+    createBuild([':app'])
+    settingsApplying(true)
+
+    when:
+    def result = run(ISOLATED)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('The dependency updates report is missing')
+    // A second producer for the project would report its modules twice.
+    result.output.count('com.google.inject:guice [2.0 -> 3.1]') == 1
+  }
+
+  private String report() {
+    return new File(testProjectDir.root, 'build/dependencyUpdates/report.json').text
+  }
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/settings-demo/com.example.settings-demo.gradle.plugin/1.0/com.example.settings-demo.gradle.plugin-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/settings-demo/com.example.settings-demo.gradle.plugin/1.0/com.example.settings-demo.gradle.plugin-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.settings-demo</groupId>
+  <artifactId>com.example.settings-demo.gradle.plugin</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Example Settings Plugin Marker</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/settings-demo/com.example.settings-demo.gradle.plugin/2.0/com.example.settings-demo.gradle.plugin-2.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/settings-demo/com.example.settings-demo.gradle.plugin/2.0/com.example.settings-demo.gradle.plugin-2.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.settings-demo</groupId>
+  <artifactId>com.example.settings-demo.gradle.plugin</artifactId>
+  <version>2.0</version>
+  <packaging>pom</packaging>
+  <name>Example Settings Plugin Marker</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/settings-demo/com.example.settings-demo.gradle.plugin/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/settings-demo/com.example.settings-demo.gradle.plugin/maven-metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata modelVersion="1.1.0">
+  <groupId>com.example.settings-demo</groupId>
+  <artifactId>com.example.settings-demo.gradle.plugin</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,5 @@ PLUGIN_LEGACY_NAME=com.github.ben-manes.versions
 PLUGIN_LEGACY_NAME_CLASS=com.github.benmanes.gradle.versions.LegacyVersionsPlugin
 PLUGIN_CONTRIBUTOR_NAME=io.github.ben-manes.versions.contributor
 PLUGIN_CONTRIBUTOR_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsContributorPlugin
+PLUGIN_SETTINGS_NAME=io.github.ben-manes.versions.settings
+PLUGIN_SETTINGS_NAME_CLASS=com.github.benmanes.gradle.versions.VersionsSettingsPlugin


### PR DESCRIPTION
Fixes #367, and closes #720 as a duplicate of it. Also fixes #533.

I tried a spike of a settings plugin for #367. Built on top of #994/#995, it worked out better than I expected.

This PR adds a new `io.github.ben-manes.versions.settings` plugin. Applied once in the settings script, it covers every project of the build. The root receives the `dependencyUpdates` task, and every other project contributes to it through the contributor plugin from #995. Invoking `dependencyUpdates` by name still runs one task and writes one merged report. No root build script is required (#533), and isolated projects needs no per-project convention wiring. It also reports the versions of the plugins the settings script itself declares (#367), which needed no new resolution machinery.

One note on build classpath pollution: a settings plugin puts itself and its dependencies (OkHttp, Moshi, and the Kotlin standard library) on the classpath of every build script in the build. To minimize the impact, only the Gradle API and the standard library execute in settings scope: settings evaluation records the settings classpath unresolved and hands it to the root project's task through the plugin's existing build service, so OkHttp and Moshi never load there. I considered resolving those dependencies at task execution instead, the way the code-quality plugins keep tool classpaths off the build script, but that would restructure the whole plugin and make every build's repositories responsible for serving them. So the dependencies ride the settings classpath as unloaded bytes, and the residual risk is a version conflict with another settings plugin wanting different versions. If that ever materializes, the durable fix is shading them into the jar under relocated packages, which is how the major settings plugins avoid the problem.

I've tested this out in a few projects I have, one of which is a somewhat involved composite build of a Gradle plugin. This uncovered #1004 and #1006, both now fixed in master.

I restructured the [README](https://github.com/ianbrandt/gradle-versions-plugin/blob/1ef973282a4426bf004c775c777a89631d428baa/README.md) to recommend the settings plugin as the standard approach. Root and per-project application moves to an "Other ways to apply the plugin" section. I tested those approaches against these changes via my three test projects, and all continue to work as expected. I also took a stab at an overall update of the README to make it current and hopefully more helpful to Gradle users of all skill levels.

The composite-build section now also shows the lifecycle-task fan-out for reporting on every included build in one invocation, since a report cannot span builds.

I added a "Migrating from prior versions" section that covers the user-facing changes from v0.54.0 and earlier, to v0.55.0 (still pending portal publication per #997), to what this PR would entail if merged and released as a new version.

Speaking of releasing, would you ever want to cut a v1.0.0, and possibly also adopt [SemVer](https://semver.org)? I don't have a strong preference myself, so that's not meant as a request or suggestion; I just wanted to ask the question before barrelling ahead with a v0.56.0.

If we do merge and release this, I believe the new plugin ID will trigger a manual Gradle Plugin Portal review. I learned my lesson with v0.55.0, and would delay creating the GitHub release until the publication is complete.
