### PR TITLE
Skip the build workflow for README-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'README.md'
   pull_request:
     types: [ opened, labeled, unlabeled, synchronize ]
+    paths-ignore:
+      - 'README.md'
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"


### PR DESCRIPTION
A README-only commit currently runs the full three-JDK matrix: test suite,
`publishToMavenLocal`, and both example builds. Nothing that runs can fail
for anything a README edit changed.

Left `.editorconfig` triggering the build deliberately—ktlint reads it, so
an edit there can legitimately turn `ktlintCheck` red.

One thing to check on your end: if `build` is a required status check on
`master`, a skipped workflow never reports, so a README-only PR would sit
at "Expected" waiting for a status that never arrives. The usual fix is a
companion job with the same name that runs on the ignored paths and exits 0.
I'd rather add that only if you know the check is required.
