### PR TITLE
Prepare the 0.56.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ben-manes
-VERSION_NAME=0.55.0
+VERSION_NAME=0.56.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps the version for the v0.56.0 release. Draft release notes below; the GitHub release waits until the new settings plugin's portal publication is confirmed.

---

* Report the plugin versions the settings script declares, from a new `io.github.ben-manes.versions.settings` plugin that reaches every project as it is evaluated (#367, #533, #720, #1008)
* Resolve `candidate` on a Groovy `rejectVersionIf` closure, which previously threw per selection and emptied the whole report (#1009, #1010)
* Accumulate resolution strategies instead of replacing them, so a second `rejectVersionIf` no longer discards the first (#1010)
* Report the whole cause chain for an unresolved dependency instead of only the top-level message (#1010)
* Resolve the aggregate results from a detached configuration, so a build that locks all of its configurations no longer locks the plugin's own (#781, #1004, #1006)
* Only override an inherited target jvm version in the query copy (#746)
* Do not inherit dependency constraints in the query copy (#802)
* Show Kotlin and Groovy examples for every README snippet

> [!NOTE]
>
> The new `io.github.ben-manes.versions.settings` plugin is now the recommended way to apply the plugin. Applied in `settings.gradle(.kts)`, it gives every project the plugin and the root project the reporting task, so `dependencyUpdates` writes one merged report for single-project and multi-project builds alike, including builds with no root build script (#533). It also reports the versions of plugins declared in the settings script's own `plugins` block (#367).
>
> The project-level `io.github.ben-manes.versions` plugin and the `io.github.ben-manes.versions.contributor` plugin for isolated projects both still work, and a build that keeps the project plugin alongside the settings plugin must request it *without* a version. See [Applying the plugin](https://github.com/ben-manes/gradle-versions-plugin#applying-the-plugin) to start fresh, or [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#v0550) to move an existing build.
