### PR TITLE
fix: honor the build's log level in the reporters (fixes #278, #388, #726)

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,10 @@ following values are supported:
 * `Closure`: will be called with the result of the dependency update analysis
   (from Kotlin, use the `outputFormatter(Action<Result>)` function instead)
 
+The console summary is printed at the lifecycle log level, so `--quiet` suppresses
+it. The report file is still written; read it, or drop `--quiet`, if a script was
+piping the console output.
+
 You can also set multiple output formats using comma as the separator:
 
 ```bash

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -14,217 +14,219 @@ import java.io.OutputStream
  * @property isInfoEnabled Whether the build already runs at the info level, so that the report does
  * not suggest enabling it.
  */
-class PlainTextReporter(
-  override val projectPath: String,
-  override val revision: String,
-  override val gradleReleaseChannel: String,
-  private val isInfoEnabled: Boolean = false,
-) : AbstractReporter(projectPath, revision, gradleReleaseChannel) {
-  @Deprecated(
-    "Use the constructor that takes the project's path.",
-    ReplaceWith("PlainTextReporter(project.path, revision, gradleReleaseChannel)"),
-  )
+class PlainTextReporter
+  @JvmOverloads
   constructor(
-    project: Project,
-    revision: String,
-    gradleReleaseChannel: String,
-  ) : this(project.path, revision, gradleReleaseChannel)
+    override val projectPath: String,
+    override val revision: String,
+    override val gradleReleaseChannel: String,
+    private val isInfoEnabled: Boolean = false,
+  ) : AbstractReporter(projectPath, revision, gradleReleaseChannel) {
+    @Deprecated(
+      "Use the constructor that takes the project's path.",
+      ReplaceWith("PlainTextReporter(project.path, revision, gradleReleaseChannel)"),
+    )
+    constructor(
+      project: Project,
+      revision: String,
+      gradleReleaseChannel: String,
+    ) : this(project.path, revision, gradleReleaseChannel)
 
-  /** Writes the report to the print stream. The stream is not automatically closed. */
-  override fun write(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    writeHeader(printStream)
-
-    if (result.count == 0) {
-      printStream.println()
-      printStream.println("No dependencies found.")
-    } else {
-      writeUpToDate(printStream, result)
-      writeExceedLatestFound(printStream, result)
-      writeUpgrades(printStream, result)
-      writeUndeclared(printStream, result)
-      writeUnresolved(printStream, result)
-    }
-
-    writeGradleUpdates(printStream, result)
-  }
-
-  override fun getFileExtension(): String {
-    return "txt"
-  }
-
-  private fun writeHeader(printStream: OutputStream) {
-    printStream.println()
-    printStream.println("------------------------------------------------------------")
-    printStream.println("$projectPath Project Dependency Updates (report to plain text file)")
-    printStream.println("------------------------------------------------------------")
-  }
-
-  private fun writeUpToDate(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    val upToDateVersions = result.current.dependencies
-    if (upToDateVersions.isNotEmpty()) {
-      printStream.println()
-      printStream.println("The following dependencies are using the latest $revision version:")
-      for (dependency in upToDateVersions) {
-        printStream.println(" - ${label(dependency)}:${dependency.version}")
-        dependency.userReason?.let {
-          printStream.println("     $it")
-        }
-      }
-    }
-  }
-
-  private fun writeExceedLatestFound(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    val downgradeVersions = result.exceeded.dependencies
-    if (downgradeVersions.isNotEmpty()) {
-      printStream.println()
-      printStream.println(
-        "The following dependencies exceed the version found at the $revision revision level:",
-      )
-      for (dependency in downgradeVersions) {
-        val currentVersion = dependency.version
-        printStream.println(" - ${label(dependency)} [$currentVersion <- ${dependency.latest}]")
-        dependency.userReason?.let {
-          printStream.println("     $it")
-        }
-        dependency.projectUrl?.let {
-          printStream.println("     $it")
-        }
-      }
-    }
-  }
-
-  private fun writeUpgrades(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    val upgradeVersions = result.outdated.dependencies
-    if (upgradeVersions.isNotEmpty()) {
-      printStream.println()
-      printStream.println("The following dependencies have later $revision versions:")
-      for (dependency in upgradeVersions) {
-        val currentVersion = dependency.version
-        printStream.println(" - ${label(dependency)} [$currentVersion -> ${dependency.available[revision]}]")
-        dependency.userReason?.let {
-          printStream.println("     $it")
-        }
-        dependency.projectUrl?.let {
-          printStream.println("     $it")
-        }
-      }
-    }
-  }
-
-  private fun writeUndeclared(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    val undeclaredVersions = result.undeclared.dependencies
-    if (undeclaredVersions.isNotEmpty()) {
-      printStream.println()
-      printStream.println(
-        "Failed to compare versions for the following dependencies because they were declared without version:",
-      )
-      for (dependency in undeclaredVersions) {
-        printStream.println(" - ${label(dependency)}")
-      }
-    }
-  }
-
-  private fun writeUnresolved(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    val unresolved = result.unresolved.dependencies
-    if (unresolved.isNotEmpty()) {
-      val hint = if (isInfoEnabled) "" else " (use --info for details)"
-      printStream.println()
-      printStream.println(
-        "Failed to determine the latest version for the following dependencies$hint:",
-      )
-      for (dependency in unresolved) {
-        printStream.println(" - " + label(dependency))
-        dependency.userReason?.let {
-          printStream.println("     $it")
-        }
-        dependency.projectUrl?.let {
-          printStream.println("     $it")
-        }
-      }
-    }
-  }
-
-  private fun writeGradleUpdates(
-    printStream: OutputStream,
-    result: Result,
-  ) {
-    if (!result.gradle.enabled) {
-      return
-    }
-
-    printStream.println()
-    printStream.println("Gradle $gradleReleaseChannel updates:")
-    // Log Gradle update checking failures.
-    if (result.gradle.current.isFailure) {
-      printStream
-        .println("[ERROR] [release channel: ${CURRENT.id}] " + result.gradle.current.reason)
-    }
-    if ((gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id) &&
-      result.gradle.releaseCandidate.isFailure
+    /** Writes the report to the print stream. The stream is not automatically closed. */
+    override fun write(
+      printStream: OutputStream,
+      result: Result,
     ) {
-      printStream
-        .println(
-          "[ERROR] [release channel: ${RELEASE_CANDIDATE.id}] " +
-            result
-              .gradle.releaseCandidate.reason,
+      writeHeader(printStream)
+
+      if (result.count == 0) {
+        printStream.println()
+        printStream.println("No dependencies found.")
+      } else {
+        writeUpToDate(printStream, result)
+        writeExceedLatestFound(printStream, result)
+        writeUpgrades(printStream, result)
+        writeUndeclared(printStream, result)
+        writeUnresolved(printStream, result)
+      }
+
+      writeGradleUpdates(printStream, result)
+    }
+
+    override fun getFileExtension(): String {
+      return "txt"
+    }
+
+    private fun writeHeader(printStream: OutputStream) {
+      printStream.println()
+      printStream.println("------------------------------------------------------------")
+      printStream.println("$projectPath Project Dependency Updates (report to plain text file)")
+      printStream.println("------------------------------------------------------------")
+    }
+
+    private fun writeUpToDate(
+      printStream: OutputStream,
+      result: Result,
+    ) {
+      val upToDateVersions = result.current.dependencies
+      if (upToDateVersions.isNotEmpty()) {
+        printStream.println()
+        printStream.println("The following dependencies are using the latest $revision version:")
+        for (dependency in upToDateVersions) {
+          printStream.println(" - ${label(dependency)}:${dependency.version}")
+          dependency.userReason?.let {
+            printStream.println("     $it")
+          }
+        }
+      }
+    }
+
+    private fun writeExceedLatestFound(
+      printStream: OutputStream,
+      result: Result,
+    ) {
+      val downgradeVersions = result.exceeded.dependencies
+      if (downgradeVersions.isNotEmpty()) {
+        printStream.println()
+        printStream.println(
+          "The following dependencies exceed the version found at the $revision revision level:",
         )
-    }
-    if (gradleReleaseChannel == NIGHTLY.id && result.gradle.nightly.isFailure) {
-      printStream
-        .println("[ERROR] [release channel: ${NIGHTLY.id}] " + result.gradle.nightly.reason)
+        for (dependency in downgradeVersions) {
+          val currentVersion = dependency.version
+          printStream.println(" - ${label(dependency)} [$currentVersion <- ${dependency.latest}]")
+          dependency.userReason?.let {
+            printStream.println("     $it")
+          }
+          dependency.projectUrl?.let {
+            printStream.println("     $it")
+          }
+        }
+      }
     }
 
-    // print Gradle updates in breadcrumb format
-    printStream.print(" - Gradle: [" + result.gradle.running.version)
-    var updatePrinted = false
-    if (result.gradle.current.isUpdateAvailable && result.gradle.current > result.gradle.running) {
-      updatePrinted = true
-      printStream.print(" -> " + result.gradle.current.version)
-    }
-    if ((gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id) &&
-      result.gradle.releaseCandidate.isUpdateAvailable &&
-      result.gradle.releaseCandidate >
-      result.gradle.current
+    private fun writeUpgrades(
+      printStream: OutputStream,
+      result: Result,
     ) {
-      updatePrinted = true
-      printStream.print(" -> " + result.gradle.releaseCandidate.version)
+      val upgradeVersions = result.outdated.dependencies
+      if (upgradeVersions.isNotEmpty()) {
+        printStream.println()
+        printStream.println("The following dependencies have later $revision versions:")
+        for (dependency in upgradeVersions) {
+          val currentVersion = dependency.version
+          printStream.println(" - ${label(dependency)} [$currentVersion -> ${dependency.available[revision]}]")
+          dependency.userReason?.let {
+            printStream.println("     $it")
+          }
+          dependency.projectUrl?.let {
+            printStream.println("     $it")
+          }
+        }
+      }
     }
-    if (gradleReleaseChannel == NIGHTLY.id &&
-      result.gradle.nightly.isUpdateAvailable &&
-      result.gradle.nightly >
-      result.gradle.current
-    ) {
-      updatePrinted = true
-      printStream.print(" -> " + result.gradle.nightly.version)
-    }
-    if (!updatePrinted) {
-      printStream.print(": UP-TO-DATE")
-    }
-    printStream.println("]")
-  }
 
-  companion object {
-    /** Returns the dependency key as a stringified label. */
-    private fun label(dependency: Dependency): String {
-      return "${dependency.group.orEmpty()}:${dependency.name}"
+    private fun writeUndeclared(
+      printStream: OutputStream,
+      result: Result,
+    ) {
+      val undeclaredVersions = result.undeclared.dependencies
+      if (undeclaredVersions.isNotEmpty()) {
+        printStream.println()
+        printStream.println(
+          "Failed to compare versions for the following dependencies because they were declared without version:",
+        )
+        for (dependency in undeclaredVersions) {
+          printStream.println(" - ${label(dependency)}")
+        }
+      }
+    }
+
+    private fun writeUnresolved(
+      printStream: OutputStream,
+      result: Result,
+    ) {
+      val unresolved = result.unresolved.dependencies
+      if (unresolved.isNotEmpty()) {
+        val hint = if (isInfoEnabled) "" else " (use --info for details)"
+        printStream.println()
+        printStream.println(
+          "Failed to determine the latest version for the following dependencies$hint:",
+        )
+        for (dependency in unresolved) {
+          printStream.println(" - " + label(dependency))
+          dependency.userReason?.let {
+            printStream.println("     $it")
+          }
+          dependency.projectUrl?.let {
+            printStream.println("     $it")
+          }
+        }
+      }
+    }
+
+    private fun writeGradleUpdates(
+      printStream: OutputStream,
+      result: Result,
+    ) {
+      if (!result.gradle.enabled) {
+        return
+      }
+
+      printStream.println()
+      printStream.println("Gradle $gradleReleaseChannel updates:")
+      // Log Gradle update checking failures.
+      if (result.gradle.current.isFailure) {
+        printStream
+          .println("[ERROR] [release channel: ${CURRENT.id}] " + result.gradle.current.reason)
+      }
+      if ((gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id) &&
+        result.gradle.releaseCandidate.isFailure
+      ) {
+        printStream
+          .println(
+            "[ERROR] [release channel: ${RELEASE_CANDIDATE.id}] " +
+              result
+                .gradle.releaseCandidate.reason,
+          )
+      }
+      if (gradleReleaseChannel == NIGHTLY.id && result.gradle.nightly.isFailure) {
+        printStream
+          .println("[ERROR] [release channel: ${NIGHTLY.id}] " + result.gradle.nightly.reason)
+      }
+
+      // print Gradle updates in breadcrumb format
+      printStream.print(" - Gradle: [" + result.gradle.running.version)
+      var updatePrinted = false
+      if (result.gradle.current.isUpdateAvailable && result.gradle.current > result.gradle.running) {
+        updatePrinted = true
+        printStream.print(" -> " + result.gradle.current.version)
+      }
+      if ((gradleReleaseChannel == RELEASE_CANDIDATE.id || gradleReleaseChannel == NIGHTLY.id) &&
+        result.gradle.releaseCandidate.isUpdateAvailable &&
+        result.gradle.releaseCandidate >
+        result.gradle.current
+      ) {
+        updatePrinted = true
+        printStream.print(" -> " + result.gradle.releaseCandidate.version)
+      }
+      if (gradleReleaseChannel == NIGHTLY.id &&
+        result.gradle.nightly.isUpdateAvailable &&
+        result.gradle.nightly >
+        result.gradle.current
+      ) {
+        updatePrinted = true
+        printStream.print(" -> " + result.gradle.nightly.version)
+      }
+      if (!updatePrinted) {
+        printStream.print(": UP-TO-DATE")
+      }
+      printStream.println("]")
+    }
+
+    companion object {
+      /** Returns the dependency key as a stringified label. */
+      private fun label(dependency: Dependency): String {
+        return "${dependency.group.orEmpty()}:${dependency.name}"
+      }
     }
   }
-}

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -10,11 +10,15 @@ import java.io.OutputStream
 
 /**
  * A plain text reporter for the dependency updates results.
+ *
+ * @property isInfoEnabled Whether the build already runs at the info level, so that the report does
+ * not suggest enabling it.
  */
 class PlainTextReporter(
   override val projectPath: String,
   override val revision: String,
   override val gradleReleaseChannel: String,
+  private val isInfoEnabled: Boolean = false,
 ) : AbstractReporter(projectPath, revision, gradleReleaseChannel) {
   @Deprecated(
     "Use the constructor that takes the project's path.",
@@ -141,9 +145,10 @@ class PlainTextReporter(
   ) {
     val unresolved = result.unresolved.dependencies
     if (unresolved.isNotEmpty()) {
+      val hint = if (isInfoEnabled) "" else " (use --info for details)"
       printStream.println()
       printStream.println(
-        "Failed to determine the latest version for the following dependencies (use --info for details):",
+        "Failed to determine the latest version for the following dependencies$hint:",
       )
       for (dependency in unresolved) {
         printStream.println(" - " + label(dependency))

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -256,7 +256,7 @@ class DependencyUpdatesReporter(
       group = info.selectorGroup,
       name = info.selectorName,
       version = currentVersions[keyOf(info)]?.version,
-      projectUrl = latestVersions[keyOf(info)]?.version,
+      projectUrl = projectUrls[keyOf(info)],
       userReason = currentVersions[keyOf(info)]?.userReason,
       reason = info.failureText,
     )

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -71,6 +71,7 @@ class DependencyUpdatesReporter(
           projectPath,
           revision,
           gradleReleaseChannel,
+          logger.isInfoEnabled,
         )
       plainTextReporter.write(System.out, buildBaseObject())
     }
@@ -114,7 +115,7 @@ class DependencyUpdatesReporter(
       "json" -> JsonReporter(projectPath, revision, gradleReleaseChannel)
       "xml" -> XmlReporter(projectPath, revision, gradleReleaseChannel)
       "html" -> HtmlReporter(projectPath, revision, gradleReleaseChannel)
-      else -> PlainTextReporter(projectPath, revision, gradleReleaseChannel)
+      else -> PlainTextReporter(projectPath, revision, gradleReleaseChannel, logger.isInfoEnabled)
     }
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -76,7 +76,7 @@ class DependencyUpdatesReporter(
     }
 
     if (outputFormatterArgument is OutputFormatterArgument.BuiltIn && outputFormatterArgument.formatterNames.isEmpty()) {
-      logger.lifecycle("Skip generating report to file (outputFormatter is empty)")
+      logger.info("Skip generating report to file (outputFormatter is empty)")
       return
     }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -65,7 +65,7 @@ class DependencyUpdatesReporter(
 ) {
   @Synchronized
   fun write() {
-    if (outputFormatterArgument !is OutputFormatterArgument.CustomAction) {
+    if (outputFormatterArgument !is OutputFormatterArgument.CustomAction && logger.isLifecycleEnabled) {
       val plainTextReporter =
         PlainTextReporter(
           projectPath,

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -18,12 +18,14 @@ package com.github.benmanes.gradle.versions
 import com.github.benmanes.gradle.versions.updates.OutputFormatterArgument
 import org.gradle.api.Action
 
+import static com.github.benmanes.gradle.versions.updates.DependencyUpdatesReporterKt.reporterFor
 import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
 import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
 
 import com.github.benmanes.gradle.versions.reporter.Reporter
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.updates.Coordinate
+import com.github.benmanes.gradle.versions.updates.PartialStatus
 import org.gradle.api.artifacts.ComponentSelection
 import com.github.benmanes.gradle.versions.updates.UnresolvedInfo
 import org.gradle.testfixtures.ProjectBuilder
@@ -345,6 +347,32 @@ final class DependencyUpdatesSpec extends Specification {
     exceeded == 2
     undeclared == 2
     unresolved == 2
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/844')
+  def 'An unresolved dependency reports its project url rather than a version'() {
+    given:
+    def project = singleProject()
+    def projectUrl = 'https://code.google.com/p/google-guice/'
+    def statuses = [
+      new PartialStatus('com.google.inject', 'guice', '2.0', null, '3.1', projectUrl, null),
+      new PartialStatus('com.google.inject', 'guice', '2.0', null, 'none', null,
+        new UnresolvedInfo('com.google.inject', 'guice', '2.0', 'Could not resolve')),
+    ]
+    def unresolved = []
+    def outputFormatter = [execute: { result ->
+      unresolved = result.unresolved.dependencies.toList()
+    }] as Action<Result>
+
+    when:
+    def reporter = reporterFor(statuses, project.path, project.logger, 'milestone',
+      new OutputFormatterArgument.CustomAction(outputFormatter), project.file('build'), 'report',
+      false, 'https://services.gradle.org/versions/', RELEASE_CANDIDATE.id)
+    reporter.write()
+
+    then:
+    unresolved.size() == 1
+    unresolved.first().projectUrl == projectUrl
   }
 
   def 'Single project with flatDir repository'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
@@ -622,4 +622,54 @@ Failed to determine the latest version for the following dependencies (use --inf
     assert result.output.toString().contains(expected)
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  def 'outputFormatter custom - the documented reporter constructor is callable from Groovy'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        import com.github.benmanes.gradle.versions.reporter.PlainTextReporter
+
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation('com.google.inject:guice:2.0')
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          def projectPath = project.path
+          def taskRevision = revision
+          def releaseChannel = gradleReleaseChannel
+
+          outputFormatter { result ->
+            new PlainTextReporter(projectPath, taskRevision, releaseChannel).write(System.out, result)
+          }
+          checkForGradleUpdate = false // future proof tests from breaking
+        }
+        """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('Project Dependency Updates')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReporterLogLevelSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReporterLogLevelSpec.groovy
@@ -61,6 +61,25 @@ final class ReporterLogLevelSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/726')
+  def 'The unresolved hint suggests --info only when it is not already enabled'() {
+    given:
+    buildFileWith('')
+
+    when:
+    def result = run(arguments)
+
+    then:
+    result.output.contains('Failed to determine the latest version for the following dependencies')
+    result.output.contains('use --info for details') == hinted
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    arguments                       || hinted
+    ['dependencyUpdates']           || true
+    ['dependencyUpdates', '--info'] || false
+  }
+
   private void buildFileWith(String extraConfiguration) {
     testProjectDir.newFile('build.gradle') <<
       """

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReporterLogLevelSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReporterLogLevelSpec.groovy
@@ -48,6 +48,19 @@ final class ReporterLogLevelSpec extends Specification {
     ['dependencyUpdates', '--quiet'] || false
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/388')
+  def 'An empty outputFormatter does not announce the skipped report file'() {
+    given:
+    buildFileWith("outputFormatter = ''")
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    !result.output.contains('Skip generating report to file')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   private void buildFileWith(String extraConfiguration) {
     testProjectDir.newFile('build.gradle') <<
       """

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReporterLogLevelSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReporterLogLevelSpec.groovy
@@ -1,0 +1,86 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for how the reporters respect the build's log level.
+ */
+final class ReporterLogLevelSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String classpathString
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    def pluginClasspathResource = getClass().classLoader.getResource("plugin-classpath.txt")
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        "Did not find plugin classpath resource, run `testClasses` build task.")
+    }
+
+    classpathString = pluginClasspathResource.readLines()
+      .collect { it.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { "'$it'" }
+      .join(", ")
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/278')
+  def 'The summary is printed at the lifecycle level but not under --quiet'() {
+    given:
+    buildFileWith('')
+
+    when:
+    def result = run(arguments)
+
+    then:
+    result.output.contains('Project Dependency Updates') == printed
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    arguments                        || printed
+    ['dependencyUpdates']            || true
+    ['dependencyUpdates', '--quiet'] || false
+  }
+
+  private void buildFileWith(String extraConfiguration) {
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.github.ben-manes:unresolvable:1.0'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false // future proof tests from breaking
+          $extraConfiguration
+        }
+      """.stripIndent()
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .build()
+  }
+}


### PR DESCRIPTION
Fixes #278, fixes #388 and fixes #726, one commit each.

The fourth commit fixes one of the three things #844 reports: an unresolved dependency's `projectUrl` was filled from `latestVersions`, the issue's own `"projectUrl": "1.5.0"` exhibit. That one was consistently wrong rather than varying, so the run-to-run differences the title is about remain and the issue stays open. @dalewking, I could not reproduce the flapping `projectUrl` or the differing `reason` text; a fresh repro against 0.57.0 would help.

The fifth commit follows from the third one's parameter: a defaulted Kotlin parameter does not emit the shorter JVM constructor, so `PlainTextReporter(String, String, String)` vanished and the Groovy `outputFormatter` example from #1020 stopped resolving. `@JvmOverloads` restores it, matching `Dependency` and `VersionAvailable`; ktlint re-indents the class body as a result, so that file reads better with `git diff -w`.

