### PR TITLE
Prepare the 0.57.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ben-manes
-VERSION_NAME=0.56.0
+VERSION_NAME=0.57.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps the version for the v0.57.0 release, motivated by the #1026 regression fix for #1022. Draft release notes below.

---

* Do not publish the `dependencyUpdatesElements` variant to a project that publishes through its `default` configuration, a [v0.55.0](https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.55.0) regression that left such a project unresolvable by its consumers (#1022, #1026)
* Apply the settings plugin from an init script, which previously crashed any build that also applies the plugin itself (#1023, #1027)
* Interpolate the project properties in a pom url, so a dependency whose `<url>` holds `${project.artifactId}` reports a real link rather than the raw placeholder, falling back to the parent pom when the result is still not an absolute url (#319, #758, #1025)
* Document the `maturityLevel` `rejectVersionIf` recipe (#440, #1024)
* Document the report entries for lazily-contributed dependencies (#1028)
* Show how a custom `outputFormatter` reaches the configuration cache (#1020)
* Publish from the release tag rather than the default branch, which had published whatever the default branch held at the time (#1019)

> [!NOTE]
>
> The [Initialization script](https://github.com/ben-manes/gradle-versions-plugin#initialization-script) recipe now applies the settings plugin from `beforeSettings`. The prior recipe, `VersionsPlugin` applied to `allprojects`, reports per project rather than once, omits the plugins the settings script declares, and fails under isolated projects. See [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#v0560).

