### PR TITLE
Report a module published only as a snapshot as up to date (fixes #475)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -169,7 +169,7 @@ class Resolver(
     // The copy inherits activated dependency locking but has no lock state of its own.
     copy.resolutionStrategy.deactivateDependencyLocking()
 
-    addRevisionFilter(copy, revision)
+    addRevisionFilter(copy, revision, current.coordinates)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, current.coordinates)
 
@@ -265,15 +265,22 @@ class Resolver(
   private fun addRevisionFilter(
     configuration: Configuration,
     revision: String,
+    currentCoordinates: Map<Coordinate.Key, Coordinate>,
   ) {
     configuration.resolutionStrategy { componentSelection ->
       componentSelection.componentSelection { rules ->
         val revisionFilter = { selection: ComponentSelection, metadata: ComponentMetadata? ->
+          // A module published only as a snapshot has no candidate that a milestone or release
+          // revision accepts, so the version the build already uses is exempt from the check.
+          // https://github.com/ben-manes/gradle-versions-plugin/issues/475
+          val candidate = Coordinate.from(selection.candidate)
+          val isCurrent = currentCoordinates[candidate.key]?.version == candidate.version
           val accepted =
             (metadata == null) ||
               ((revision == "release") && (metadata.status == "release")) ||
               ((revision == "milestone") && (metadata.status != "integration")) ||
-              (revision == "integration") || (selection.candidate.version == "none")
+              (revision == "integration") || (selection.candidate.version == "none") ||
+              isCurrent
           if (!accepted) {
             selection.reject("Component status ${metadata?.status} rejected by revision $revision")
           }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -273,8 +273,9 @@ class Resolver(
           // A module published only as a snapshot has no candidate that a milestone or release
           // revision accepts, so the version the build already uses is exempt from the check.
           // https://github.com/ben-manes/gradle-versions-plugin/issues/475
-          val candidate = Coordinate.from(selection.candidate)
-          val isCurrent = currentCoordinates[candidate.key]?.version == candidate.version
+          val candidateCoordinate = Coordinate.from(selection.candidate)
+          val isCurrent =
+            currentCoordinates[candidateCoordinate.key]?.version == candidateCoordinate.version
           val accepted =
             (metadata == null) ||
               ((revision == "release") && (metadata.status == "release")) ||

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -408,6 +408,115 @@ final class DependencyUpdatesSpec extends Specification {
     }
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/475')
+  def 'Single project with a snapshot-only module reports up to date'() {
+    given:
+    def project = singleProject()
+    addRepositoryTo(project)
+    project.configurations {
+      upToDate
+    }
+    project.dependencies {
+      upToDate 'com.example:snapshot-only:1.0-SNAPSHOT'
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      unresolved.isEmpty()
+      upgradeVersions.isEmpty()
+      downgradeVersions.isEmpty()
+      (upToDateVersions.get(['group': 'com.example', 'name': 'snapshot-only']).getVersion() ==
+        '1.0-SNAPSHOT')
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/475')
+  def 'Single project with a snapshot module having a newer release still reports the upgrade'() {
+    given:
+    def project = singleProject()
+    addRepositoryTo(project)
+    project.configurations {
+      upgradesFound
+    }
+    project.dependencies {
+      upgradesFound 'com.example:snapshot-mixed:1.0-SNAPSHOT'
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      unresolved.isEmpty()
+      upToDateVersions.isEmpty()
+      (upgradeVersions.get(['group': 'com.example', 'name': 'snapshot-mixed']).getVersion() ==
+        '1.0-SNAPSHOT')
+      (latestVersions.get(['group': 'com.example', 'name': 'snapshot-mixed']).getVersion() ==
+        '1.5')
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/475')
+  def 'Single project already on the newest snapshot of a mixed module reports up to date'() {
+    given:
+    def project = singleProject()
+    addRepositoryTo(project)
+    project.configurations {
+      upToDate
+    }
+    project.dependencies {
+      // No milestone/release candidate exceeds this snapshot, so the module is up to date at it.
+      upToDate 'com.example:snapshot-mixed:2.0-SNAPSHOT'
+    }
+
+    when:
+    def reporter = evaluate(project)
+    reporter.write()
+
+    then:
+    with(reporter) {
+      unresolved.isEmpty()
+      downgradeVersions.isEmpty()
+      (upToDateVersions.get(['group': 'com.example', 'name': 'snapshot-mixed']).getVersion() ==
+        '2.0-SNAPSHOT')
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/475')
+  def 'Single project where a snapshot exemption does not carry to another module'() {
+    given:
+    def project = singleProject()
+    addRepositoryTo(project)
+    project.configurations {
+      upToDate
+    }
+    project.dependencies {
+      // snapshot-peer also publishes 1.0.1-SNAPSHOT and 2.0-SNAPSHOT, the latter being the version
+      // snapshot-mixed is exempted at, so neither may be offered as an upgrade of snapshot-peer.
+      upToDate 'com.example:snapshot-peer:1.0'
+      upToDate 'com.example:snapshot-mixed:2.0-SNAPSHOT'
+    }
+
+    when:
+    def reporter = evaluate(project, 'release')
+    reporter.write()
+
+    then:
+    with(reporter) {
+      unresolved.isEmpty()
+      upgradeVersions.isEmpty()
+      (upToDateVersions.get(['group': 'com.example', 'name': 'snapshot-peer']).getVersion() ==
+        '1.0')
+      (upToDateVersions.get(['group': 'com.example', 'name': 'snapshot-mixed']).getVersion() ==
+        '2.0-SNAPSHOT')
+    }
+  }
+
   def 'Single project with annotation processor'() {
     given:
     def project = singleProject()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DependencyUpdatesSpec.groovy
@@ -517,6 +517,34 @@ final class DependencyUpdatesSpec extends Specification {
     }
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/475')
+  def 'Single project declaring a snapshot-only module dynamically reports up to date'() {
+    given:
+    def project = singleProject()
+    addRepositoryTo(project)
+    project.configurations {
+      upToDate
+    }
+    project.dependencies {
+      // The current coordinates record the resolved 1.0-SNAPSHOT rather than the '+' literal, so
+      // the exemption still matches the version the build uses.
+      upToDate 'com.example:snapshot-only:+'
+    }
+
+    when:
+    def reporter = evaluate(project, 'release')
+    reporter.write()
+
+    then:
+    with(reporter) {
+      unresolved.isEmpty()
+      upgradeVersions.isEmpty()
+      downgradeVersions.isEmpty()
+      (upToDateVersions.get(['group': 'com.example', 'name': 'snapshot-only']).getVersion() ==
+        '1.0-SNAPSHOT')
+    }
+  }
+
   def 'Single project with annotation processor'() {
     given:
     def project = singleProject()

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/1.0-SNAPSHOT/snapshot-mixed-1.0-SNAPSHOT.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/1.0-SNAPSHOT/snapshot-mixed-1.0-SNAPSHOT.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-mixed</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Example Snapshot Mixed Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/1.5/snapshot-mixed-1.5.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/1.5/snapshot-mixed-1.5.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-mixed</artifactId>
+  <version>1.5</version>
+  <name>Example Snapshot Mixed Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/2.0-SNAPSHOT/snapshot-mixed-2.0-SNAPSHOT.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/2.0-SNAPSHOT/snapshot-mixed-2.0-SNAPSHOT.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-mixed</artifactId>
+  <version>2.0-SNAPSHOT</version>
+  <name>Example Snapshot Mixed Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-mixed/maven-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-mixed</artifactId>
+  <versioning>
+    <latest>2.0-SNAPSHOT</latest>
+    <release>1.5</release>
+    <versions>
+      <version>1.0-SNAPSHOT</version>
+      <version>1.5</version>
+      <version>2.0-SNAPSHOT</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-only/1.0-SNAPSHOT/snapshot-only-1.0-SNAPSHOT.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-only/1.0-SNAPSHOT/snapshot-only-1.0-SNAPSHOT.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-only</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Example Snapshot Only Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-only/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-only/maven-metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-only</artifactId>
+  <versioning>
+    <latest>1.0-SNAPSHOT</latest>
+    <versions>
+      <version>1.0-SNAPSHOT</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/1.0.1-SNAPSHOT/snapshot-peer-1.0.1-SNAPSHOT.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/1.0.1-SNAPSHOT/snapshot-peer-1.0.1-SNAPSHOT.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-peer</artifactId>
+  <version>1.0.1-SNAPSHOT</version>
+  <name>Example Snapshot Peer Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/1.0/snapshot-peer-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/1.0/snapshot-peer-1.0.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-peer</artifactId>
+  <version>1.0</version>
+  <name>Example Snapshot Peer Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/2.0-SNAPSHOT/snapshot-peer-2.0-SNAPSHOT.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/2.0-SNAPSHOT/snapshot-peer-2.0-SNAPSHOT.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-peer</artifactId>
+  <version>2.0-SNAPSHOT</version>
+  <name>Example Snapshot Peer Library</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/snapshot-peer/maven-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>snapshot-peer</artifactId>
+  <versioning>
+    <latest>2.0-SNAPSHOT</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.0.1-SNAPSHOT</version>
+      <version>2.0-SNAPSHOT</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Fixes #475.

A module published only as a snapshot has no candidate the `milestone` or `release` revision filter accepts, so at `revision = "release"` it reports as a failure rather than as current:

```
Failed to determine the latest version for the following dependencies (use --info for details):
 - com.example:snapshot-only
```

The fix exempts one candidate from the status check, the version the build already resolves:

```
The following dependencies are using the latest release version:
 - com.example:snapshot-only:1.0-SNAPSHOT
```

The exemption reaches a little past #475. A build declaring a published pre-release that is ahead of the latest release moves category too, from

```
The following dependencies exceed the version found at the release revision level:
 - com.example:snapshot-mixed [2.0-SNAPSHOT <- 1.5]
```

to

```
The following dependencies are using the latest release version:
 - com.example:snapshot-mixed:2.0-SNAPSHOT
```

A module with a real newer release is unaffected either way. `snapshot-mixed:1.0-SNAPSHOT` still reports `[1.0-SNAPSHOT -> 1.5]`.