### PR TITLE
fix: resolve candidate on a Groovy rejectVersionIf closure (fixes #1009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ def isNonStable = { String version ->
 You can then configure [Component Selection Rules][component_selection_rules].
 The current version of a component can be retrieved with the `currentVersion` property.
 You can either use the simplified syntax `rejectVersionIf { ... }` or configure a complete resolution strategy.
+Multiple registrations compose, so a candidate is rejected if any registered filter rejects it.
 
 
 <details open>

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -44,11 +44,16 @@ class DependencyStatus {
       unresolved?.let { dependency ->
         val selector = dependency.attempted as ModuleComponentSelector
         val failure = dependency.failure
+        val reason =
+          generateSequence(failure) { it.cause }
+            .take(MAX_FAILURE_CAUSES)
+            .map { it.message ?: it.toString() }
+            .joinToString(separator = "; ")
         UnresolvedInfo(
           selector.group,
           selector.module,
           selector.version,
-          failure.message ?: failure.toString(),
+          reason,
         )
       }
     return PartialStatus(
@@ -60,5 +65,10 @@ class DependencyStatus {
       projectUrl,
       info,
     )
+  }
+
+  private companion object {
+    /** Guards against a cause chain that cycles back on itself. */
+    const val MAX_FAILURE_CAUSES = 20
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -250,12 +250,23 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   }
 
   /**
-   * Sets the [resolutionStrategy] to the provided strategy.
+   * Accumulates the provided strategy with any previously registered one, or clears every
+   * previously registered strategy when called with no argument.
    *
    * @param resolutionStrategy the resolution strategy
    */
+  @JvmOverloads
   fun resolutionStrategy(resolutionStrategy: Action<in ResolutionStrategyWithCurrent>? = null) {
-    parameters.resolutionStrategy = resolutionStrategy
+    val existing = parameters.resolutionStrategy
+    parameters.resolutionStrategy =
+      if (resolutionStrategy == null || existing == null) {
+        resolutionStrategy
+      } else {
+        Action<ResolutionStrategyWithCurrent> { current ->
+          existing.execute(current)
+          resolutionStrategy.execute(current)
+        }
+      }
     parameters.resolutionStrategySet = true
     this.resolutionStrategy = null
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -7,6 +7,7 @@ import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentF
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import groovy.lang.Closure
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
@@ -231,6 +232,21 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
         )
       }
     }
