### PR TITLE
docs: document the maturityLevel rejectVersionIf recipe (#440)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,27 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 }
 ```
 
+Example 4: disallow candidates less mature than the current version, so an `-rc`
+keeps being offered `-rc` updates but never a `-beta`
+
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  val qualifiers = listOf("preview", "alpha", "beta", "m", "cr", "rc") // order is important
+  fun maturityLevel(version: String): Int {
+    val index = qualifiers.indexOfFirst {
+      version.matches(".*[.\\-]$it[.\\-\\d]*".toRegex(RegexOption.IGNORE_CASE))
+    }
+    return if (index < 0) qualifiers.size else index
+  }
+
+  rejectVersionIf {
+    maturityLevel(candidate.version) < maturityLevel(currentVersion)
+  }
+}
+```
+
 </details>
 
 <details>
@@ -374,6 +395,23 @@ tasks.named("dependencyUpdates").configure {
         }
       }
     }
+  }
+}
+```
+
+Example 4: disallow candidates less mature than the current version, so an `-rc`
+keeps being offered `-rc` updates but never a `-beta`
+
+```groovy
+tasks.named("dependencyUpdates").configure {
+  def qualifiers = ['preview', 'alpha', 'beta', 'm', 'cr', 'rc'] // order is important
+  def maturityLevel = { String version ->
+    def index = qualifiers.findIndexOf { version ==~ /(?i).*[.\-]$it[.\-\d]*/ }
+    return (index < 0) ? qualifiers.size() : index
+  }
+
+  rejectVersionIf {
+    maturityLevel(candidate.version) < maturityLevel(currentVersion)
   }
 }
 ```

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -59,6 +59,16 @@ tasks.named("dependencyUpdates").configure {
       }
     }
   }
+
+  // Example 4: disallow candidates less mature than the current version
+  def qualifiers = ['preview', 'alpha', 'beta', 'm', 'cr', 'rc'] // order is important
+  def maturityLevel = { String version ->
+    def index = qualifiers.findIndexOf { version ==~ /(?i).*[.\-]$it[.\-\d]*/ }
+    return (index < 0) ? qualifiers.size() : index
+  }
+  rejectVersionIf {
+    maturityLevel(candidate.version) < maturityLevel(currentVersion)
+  }
 }
 
 dependencies {

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -59,6 +59,18 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     }
   }
 
+  // Example 4: disallow candidates less mature than the current version
+  val qualifiers = listOf("preview", "alpha", "beta", "m", "cr", "rc") // order is important
+  fun maturityLevel(version: String): Int {
+    val index = qualifiers.indexOfFirst {
+      version.matches(".*[.\\-]$it[.\\-\\d]*".toRegex(RegexOption.IGNORE_CASE))
+    }
+    return if (index < 0) qualifiers.size else index
+  }
+  rejectVersionIf {
+    maturityLevel(candidate.version) < maturityLevel(currentVersion)
+  }
+
   // optional parameters
   checkForGradleUpdate = true
   outputFormatter = "json"


### PR DESCRIPTION
Fixes #440.

Adds the `maturityLevel` recipe to the RejectVersionsIf section as Example 4, in Kotlin and Groovy, and to `examples/kotlin` and `examples/groovy` alongside the existing three. You said yes to this in March 2023 and it never got sent, so this is also the re-confirmation—the section was reworked since, and the snippet is adapted to its current Kotlin/Groovy pair format.

It covers what the `isNonStable` examples do not: a build already on an `-rc` keeps being offered `-rc` updates but is not offered a `-beta`. The Kotlin is G00fY2's `indexOfFirst` variant and the Groovy is the community port from the same thread.
