### PR TITLE
Do not publish a variant to a project that publishes by fallback (fixes #1022)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -4,6 +4,7 @@ import com.github.benmanes.gradle.versions.updates.resolutionstrategy.Resolution
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
@@ -170,10 +171,15 @@ internal fun registerAggregation(
 
   // Declared for every project so that computing the aggregate's dependencies configures each of
   // them, which configure on demand skips when the task is invoked by its path rather than by name.
+  // The producer's configuration is named rather than matched by its attributes, so that a project
+  // which publishes no variant is skipped instead of falling back to its `default` configuration,
+  // whose artifacts are the project's own and not a partial result to read the report from.
   for (aggregated in project.allprojects) {
     project.dependencies.add(
       AGGREGATION_CONFIGURATION,
-      project.dependencies.project(mapOf("path" to aggregated.path)),
+      project.dependencies.project(
+        mapOf("path" to aggregated.path, "configuration" to ELEMENTS_CONFIGURATION),
+      ),
     )
   }
 
@@ -263,7 +269,42 @@ private fun registerProducer(
       task.partialJson.disallowChanges()
     }
 
-  project.configurations.consumable(ELEMENTS_CONFIGURATION) { configuration ->
+  // Published once the project is configured, as whether it may carry a variant at all depends on
+  // the configurations that its plugins and build script create.
+  if (project.state.executed) {
+    publishResults(project, partial)
+  } else {
+    project.afterEvaluate { evaluated -> publishResults(evaluated, partial) }
+  }
+  return partial
+}
+
+/**
+ * Publishes the project's statuses as an outgoing variant, unless the project publishes through its
+ * `default` configuration, as one that exposes a local aar or jar file does.
+ *
+ * A project that declares no variant of its own is resolved by falling back to that configuration
+ * whatever the consumer asks for. Gradle drops the fallback as soon as the project declares any
+ * variant, so publishing one here would leave every consumer of such a project without a match. The
+ * artifacts are read rather than the variants alone, as a plugin may declare its variants from its
+ * own `afterEvaluate` and so after this runs, while a project publishes by fallback from the build
+ * script that this is ordered behind.
+ * https://github.com/ben-manes/gradle-versions-plugin/issues/1022
+ */
+private fun publishResults(
+  project: Project,
+  partial: TaskProvider<DependencyUpdatesPartialTask>,
+) {
+  val configurations = project.configurations
+  val fallback = configurations.findByName(Dependency.DEFAULT_CONFIGURATION)
+  val publishesByFallback =
+    fallback != null && fallback.isCanBeConsumed && fallback.artifacts.isNotEmpty() &&
+      configurations.none { it.isCanBeConsumed && it.attributes.keySet().isNotEmpty() }
+  if (publishesByFallback) {
+    return
+  }
+
+  configurations.consumable(ELEMENTS_CONFIGURATION) { configuration ->
     configuration.description = "The dependency update statuses of ${project.path}."
     configuration.attributes { attributes ->
       attributes.attribute(
@@ -277,7 +318,6 @@ private fun registerProducer(
     }
     configuration.outgoing.artifact(partial.flatMap { it.outputFile })
   }
-  return partial
 }
 
 /** Returns the statuses of the project's own configurations, skipping any that fail to resolve. */

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DefaultConfigurationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DefaultConfigurationSpec.groovy
@@ -1,0 +1,101 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1022')
+final class DefaultConfigurationSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+    testProjectDir.newFile('settings.gradle') << "include 'app', 'local'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+      """.stripIndent()
+
+    // Declares no variant of its own, so that a consumer resolves it through the fallback to its
+    // default configuration, as a project that exposes a local aar or jar file does.
+    testProjectDir.newFolder('local')
+    testProjectDir.newFile('local/local.jar')
+    testProjectDir.newFile('local/build.gradle') <<
+      """
+        configurations.maybeCreate('default')
+        artifacts.add('default', file('local.jar'))
+
+        group = 'com.example'
+        version = '1.0'
+      """.stripIndent()
+
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+
+        plugins {
+          id 'java-library'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation project(':local')
+          // Reported by the aggregate, and kept off the runtime classpath that resolve traverses,
+          // as the test repository publishes poms without the files to resolve them to.
+          compileOnly 'com.google.inject:guice:2.0'
+        }
+
+        // Resolves the graph, which is where the project's variant is selected, and collects the
+        // artifact it selects.
+        tasks.register('resolve') {
+          def classpath = configurations.runtimeClasspath.incoming.artifactView {
+            componentFilter { it instanceof ProjectComponentIdentifier }
+          }.files
+          doLast {
+            println "RESOLVED \${classpath.files.collect { it.name }}"
+          }
+        }
+      """.stripIndent()
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Consumes a project that publishes through its default configuration'() {
+    when:
+    def result = run([':app:resolve'])
+
+    then:
+    result.task(':app:resolve').outcome == SUCCESS
+    result.output.contains('RESOLVED [local.jar]')
+  }
+
+  def 'Aggregates a project that publishes through its default configuration'() {
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.task(':local:partialDependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('The dependency updates report is missing')
+  }
+}


### PR DESCRIPTION
Fixes #1022, a regression introduced in 0.55.0 by the aggregation feature (#948).

## The bug

A project that declares no variant of its own — the flat-file pattern below, which the reporter's build uses to swap in a local aar — is resolved by falling back to its `default` configuration whatever the consumer asks for:

```groovy
configurations.maybeCreate('default')
artifacts.add('default', file('ausweisapp.aar'))
```

Gradle drops that fallback as soon as the project declares any variant. Since 0.55.0 the plugin adds a `dependencyUpdatesElements` variant to every project, which flipped such projects into variant-aware matching and left their consumers with no match:

```
> Could not resolve project :ausweisapp.
   > No matching variant of project :ausweisapp was found. ...
      - Variant 'dependencyUpdatesElements':
          - Incompatible because this component declares a component of category 'verification'
            and the consumer needed a library
```

## The fix

Two parts, each independently necessary:

1. The variant is published once the project is configured, and only when the project does not publish through its `default` configuration. The predicate reads that configuration's own artifacts rather than the absence of other variants, so that it is not sensitive to a plugin that declares its variants from its own `afterEvaluate` — verified against AGP, whose library and application projects both keep publishing the variant.
2. The aggregate names the producer's configuration instead of matching it by attributes, so a project without one is skipped rather than resolved through its `default` configuration, whose artifacts would then be read as a partial result.

A project that is skipped is still aggregated: its producer's output is wired as a task output.

## Verification

Reproduced against the reporter's build ([Governikus/AusweisApp-SDK-Wrapper](https://github.com/Governikus/AusweisApp-SDK-Wrapper)) with `ausweisapp-2.5.4.aar` in `android/ausweisapp`: `./gradlew assembleDebug` fails on 0.56.0 with the error above and succeeds with this change. Only `:ausweisapp` skips the variant there; `:sdkwrapper`, `:tester`, and the root project all publish it.

`DefaultConfigurationSpec` covers both halves — each case fails without its corresponding part of the fix, the first with the reported `No matching variant`, the second with `dependencyUpdates` reading the local jar as a partial result.