+  }
+
+  /**
+   * Registers a Groovy [closure] as the reject filter, resolving `candidate` against the
+   * selection whether the closure uses the bare implicit receiver or an explicit parameter.
+   */
+  fun rejectVersionIf(closure: Closure<*>) {
+    rejectVersionIf(
+      ComponentFilter { current ->
+        // Selections are evaluated concurrently, so give each its own copy to set the delegate on.
+        val invocation = closure.clone() as Closure<*>
+        invocation.delegate = current
+        DefaultTypeTransformation.castToBoolean(invocation.call(current))
+      },
+    )
   }
 
   /**

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -70,6 +70,32 @@ final class KotlinDslUsageSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  def 'rejectVersionIf binds to the ComponentFilter overload from kotlin-dsl'() {
+    given:
+    buildFile << '''
+      tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+          checkForGradleUpdate = true
+          outputFormatter = "json"
+          outputDir = "build/dependencyUpdates"
+          reportfileName = "report"
+          rejectVersionIf {
+            candidate.version == "3.1"
+          }
+        }
+    '''
+
+    when:
+    def result = GradleRunner.create()
+      .withPluginClasspath()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .build()
+
+    then:
+    result.output.contains('''com.google.inject:guice [2.0 -> 3.0]''')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   @Unroll
   def "user friendly kotlin-dsl with #outputFormatter produces #expectedOutput"() {
     given:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/RejectVersionIfSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/RejectVersionIfSpec.groovy
@@ -1,4 +1,4 @@
-package com.github.benmanes.gradle.versions.updates
+package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/RejectVersionIfSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/RejectVersionIfSpec.groovy
@@ -356,4 +356,23 @@ final class RejectVersionIfSpec extends Specification {
     closureState.startsWith("${Closure.OWNER_FIRST}|")
     !closureState.contains('ComponentSelectionWithCurrent')
   }
+
+  def 'an unresolved dependency reports the cause that failed it'() {
+    given: 'a filter that throws, which Gradle reports as an unresolved dependency'
+    buildFile = writeBuildFile('candidate.version == noSuchProperty')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then: 'the reason names the failing rule instead of stopping at the resolution failure'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.unresolved.dependencies*.name == ['guava']
+    report.unresolved.dependencies[0].reason.contains('Could not resolve com.google.guava:guava')
+    report.unresolved.dependencies[0].reason.contains('noSuchProperty')
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/updates/RejectVersionIfSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/updates/RejectVersionIfSpec.groovy
@@ -1,0 +1,178 @@
+package com.github.benmanes.gradle.versions.updates
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A Groovy {@code rejectVersionIf} closure using the bare implicit-receiver form (plain
+ * {@code candidate}, no closure parameter) must resolve {@code candidate} against the
+ * selection rather than throwing {@code MissingPropertyException}, which otherwise fails every
+ * dependency's version query and empties the whole report.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1009')
+final class RejectVersionIfSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private File buildFile
+  private List<File> pluginClasspath
+  private String reportFolder
+  private String classpathString
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    def pluginClasspathResource = getClass().classLoader.getResource("plugin-classpath.txt")
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        "Did not find plugin classpath resource, run `testClasses` build task.")
+    }
+
+    pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+    classpathString = pluginClasspath
+      .collect { it.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { "'$it'" }
+      .join(", ")
+    reportFolder = "${testProjectDir.root.path.replaceAll("\\\\", '/')}/build/dependencyUpdates"
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private File writeBuildFile(String rejectVersionIfBody) {
+    return writeScript(
+      """
+        tasks.named('dependencyUpdates').configure {
+          outputFormatter = 'json'
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            $rejectVersionIfBody
+          }
+        }
+        """)
+  }
+
+  private File writeScript(String body) {
+    def file = testProjectDir.newFile('build.gradle')
+    file <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+
+        $body
+        """.stripIndent()
+    return file
+  }
+
+  def 'bare implicit receiver form resolves candidate without emptying the report'() {
+    given:
+    buildFile = writeBuildFile("candidate.version.toLowerCase().contains('-zzz')")
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.outdated.dependencies*.name == ['guava']
+    report.outdated.dependencies[0].available.milestone == '16.0-rc1'
+    report.unresolved.dependencies.isEmpty()
+  }
+
+  def 'explicit parameter form continues to resolve candidate'() {
+    given:
+    buildFile = writeBuildFile("s -> s.candidate.version.toLowerCase().contains('-zzz')")
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.outdated.dependencies*.name == ['guava']
+    report.outdated.dependencies[0].available.milestone == '16.0-rc1'
+    report.unresolved.dependencies.isEmpty()
+  }
+
+  def 'a build script property is not shadowed by a selection property of the same name'() {
+    given:
+    buildFile = writeScript('''
+      ext.currentVersion = '16.0-rc1'
+
+      tasks.named('dependencyUpdates').configure {
+        outputFormatter = 'json'
+        checkForGradleUpdate = false
+        rejectVersionIf {
+          candidate.version == currentVersion
+        }
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then: 'the script property wins, so the only upgrade is rejected'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.outdated.dependencies.isEmpty()
+    report.current.dependencies*.name == ['guava']
+  }
+
+  def 'the closure supplied by the build script is left unmodified'() {
+    given:
+    buildFile = writeScript('''
+      def filter = { candidate.version.toLowerCase().contains('-zzz') }
+
+      tasks.named('dependencyUpdates').configure {
+        outputFormatter = 'json'
+        checkForGradleUpdate = false
+        rejectVersionIf filter
+        doLast {
+          file('closure-state.txt').text = "${filter.resolveStrategy}|${filter.delegate.getClass().name}"
+        }
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def closureState = new File(testProjectDir.root, 'closure-state.txt').text
+
+    then: 'each selection gets its own copy, so concurrent evaluation cannot tear'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    closureState.startsWith("${Closure.OWNER_FIRST}|")
+    !closureState.contains('ComponentSelectionWithCurrent')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/updates/RejectVersionIfSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/updates/RejectVersionIfSpec.groovy
@@ -147,6 +147,187 @@ final class RejectVersionIfSpec extends Specification {
     report.current.dependencies*.name == ['guava']
   }
 
+  def 'two rejectVersionIf calls both apply'() {
+    given: 'each filter targets a different dependency, so either alone leaves the other unfiltered'
+    buildFile = writeScript('''
+      dependencies {
+        implementation 'com.google.inject:guice:2.0'
+      }
+
+      tasks.named('dependencyUpdates').configure {
+        outputFormatter = 'json'
+        checkForGradleUpdate = false
+        rejectVersionIf {
+          candidate.version == '16.0-rc1'
+        }
+        rejectVersionIf {
+          candidate.version == '3.1'
+        }
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then: 'guava has no update (its only candidate was rejected) and guice stops at 3.0'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.current.dependencies*.name == ['guava']
+    report.outdated.dependencies*.name == ['guice']
+    report.outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  def 'rejectVersionIf then resolutionStrategy both apply'() {
+    given:
+    buildFile = writeScript('''
+      dependencies {
+        implementation 'com.google.inject:guice:2.0'
+      }
+
+      tasks.named('dependencyUpdates').configure {
+        outputFormatter = 'json'
+        checkForGradleUpdate = false
+        rejectVersionIf {
+          candidate.version == '16.0-rc1'
+        }
+        resolutionStrategy {
+          componentSelection {
+            all {
+              if (candidate.version == '3.1') {
+                reject('rejected by componentSelection')
+              }
+            }
+          }
+        }
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then: 'the rejectVersionIf filter and the componentSelection rule both took effect'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.current.dependencies*.name == ['guava']
+    report.outdated.dependencies*.name == ['guice']
+    report.outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  def 'resolutionStrategy then rejectVersionIf both apply'() {
+    given:
+    buildFile = writeScript('''
+      dependencies {
+        implementation 'com.google.inject:guice:2.0'
+      }
+
+      tasks.named('dependencyUpdates').configure {
+        outputFormatter = 'json'
+        checkForGradleUpdate = false
+        resolutionStrategy {
+          componentSelection {
+            all {
+              if (candidate.version == '3.1') {
+                reject('rejected by componentSelection')
+              }
+            }
+          }
+        }
+        rejectVersionIf {
+          candidate.version == '16.0-rc1'
+        }
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then: 'the componentSelection rule and the rejectVersionIf filter both took effect'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.current.dependencies*.name == ['guava']
+    report.outdated.dependencies*.name == ['guice']
+    report.outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  def 'resolutionStrategy with no argument clears a previously registered rejectVersionIf'() {
+    given:
+    buildFile = writeScript('''
+      dependencies {
+        implementation 'com.google.inject:guice:2.0'
+      }
+
+      tasks.named('dependencyUpdates').configure {
+        rejectVersionIf {
+          candidate.version == '3.1'
+        }
+        resolutionStrategy()
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the reset escape hatch wins, so nothing is rejected'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  def 'the deprecated resolutionStrategy property assignment replaces a previously registered rejectVersionIf'() {
+    given: 'the rejectVersionIf filter targets guava, so a survived guava rejection would prove it was clobbered'
+    buildFile = writeScript('''
+      dependencies {
+        implementation 'com.google.inject:guice:2.0'
+      }
+
+      tasks.named('dependencyUpdates').configure {
+        outputFormatter = 'json'
+        checkForGradleUpdate = false
+        rejectVersionIf {
+          candidate.version == '16.0-rc1'
+        }
+        resolutionStrategy = {
+          componentSelection {
+            all {
+              if (candidate.version == '3.1') {
+                reject('rejected by componentSelection')
+              }
+            }
+          }
+        }
+      }
+      ''')
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    def report = new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+
+    then: 'the assignment replaced the guava filter rather than composing with it, so guava is outdated again'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    report.outdated.dependencies*.name.sort() == ['guava', 'guice']
+    report.outdated.dependencies.find { it.name == 'guava' }.available.milestone == '16.0-rc1'
+    report.outdated.dependencies.find { it.name == 'guice' }.available.milestone == '3.0'
+  }
+
   def 'the closure supplied by the build script is left unmodified'() {
     given:
     buildFile = writeScript('''


### PR DESCRIPTION
Fixes #1009.

Groovy coerced the closure to the `ComponentFilter` SAM without setting a delegate, so a bare `candidate` threw `MissingPropertyException` once per selection and left every dependency unresolved. A `Closure` overload of `rejectVersionIf` sets the delegate, mirroring `ComponentSelectionRulesWithCurrent.all(Closure)`. Each selection gets its own copy of the closure rather than sharing one: selections are evaluated concurrently, and mutating a single instance's delegate lets one rule read another module's candidate. Leaving the resolve strategy at Groovy's default `OWNER_FIRST` is what keeps a build script's own property from being shadowed by a selection property of the same name, which matters for the README's Example 2 shape where `currentVersion` appears on both.

The second commit is why the first one took so long to find. An unresolved dependency reported only the top-level `Could not resolve com.google.guava:guava:+.`, dropping the cause chain that names the rule that actually failed; it now reports the whole chain, bounded in case a chain cycles. A filter referencing an undefined property is the regression fixture: the reported reason has to name that property, not stop at the resolution failure.

The third commit is a behavior change, and it is separable if you would rather not take it. `resolutionStrategy(Action)` assigned rather than accumulated, so every registration silently discarded the previous one. That is why `examples/groovy` never caught any of this: its two `rejectVersionIf` closures are dead code, clobbered by the trailing `resolutionStrategy` block, and the README's own note points contributors at that file to verify a snippet ("Always modify first examples/groovy and make sure that it works"). Instrumenting all three registrations with marker files, only the third fires.

Three ways to resolve it seemed reasonable:

1. Accumulate, so a candidate is rejected if any registered filter rejects it.
2. Keep replacing and document it.
3. Keep replacing but warn on a second registration.

I went with accumulate for ease of use. Option 2 leaves a footgun with no signal: a convention plugin registers a filter, a build script adds its own, and the first one vanishes silently. Option 3 removes the silence but still makes the user choose one filter and restructure to combine them, and it would fire on `examples/groovy` as written. Accumulate is the only one where every filter a user wrote has an effect, and it matches Gradle's own convention that rule registration is additive, which is what someone writing a second `rejectVersionIf` already expects. The tradeoff is honest to state: accumulate can only ever reject more, so it hides more updates rather than fewer. A no-argument `resolutionStrategy()` remains the reset, and the deprecated `resolutionStrategy = { ... }` property still replaces, since that is what the assignment operator says.

`examples/groovy` is unchanged and its output is byte-identical, because today's real versions already satisfy the strictest of its three filters; the marker-file probe is what shows all three now running.

`RejectVersionIfSpec` covers the bare implicit-receiver form, the explicit-parameter form, a build script property colliding with a selection property, the closure coming back unmodified, two filters accumulating, a filter composing with a full `resolutionStrategy` in both orders, the no-argument reset, the property assignment still replacing, and the cause chain surviving into the report. The first fails on master; the delegate-copy and shadowing cases fail against a naive delegate-mutating fix; the accumulation cases fail against plain assignment; the cause-chain case fails against the single-message reason. `KotlinDslUsageSpec` gains one test pinning that a Kotlin `rejectVersionIf` lambda still binds the `ComponentFilter` overload, since the Groovy fix adds a `Closure` one alongside it.
