### PR TITLE
fix: interpolate the project properties in a pom url (fixes #319, #758)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -477,7 +477,7 @@ class Resolver(
           if (artifact is ResolvedArtifactResult) {
             val file = artifact.file
             project.logger.info("Pom file for $id is $file")
-            var url = getUrlFromPom(file)
+            var url = interpolate(getUrlFromPom(file), id)
             if (!url.isNullOrEmpty()) {
               project.logger.info("Found url for $id: $url")
               return url.trim()
@@ -531,11 +531,32 @@ class Resolver(
   )
 
   companion object {
+    private val PROJECT_PROPERTY = Regex("""\$\{project\.(groupId|artifactId|version)}""")
+    private val ABSOLUTE_URL = Regex("""^[a-zA-Z][a-zA-Z0-9+.-]*://""")
+
     private fun getUrlFromPom(file: File): String? {
       val pom = XmlSlurper(false, false).parse(file)
-      val url = (pom.getProperty("url") as NodeChildren?)?.text()
-      return url
+      return (pom.getProperty("url") as NodeChildren?)?.text()
         ?: ((pom.getProperty("scm") as NodeChildren?)?.getProperty("url") as NodeChildren?)?.text()
+    }
+
+    /** Returns the url with the project properties resolved, or null if it is not usable as one. */
+    private fun interpolate(
+      url: String?,
+      id: ModuleVersionIdentifier,
+    ): String? {
+      if (url == null || !url.contains("\${")) {
+        return url
+      }
+      val resolved =
+        PROJECT_PROPERTY.replace(url) { match ->
+          when (match.groupValues[1]) {
+            "groupId" -> id.group
+            "artifactId" -> id.name
+            else -> id.version
+          }
+        }
+      return resolved.takeIf { !it.contains("\${") && ABSOLUTE_URL.containsMatchIn(it) }
     }
 
     private fun getParentFromPom(file: File): ModuleVersionIdentifier? {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -583,6 +583,78 @@ final class DependencyUpdatesSpec extends Specification {
     }
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/319')
+  def 'Project url interpolates the project properties'() {
+    given:
+    def project = ProjectBuilder.builder().withName('single').build()
+    addRepositoryTo(project)
+    project.configurations {
+      compile
+    }
+    project.dependencies {
+      compile 'com.example:interpolated-url:1.0'
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      projectUrls == [
+        ['group': 'com.example', 'name': 'interpolated-url']: 'https://example.com/com.example/interpolated-url/1.0'
+      ]
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/758')
+  def 'Project url with an unresolvable placeholder falls back to the parent pom'() {
+    given:
+    def project = ProjectBuilder.builder().withName('single').build()
+    addRepositoryTo(project)
+    project.configurations {
+      compile
+    }
+    project.dependencies {
+      compile 'com.example:unresolved-url:1.0'
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      projectUrls == [
+        ['group': 'com.example', 'name': 'unresolved-url']: 'https://example.com/parent/'
+      ]
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/319')
+  def 'Project url that interpolates to a relative path falls back to the parent pom'() {
+    given:
+    def project = ProjectBuilder.builder().withName('single').build()
+    addRepositoryTo(project)
+    project.configurations {
+      compile
+    }
+    project.dependencies {
+      compile 'com.example:bare-placeholder-url:1.0'
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      projectUrls == [
+        ['group': 'com.example', 'name': 'bare-placeholder-url']: 'https://example.com/parent/'
+      ]
+    }
+  }
+
   def 'Constructor takes gradle release channel'() {
     given:
     def project = ProjectBuilder.builder().withName('single').build()

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/bare-placeholder-url/1.0/bare-placeholder-url-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/bare-placeholder-url/1.0/bare-placeholder-url-1.0.pom
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>bare-placeholder-url</artifactId>
+  <version>1.0</version>
+  <url>${project.artifactId}</url>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/bare-placeholder-url/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/bare-placeholder-url/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>bare-placeholder-url</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/example-parent/1.0/example-parent-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/example-parent/1.0/example-parent-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>example-parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <url>https://example.com/parent/</url>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/interpolated-url/1.0/interpolated-url-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/interpolated-url/1.0/interpolated-url-1.0.pom
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>interpolated-url</artifactId>
+  <version>1.0</version>
+  <url>https://example.com/${project.groupId}/${project.artifactId}/${project.version}</url>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/interpolated-url/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/interpolated-url/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>interpolated-url</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/unresolved-url/1.0/unresolved-url-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/unresolved-url/1.0/unresolved-url-1.0.pom
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>unresolved-url</artifactId>
+  <version>1.0</version>
+  <url>${project.organization.url}#${project.artifactId}</url>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/unresolved-url/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/unresolved-url/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>unresolved-url</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Fixes #319. Fixes #758.

`getUrlFromPom` returns `<url>` verbatim, so assertj-core reports `${project.organization.url}#${project.artifactId}` as its project url and neo4j-kernel reports `http://components.neo4j.org/${project.artifactId}/${project.version}`. This interpolates `${project.groupId|artifactId|version}` from the coordinate being resolved, and treats a result that still holds a `${`, or that interpolates to something which isn't an absolute url, as absent so the existing parent-pom fallback takes over.

Across 6028 poms in my local Gradle and Maven caches, 43 interpolate cleanly, mostly `https://maven.apache.org/ref/${project.version}/`. About 20 more use a custom `<properties>` placeholder such as `${site.url}/site/${project.artifactId}`; those now inherit the parent's url instead of printing the raw string. Resolving `<properties>` as well is a straightforward follow-on if you want it.

One thing I hit and did not touch: the `?:` scm fallback in `getUrlFromPom` is unreachable, because `XmlSlurper` returns an empty `NodeChildren` rather than null for a missing element, so `.text()` is `""` and the elvis never fires. `DependencyUpdatesSpec`'s backport-util-concurrent-java12 case pins the current no-url behavior, so reviving it would be a behavior change rather than a fix.
