### PR TITLE
Apply the settings plugin from an init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
 - [Samples](#samples)
 - [Compatibility](#compatibility)
 - [Migrating from prior versions](#migrating-from-prior-versions)
+  - [v0.56.0](#v0560)
   - [v0.55.0](#v0550)
   - [v0.54.0 and earlier](#v0540-and-earlier)
 - [Related plugins](#related-plugins)
@@ -1364,14 +1365,19 @@ also gets its own `dependencyUpdates` task covering itself and its subprojects.
 
 You can also transparently add the plugin to every Gradle project that you run
 via a
-[Gradle init script](https://docs.gradle.org/current/userguide/init_scripts.html):
+[Gradle init script](https://docs.gradle.org/current/userguide/init_scripts.html).
+Apply the settings plugin from `beforeSettings`, which covers every project of
+the build and works under isolated projects (see [Isolated
+projects](#isolated-projects)). Every build that runs gets its own
+`dependencyUpdates` task, so an included build is reported without being
+modified (see [Composite builds](#composite-builds)):
 
 <details open>
 <summary>Kotlin</summary>
 
 "$HOME/.gradle/init.d/add-versions-plugin.init.gradle.kts":
 ```kotlin
-import com.github.benmanes.gradle.versions.VersionsPlugin
+import com.github.benmanes.gradle.versions.VersionsSettingsPlugin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 initscript {
@@ -1384,13 +1390,15 @@ initscript {
   }
 }
 
-allprojects {
-  apply<VersionsPlugin>()
+gradle.beforeSettings(Action<Settings> {
+  pluginManager.apply(VersionsSettingsPlugin::class.java)
+})
 
-  tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+gradle.rootProject(Action<Project> {
+  tasks.withType(DependencyUpdatesTask::class.java).configureEach {
     // configure the task, for example wrt. resolution strategies
   }
-}
+})
 ```
 
 </details>
@@ -1400,6 +1408,9 @@ allprojects {
 
 "$HOME/.gradle/init.d/add-versions-plugin.gradle":
 ```groovy
+import com.github.benmanes.gradle.versions.VersionsSettingsPlugin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
 initscript {
   repositories {
     gradlePluginPortal()
@@ -1410,16 +1421,31 @@ initscript {
   }
 }
 
-allprojects {
-  apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
+beforeSettings { settings ->
+  settings.pluginManager.apply(VersionsSettingsPlugin)
+}
 
-  tasks.named("dependencyUpdates").configure {
+gradle.rootProject {
+  tasks.withType(DependencyUpdatesTask).configureEach {
     // configure the task, for example wrt. resolution strategies
   }
 }
 ```
 
 </details>
+
+A script has no implicit import for the plugin's types, so the imports at the
+top of these snippets are required to reference them by their simple names.
+
+An init script resolves the plugin on a classpath of its own, so a build that
+applies the plugin itself holds a second copy of it. An init script reaches a
+build before the build's own scripts do, so its copy is the one that reports and
+the build's copy defers to it, which leaves such a build working as it did. For
+the same reason the plugin is absent from the
+project's own classpath, so a `plugins` block that requests it alongside an init
+script needs a version, unlike one in a build whose settings script applies the
+settings plugin (see [Other ways to apply the
+plugin](#other-ways-to-apply-the-plugin)).
 
 ## Samples
 
@@ -1449,6 +1475,15 @@ projects (see [Isolated projects](#isolated-projects)) are supported.
 Start at the subsection for the version your build is on and work upward: each
 subsection migrates to the version covered by the subsection above it, and the
 topmost migrates to the current release.
+
+### v0.56.0
+
+v0.57.0 supports applying the settings plugin from an init script:
+
+* An init script that applies `VersionsPlugin` to `allprojects` reports per
+  project rather than once, omits the plugins that the settings script declares,
+  and fails under isolated projects. Apply the settings plugin from
+  `beforeSettings` instead (see [Initialization script](#initialization-script)).
 
 ### v0.55.0
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsContributorPlugin.kt
@@ -17,6 +17,9 @@ import org.gradle.api.Project
 class VersionsContributorPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     requireMinimumGradleVersion("io.github.ben-manes.versions.contributor")
+    if (!claims(project)) {
+      return
+    }
     registerProducer(project)
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsPlugin.kt
@@ -7,6 +7,8 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.util.GradleVersion
 import org.xml.sax.SAXException
 import javax.xml.parsers.SAXParserFactory
@@ -17,6 +19,9 @@ import javax.xml.parsers.SAXParserFactory
 class VersionsPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     requireMinimumGradleVersion("io.github.ben-manes.versions")
+    if (!claims(project)) {
+      return
+    }
 
     val tasks = project.tasks
     if (!tasks.names.contains("dependencyUpdates")) {
@@ -62,3 +67,34 @@ internal fun requireMinimumGradleVersion(pluginId: String) {
     throw GradleException("Gradle 8.4 or greater is required to apply the $pluginId plugin.")
   }
 }
+
+/**
+ * Returns whether this copy of the plugin may configure [owner], which it may not if a copy loaded
+ * by another classloader already has.
+ *
+ * An init script injects the plugin from a classpath of its own, so a build that applies the plugin
+ * as well holds two copies of every class. Gradle keys the tasks, configurations, and shared
+ * services that the plugin registers by name, and the second copy would fail to cast what the first
+ * registered to its own type. The first copy configures the build and the rest defer to it, which
+ * keeps a build that applies the plugin working when an init script injects it too. The marker is
+ * held under a plain string key and compared by reference, which every copy can do without loading
+ * a type that belongs to another.
+ */
+internal fun claims(owner: ExtensionAware): Boolean {
+  val identity = VersionsPlugin::class.java.classLoader
+  val properties = owner.extensions.extraProperties
+  if (!properties.has(OWNER_PROPERTY)) {
+    properties.set(OWNER_PROPERTY, identity)
+    return true
+  }
+  if (properties.get(OWNER_PROPERTY) === identity) {
+    return true
+  }
+  Logging.getLogger(VersionsPlugin::class.java).info(
+    "Another copy of the gradle-versions-plugin already configures {}, so this one is ignored.",
+    owner,
+  )
+  return false
+}
+
+private const val OWNER_PROPERTY = "com.github.benmanes.gradle.versions.owner"

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsSettingsPlugin.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/VersionsSettingsPlugin.kt
@@ -12,6 +12,9 @@ import org.gradle.api.initialization.Settings
 class VersionsSettingsPlugin : Plugin<Settings> {
   override fun apply(settings: Settings) {
     requireMinimumGradleVersion("io.github.ben-manes.versions.settings")
+    if (!claims(settings)) {
+      return
+    }
 
     // The settings script's classpath carries the versions of the plugins that its own plugins
     // block declares, which no project's buildscript does.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -1,5 +1,6 @@
 package com.github.benmanes.gradle.versions.updates
 
+import com.github.benmanes.gradle.versions.claims
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -188,8 +189,14 @@ internal fun registerAggregation(
     // The results are wired as task outputs too, as module conflict resolution would otherwise drop
     // every project that shares a group and name with a sibling from the artifacts.
     project.allprojects { aggregated ->
-      val partial = registerProducer(aggregated, service)
-      accumulator.configure { task -> task.partialResults.from(partial.flatMap { it.outputFile }) }
+      // A project that another copy of the plugin claimed holds a producer of that copy's type,
+      // which this one cannot wire to its accumulator. That copy reports the project instead.
+      if (claims(aggregated)) {
+        val partial = registerProducer(aggregated, service)
+        accumulator.configure { task ->
+          task.partialResults.from(partial.flatMap { it.outputFile })
+        }
+      }
     }
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
@@ -1,0 +1,199 @@
+package com.github.benmanes.gradle.versions
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+
+/**
+ * An init script injects the plugin into every build, so it reaches builds that apply the plugin
+ * themselves. The init script's classpath is a separate classloader from the build's, which gives
+ * the same class two identities, and Gradle keys the tasks, configurations, and shared services
+ * that the plugin registers by name.
+ */
+// Gradle 9 requires JVM 17.
+@Requires({ jvm.java17Compatible })
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1023')
+final class InitScriptAggregationSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  @Rule final TemporaryFolder initScriptDir = new TemporaryFolder()
+  private String mavenRepoUrl
+  private File initScript
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+
+    // Copied rather than read from the classpath that withPluginClasspath injects, so that the two
+    // classpaths do not share a classloader, as an init script resolving the plugin for itself does
+    // not share one with the build that applies it.
+    def classpath = GradleRunner.create().withPluginClasspath().pluginClasspath
+      .findAll { it.exists() }
+      .collect { copyOf(it) }
+      .collect { "'${it.absolutePath.replace('\\', '/')}'" }
+      .join(', ')
+    initScript = initScriptDir.newFile('versions.init.gradle')
+    initScript <<
+      """
+        initscript {
+          dependencies {
+            classpath files(${classpath})
+          }
+        }
+
+        beforeSettings { settings ->
+          settings.pluginManager.apply(com.github.benmanes.gradle.versions.VersionsSettingsPlugin)
+        }
+      """.stripIndent()
+
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        plugins {
+          id 'java'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+  }
+
+  /** Returns a copy of the classpath entry, which may be a jar or a directory of classes. */
+  private File copyOf(File entry) {
+    def target = new File(initScriptDir.newFolder(), entry.name)
+    Path source = entry.toPath()
+    if (entry.directory) {
+      Files.walk(source).withCloseable { paths ->
+        paths.forEach { path ->
+          def destination = target.toPath().resolve(source.relativize(path))
+          if (Files.isDirectory(path)) {
+            Files.createDirectories(destination)
+          } else {
+            Files.createDirectories(destination.parent)
+            Files.copy(path, destination, REPLACE_EXISTING)
+          }
+        }
+      }
+    } else {
+      Files.copy(source, target.toPath(), REPLACE_EXISTING)
+    }
+    return target
+  }
+
+  private def run(String... arguments) {
+    return GradleRunner.create()
+      .withGradleVersion('9.7.0-rc-1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Reports every project when only the init script applies the plugin'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+
+    when:
+    def result = run('dependencyUpdates', '--init-script', initScript.absolutePath)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('The dependency updates report is missing')
+  }
+
+  def 'Reports when the settings script applies the plugin the init script already applied'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+
+          dependencies {
+            classpath 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+        }
+
+        include 'app'
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '--init-script', initScript.absolutePath)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    // The copy that defers no longer publishes the settings classpath, so the copy that claimed the
+    // build must still see what the settings script declared after its own beforeSettings ran.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/367
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    !result.output.contains('The dependency updates report is missing')
+  }
+
+  def 'Reports when a project applies the contributor plugin the init script already applied'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+    new File(testProjectDir.root, 'app/build.gradle').text =
+      """
+        plugins {
+          id 'java'
+          id 'io.github.ben-manes.versions.contributor'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '--init-script', initScript.absolutePath)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('The dependency updates report is missing')
+  }
+
+  def 'Reports under isolated projects when only the init script applies the plugin'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+
+    when:
+    def result = run('dependencyUpdates', '--init-script', initScript.absolutePath,
+      '-Dorg.gradle.isolated-projects=true', '--configuration-cache', '--parallel')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Isolated Projects is an incubating feature.')
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('The dependency updates report is missing')
+  }
+}


### PR DESCRIPTION
Fixes #1023.

An init script that applies the settings plugin crashes on any build that applies the plugin itself, because the init script resolves the plugin on a classpath of its own and Gradle keys the tasks, configurations, and shared services that the plugin registers by name. The second copy failed to cast what the first had registered, either the parameters service or the producer task. The copy that claims a settings or project object now configures it and the rest defer to it, so injecting the plugin globally leaves those builds working.

The init script section documented the recipe that predates the settings plugin, which reports per project rather than once, omits the plugins that the settings script declares, and fails under isolated projects; it now shows the `beforeSettings` form from #1023.

The added migration note assumes this ships in "v0.57.0", and would need to be updated otherwise.
