### PR TITLE
Fix: publish from the release tag rather than the default branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3


### PR DESCRIPTION
The checkout takes the default branch, so a release publishes whatever master holds at the time rather than the commit the tag names. v0.55.0 shipped from two commits past its tag that way. The expression is empty on a manual dispatch, which falls back to the dispatched ref.
