### PR TITLE
Name the projects behind a coordinate that resolves to more than one version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,16 @@ configuration cache the dependency metadata read during resolution is tracked as
 an input, so a newly published version invalidates the cached entry rather than
 serving a stale report.
 
+When a coordinate's declared version differs across the aggregated projects, the
+plain text, JSON, XML, and HTML reports name the projects that declared each
+version, so the entry no longer reads as self-contradictory:
+
+```text
+The following dependencies have later milestone versions:
+ - org.jacoco:org.jacoco.ant [0.8.14 -> 0.8.15]
+     declared in root project
+```
+
 With the settings plugin applied (see [Applying the
 plugin](#applying-the-plugin)), the root project receives the
 `dependencyUpdates` task and every other project contributes to it. No project

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,10 @@ The following dependencies have later milestone versions:
      declared in root project
 ```
 
+The plain text and HTML reports name the first five projects and count the rest
+(`declared in :app, :lib, ... and 60 others`). The JSON and XML reports always
+carry the complete list, so use one of them when a tool needs every project.
+
 With the settings plugin applied (see [Applying the
 plugin](#applying-the-plugin)), the root project receives the
 `dependencyUpdates` task and every other project contributes to it. No project

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -23,3 +23,6 @@ fun OutputStream.print(s: String = "") {
 fun OutputStream.println(s: String = "") {
   (this as PrintStream).println(s)
 }
+
+/** Returns the display list of the projects that declared a divergent version. */
+internal fun projectsLabel(projects: List<String>): String = projects.joinToString(", ") { if (it == ":") "root project" else it }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -24,5 +24,18 @@ fun OutputStream.println(s: String = "") {
   (this as PrintStream).println(s)
 }
 
-/** Returns the display list of the projects that declared a divergent version. */
-internal fun projectsLabel(projects: List<String>): String = projects.joinToString(", ") { if (it == ":") "root project" else it }
+/** The number of projects named before a long list is elided in the human readable reports. */
+private const val MAX_LISTED_PROJECTS = 5
+
+/**
+ * Returns the display list of the projects that declared a divergent version, eliding all but the
+ * first few of a long list.
+ */
+internal fun projectsLabel(projects: List<String>): String {
+  val names = projects.map { if (it == ":") "root project" else it }
+  return if (names.size <= MAX_LISTED_PROJECTS + 1) {
+    names.joinToString(", ")
+  } else {
+    names.take(MAX_LISTED_PROJECTS).joinToString(", ") + " and ${names.size - MAX_LISTED_PROJECTS} others"
+  }
+}

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
@@ -1,5 +1,6 @@
 package com.github.benmanes.gradle.versions.reporter
 
+import com.github.benmanes.gradle.versions.reporter.result.Dependency
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.reporter.result.VersionAvailable
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
@@ -230,7 +231,8 @@ class HtmlReporter(
           dependency.name.orEmpty(),
           dependency.group.orEmpty(),
           getUrlString(dependency.projectUrl),
-          getVersionString(dependency.group.orEmpty(), dependency.name.orEmpty(), dependency.version),
+          getVersionString(dependency.group.orEmpty(), dependency.name.orEmpty(), dependency.version) +
+            declaredIn(dependency),
           getVersionString(
             dependency.group.orEmpty(),
             dependency.name.orEmpty(),
@@ -353,7 +355,7 @@ class HtmlReporter(
               dependency.group.orEmpty(),
               dependency.name.orEmpty(),
               dependency.version,
-            ),
+            ) + declaredIn(dependency),
             dependency.userReason.orEmpty(),
           )
         rows.add(rowString)
@@ -386,7 +388,7 @@ class HtmlReporter(
               dependency.group.orEmpty(),
               dependency.name.orEmpty(),
               dependency.version,
-            ),
+            ) + declaredIn(dependency),
             getVersionString(
               dependency.group.orEmpty(),
               dependency.name.orEmpty(),
@@ -457,6 +459,8 @@ class HtmlReporter(
           version,
         )
     }
+
+    private fun declaredIn(dependency: Dependency): String = dependency.projects?.let { "<br>declared in ${projectsLabel(it)}" }.orEmpty()
 
     private fun getUrlString(url: String?): String {
       if (url == null) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/JsonReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/JsonReporter.kt
@@ -1,7 +1,12 @@
 package com.github.benmanes.gradle.versions.reporter
 
+import com.github.benmanes.gradle.versions.reporter.result.AbsentWhenNull
 import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.gradle.api.Project
 import java.io.OutputStream
@@ -44,7 +49,45 @@ class JsonReporter(
   companion object {
     private val moshi =
       Moshi.Builder()
+        .add(AbsentWhenNullAdapter())
         .addLast(KotlinJsonAdapterFactory())
         .build()
+  }
+}
+
+/** Omits an absent optional property that serializeNulls would otherwise write as null. */
+private class AbsentWhenNullAdapter {
+  @ToJson
+  fun toJson(
+    writer: JsonWriter,
+    @AbsentWhenNull projects: List<String>?,
+  ) {
+    if (projects == null) {
+      val serializeNulls = writer.serializeNulls
+      writer.serializeNulls = false
+      try {
+        writer.nullValue()
+      } finally {
+        writer.serializeNulls = serializeNulls
+      }
+    } else {
+      writer.beginArray()
+      for (project in projects) {
+        writer.value(project)
+      }
+      writer.endArray()
+    }
+  }
+
+  @FromJson
+  @AbsentWhenNull
+  fun fromJson(reader: JsonReader): List<String>? {
+    val projects = mutableListOf<String>()
+    reader.beginArray()
+    while (reader.hasNext()) {
+      projects.add(reader.nextString())
+    }
+    reader.endArray()
+    return projects
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -77,6 +77,9 @@ class PlainTextReporter
           dependency.userReason?.let {
             printStream.println("     $it")
           }
+          dependency.projects?.let {
+            printStream.println("     declared in ${projectsLabel(it)}")
+          }
         }
       }
     }
@@ -100,6 +103,9 @@ class PlainTextReporter
           dependency.projectUrl?.let {
             printStream.println("     $it")
           }
+          dependency.projects?.let {
+            printStream.println("     declared in ${projectsLabel(it)}")
+          }
         }
       }
     }
@@ -120,6 +126,9 @@ class PlainTextReporter
           }
           dependency.projectUrl?.let {
             printStream.println("     $it")
+          }
+          dependency.projects?.let {
+            printStream.println("     declared in ${projectsLabel(it)}")
           }
         }
       }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
@@ -201,6 +201,13 @@ class XmlReporter(
     appendTextChild(document, dependencyElement, "version", dependency.version)
     appendTextChild(document, dependencyElement, "projectUrl", dependency.projectUrl)
     appendTextChild(document, dependencyElement, "userReason", dependency.userReason)
+    dependency.projects?.let { projects ->
+      val element = document.createElement("projects")
+      dependencyElement.appendChild(element)
+      for (project in projects) {
+        appendTextChild(document, element, "project", project)
+      }
+    }
     return dependencyElement
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
@@ -1,5 +1,12 @@
 package com.github.benmanes.gradle.versions.reporter.result
 
+import com.squareup.moshi.JsonQualifier
+
+/** Marks an optional report property that is omitted when null rather than serialized as null. */
+@JsonQualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AbsentWhenNull
+
 /**
  * A project's dependency.
  */
@@ -11,6 +18,7 @@ open class Dependency
     open val version: String? = null,
     open val projectUrl: String? = null,
     open val userReason: String? = null,
+    @AbsentWhenNull open val projects: List<String>? = null,
   ) : Comparable<Dependency> {
     override fun compareTo(other: Dependency): Int {
       return compareValuesBy(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
@@ -1,10 +1,13 @@
 package com.github.benmanes.gradle.versions.reporter.result
 
-data class DependencyLatest(
-  override val group: String? = null,
-  override val name: String? = null,
-  override val version: String? = null,
-  override val projectUrl: String? = null,
-  override val userReason: String? = null,
-  val latest: String,
-) : Dependency()
+data class DependencyLatest
+  @JvmOverloads
+  constructor(
+    override val group: String? = null,
+    override val name: String? = null,
+    override val version: String? = null,
+    override val projectUrl: String? = null,
+    override val userReason: String? = null,
+    val latest: String,
+    @AbsentWhenNull override val projects: List<String>? = null,
+  ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
@@ -1,10 +1,13 @@
 package com.github.benmanes.gradle.versions.reporter.result
 
-data class DependencyOutdated(
-  override val group: String? = null,
-  override val name: String? = null,
-  override val version: String? = null,
-  override val projectUrl: String? = null,
-  override val userReason: String? = null,
-  val available: VersionAvailable,
-) : Dependency()
+data class DependencyOutdated
+  @JvmOverloads
+  constructor(
+    override val group: String? = null,
+    override val name: String? = null,
+    override val version: String? = null,
+    override val projectUrl: String? = null,
+    override val userReason: String? = null,
+    val available: VersionAvailable,
+    @AbsentWhenNull override val projects: List<String>? = null,
+  ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
@@ -1,10 +1,13 @@
 package com.github.benmanes.gradle.versions.reporter.result
 
-data class DependencyUnresolved(
-  override val group: String? = null,
-  override val name: String? = null,
-  override val version: String? = null,
-  override val projectUrl: String? = null,
-  override val userReason: String? = null,
-  val reason: String,
-) : Dependency()
+data class DependencyUnresolved
+  @JvmOverloads
+  constructor(
+    override val group: String? = null,
+    override val name: String? = null,
+    override val version: String? = null,
+    override val projectUrl: String? = null,
+    override val userReason: String? = null,
+    val reason: String,
+    @AbsentWhenNull override val projects: List<String>? = null,
+  ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -42,6 +42,7 @@ import java.util.TreeSet
  * and gradle updates.
  * @property gradleReleaseChannel The gradle release channel to use for reporting.
  * @property latestByCurrent The latest version found for each declared version.
+ * @property projectsByCoordinate The projects declaring each version of a coordinate whose versions diverge.
  *
  */
 class DependencyUpdatesReporter(
@@ -62,6 +63,7 @@ class DependencyUpdatesReporter(
   val gradleUpdateChecker: GradleUpdateChecker,
   val gradleReleaseChannel: String,
   val latestByCurrent: Map<Coordinate, Coordinate> = emptyMap(),
+  val projectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
 ) {
   @Synchronized
   fun write() {
@@ -226,6 +228,7 @@ class DependencyUpdatesReporter(
       version = coordinate.version,
       projectUrl = projectUrls[key],
       userReason = coordinate.userReason,
+      projects = projectsByCoordinate[coordinate],
     )
   }
 
@@ -240,6 +243,7 @@ class DependencyUpdatesReporter(
       projectUrl = projectUrls[key],
       userReason = coordinate.userReason,
       latest = latestFor(coordinate, key).orEmpty(),
+      projects = projectsByCoordinate[coordinate],
     )
   }
 
@@ -280,6 +284,7 @@ class DependencyUpdatesReporter(
       projectUrl = projectUrls[key],
       userReason = coordinate.userReason,
       available = available,
+      projects = projectsByCoordinate[coordinate],
     )
   }
 
@@ -354,6 +359,7 @@ fun reporterFor(
   gradleReleaseChannel: String,
 ): DependencyUpdatesReporter {
   val versions = VersionMapping(logger, statuses)
+  val projectsByCoordinate = divergentProjects(statuses)
   val unresolved = statuses.mapNotNullTo(mutableSetOf()) { it.unresolved }
   val projectUrls =
     statuses
@@ -378,8 +384,23 @@ fun reporterFor(
     projectPath, logger, revision, outputFormatterArgument, outputDir,
     reportfileName, currentVersions, latestVersions, upToDateVersions, downgradeVersions,
     upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
-    gradleReleaseChannel, versions.latestByCurrent,
+    gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate,
   )
+}
+
+/** Returns the projects declaring each version of a key whose declared versions diverge. */
+private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, List<String>> {
+  if (statuses.mapTo(mutableSetOf()) { it.projectPath }.size <= 1) {
+    return emptyMap()
+  }
+  return statuses
+    .filter { it.projectPath != null }
+    .groupBy { Coordinate.Key(it.group, it.name) }
+    .values
+    .filter { statusesOfKey -> statusesOfKey.mapTo(mutableSetOf()) { it.declaredVersion }.size > 1 }
+    .flatten()
+    .groupBy({ it.coordinate }, { it.projectPath!! })
+    .mapValues { (_, paths) -> paths.distinct().sorted() }
 }
 
 /** Returns the coordinates keyed by their group and name, disambiguating a repeated name. */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -199,8 +199,14 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
       )
     }
     val statuses =
-      mergeStatuses(partials.flatMap { it.statuses }) +
-        mergeStatuses(partials.flatMap { it.buildscriptStatuses })
+      mergeStatuses(
+        partials.flatMap { partial -> partial.statuses.map { it.copy(projectPath = partial.projectPath) } },
+      ) +
+        mergeStatuses(
+          partials.flatMap { partial ->
+            partial.buildscriptStatuses.map { it.copy(projectPath = partial.projectPath) }
+          },
+        )
 
     reporterFor(
       statuses, projectPath, logger, revision, outputFormatter(), outputDirectory(), reportfileName,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -4,21 +4,25 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 /** One dependency's status, as observed by a single project. */
-data class PartialStatus(
-  val group: String,
-  val name: String,
-  val declaredVersion: String,
-  val userReason: String?,
-  val latestVersion: String,
-  val projectUrl: String?,
-  val unresolved: UnresolvedInfo?,
-) {
-  val coordinate: Coordinate
-    get() = Coordinate(group, name, declaredVersion, userReason)
+data class PartialStatus
+  @JvmOverloads
+  constructor(
+    val group: String,
+    val name: String,
+    val declaredVersion: String,
+    val userReason: String?,
+    val latestVersion: String,
+    val projectUrl: String?,
+    val unresolved: UnresolvedInfo?,
+    /** The observing project, stamped by the accumulator rather than serialized. */
+    @Transient val projectPath: String? = null,
+  ) {
+    val coordinate: Coordinate
+      get() = Coordinate(group, name, declaredVersion, userReason)
 
-  val latestCoordinate: Coordinate
-    get() = Coordinate(group, name, latestVersion, userReason)
-}
+    val latestCoordinate: Coordinate
+      get() = Coordinate(group, name, latestVersion, userReason)
+  }
 
 /** A resolution failure, as a value that survives the project boundary. */
 data class UnresolvedInfo(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DivergentVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DivergentVersionsSpec.groovy
@@ -1,0 +1,256 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import groovy.xml.XmlParser
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for naming the projects behind a coordinate whose declared versions diverge
+ * across an aggregated build.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+final class DivergentVersionsSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private void writeBuild(String rootBuildscript = '', String rootDependencies = '') {
+    testProjectDir.newFile('settings.gradle') << "include 'app', 'lib'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        $rootBuildscript
+
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          apply plugin: 'java'
+
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        dependencies {
+          $rootDependencies
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Names the projects behind a divergent coordinate'() {
+    given:
+    writeBuild('', "implementation 'com.google.guava:guava:15.0'")
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:16.0-rc1'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.guava:guava:16.0-rc1${nl}     declared in :app")
+    result.output.contains(
+      " - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     declared in root project")
+    result.output.count('declared in') == 2
+  }
+
+  def 'Lists every project that declared the shared version'() {
+    given:
+    writeBuild('', "implementation 'com.google.inject:guice:2.0'")
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:3.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:3.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(' - com.google.inject:guice [3.0 -> 3.1]')
+    result.output.contains(' - com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('     declared in :app, :lib')
+    result.output.contains('     declared in root project')
+  }
+
+  def 'Aggregated projects that agree keep the report byte-identical'() {
+    given:
+    writeBuild()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+    def reportFile = new File(testProjectDir.root, 'build/dependencyUpdates/report.txt')
+    def expected =
+      """
+    ------------------------------------------------------------
+    : Project Dependency Updates (report to plain text file)
+    ------------------------------------------------------------
+
+    The following dependencies have later milestone versions:
+     - com.google.guava:guava [15.0 -> 16.0-rc1]
+      """.stripIndent().replace('\r', '').replace('\n', System.lineSeparator())
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    reportFile.text == expected
+    !reportFile.text.contains('declared in')
+  }
+
+  def 'Omits the projects key for a single version in the file reports'() {
+    given:
+    writeBuild()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json', '--no-parallel'])
+    def report = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    (report.current.dependencies + report.outdated.dependencies).every { !it.containsKey('projects') }
+  }
+
+  def 'Names the projects in the file reports'() {
+    given:
+    writeBuild('', "implementation 'com.google.guava:guava:15.0'")
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:16.0-rc1'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+
+    when:
+    def result = run(
+      ['dependencyUpdates', '-DoutputFormatter=json,xml,html', '--no-parallel'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def xmlReport = new XmlParser()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.xml'))
+    def htmlReport = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    jsonReport.outdated.dependencies[0].projects == [':']
+    jsonReport.current.dependencies[0].projects == [':app']
+    xmlReport.outdated.dependencies.outdatedDependency[0].projects.project*.text() == [':']
+    htmlReport.contains('declared in root project')
+    htmlReport.contains('declared in :app')
+  }
+
+  def 'Leaves a single project report unchanged'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations {
+          second
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+          second 'com.google.inject:guice:3.0'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
+    !result.output.contains('declared in')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DivergentVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DivergentVersionsSpec.groovy
@@ -23,8 +23,9 @@ final class DivergentVersionsSpec extends Specification {
     mavenRepoUrl = getClass().getResource('/maven/').toURI()
   }
 
-  private void writeBuild(String rootBuildscript = '', String rootDependencies = '') {
-    testProjectDir.newFile('settings.gradle') << "include 'app', 'lib'"
+  private void writeBuild(String rootBuildscript = '', String rootDependencies = '',
+      List<String> projects = ['app', 'lib']) {
+    testProjectDir.newFile('settings.gradle') << "include ${projects.collect { "'$it'" }.join(', ')}"
     testProjectDir.newFile('build.gradle') <<
       """
         $rootBuildscript
@@ -118,6 +119,59 @@ final class DivergentVersionsSpec extends Specification {
     result.output.contains(' - com.google.inject:guice [2.0 -> 3.1]')
     result.output.contains('     declared in :app, :lib')
     result.output.contains('     declared in root project')
+  }
+
+  def 'Elides a long project list in the human readable reports only'() {
+    given:
+    def projects = (1..7).collect { "p$it" }
+    writeBuild('', "implementation 'com.google.inject:guice:2.0'", projects)
+    projects.each { project ->
+      testProjectDir.newFolder(project)
+      testProjectDir.newFile("$project/build.gradle") <<
+        """
+          dependencies {
+            implementation 'com.google.inject:guice:3.0'
+          }
+        """.stripIndent()
+    }
+
+    when:
+    def result = run(
+      ['dependencyUpdates', '-DoutputFormatter=plain,json,html', '--no-parallel'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def htmlReport = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('     declared in :p1, :p2, :p3, :p4, :p5 and 2 others')
+    result.output.contains('     declared in root project')
+    htmlReport.contains('declared in :p1, :p2, :p3, :p4, :p5 and 2 others')
+    jsonReport.outdated.dependencies.find { it.version == '3.0' }.projects ==
+      projects.collect { ":$it" }
+  }
+
+  def 'Names every project of a list at the elision threshold'() {
+    given:
+    def projects = (1..6).collect { "p$it" }
+    writeBuild('', "implementation 'com.google.inject:guice:2.0'", projects)
+    projects.each { project ->
+      testProjectDir.newFolder(project)
+      testProjectDir.newFile("$project/build.gradle") <<
+        """
+          dependencies {
+            implementation 'com.google.inject:guice:3.0'
+          }
+        """.stripIndent()
+    }
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('     declared in :p1, :p2, :p3, :p4, :p5, :p6')
+    !result.output.contains('others')
   }
 
   def 'Aggregated projects that agree keep the report byte-identical'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -29,6 +29,21 @@ final class PartialResultSpec extends Specification {
     decoded == result
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+  def 'The observing project is not serialized'() {
+    given:
+    def status = new PartialStatus('com.google.guava', 'guava', '1.0', null, '1.0', null, null, ':stamped-project')
+    def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [status], [])
+
+    when:
+    def json = result.toJson()
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    !json.contains('stamped-project')
+    decoded.statuses[0].projectPath == null
+  }
+
   def 'Rejects an unknown format version'() {
     given:
     def json = new PartialResult(99, ':', [], []).toJson()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ProjectEvaluator.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ProjectEvaluator.groovy
@@ -47,7 +47,11 @@ final class ProjectEvaluator {
     def resolver = new Resolver(project, resolutionStrategy, checkConstraints)
     return configurations.findAll { it.canBeResolved }.collectMany { Configuration configuration ->
       try {
-        return resolver.resolve(configuration, revision).collect { it.toPartialStatus() }
+        return resolver.resolve(configuration, revision).collect {
+          def status = it.toPartialStatus()
+          new PartialStatus(status.group, status.name, status.declaredVersion, status.userReason,
+            status.latestVersion, status.projectUrl, status.unresolved, project.path)
+        }
       } catch (Exception e) {
         project.logger.info("Skipping configuration ${project.path}:${configuration.name}", e)
         return []

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
@@ -70,6 +70,55 @@ final class ReportJoinSpec extends Specification {
     report.count == 2
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+  def 'A divergent version names its declaring projects'() {
+    given:
+    def root = twoProjects('com.google.inject', 'guice', '3\\.1', '2.0', '3.0')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.outdated.dependencies*.projects == [[':pinned'], [':open']]
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+  def 'A shared version carries no projects'() {
+    given:
+    def root = twoProjects('com.google.inject', 'guice', 'nomatch', '3.1', '3.1')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.current.dependencies*.projects == [null]
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+  def 'Attributes a buildscript dependency to its project'() {
+    given:
+    def root = ProjectBuilder.builder().withName('root').build()
+    def app = ProjectBuilder.builder().withName('app').withParent(root).build()
+    def localMavenRepo = getClass().getResource('/maven/')
+    for (project in [root, app]) {
+      project.buildscript.repositories {
+        maven {
+          url localMavenRepo.toURI()
+        }
+      }
+    }
+    root.buildscript.dependencies.add('classpath', 'com.google.inject:guice:2.0')
+    app.buildscript.dependencies.add('classpath', 'com.google.inject:guice:3.0')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.outdated.dependencies*.version.sort() == ['2.0', '3.0']
+    result.outdated.dependencies.find { it.version == '2.0' }.projects == [':']
+    result.outdated.dependencies.find { it.version == '3.0' }.projects == [':app']
+  }
+
   /**
    * A root project whose two children declare the same module, where the first child's repository
    * hides the versions matching {@code hiddenVersionRegex}. The latest version found therefore


### PR DESCRIPTION
Addresses #1032.

The merged report drops which project declared which version, so one coordinate can print at several versions with nothing telling them apart. Kafka's `streams:upgrade-system-tests-*` projects each declare a different old `kafka-streams` on purpose, and today they render like this:

```
 - org.apache.kafka:kafka-streams [0.11.0.3 -> 4.3.1]
     https://kafka.apache.org
 - org.apache.kafka:kafka-streams [1.0.2 -> 4.3.1]
     https://kafka.apache.org
 - org.apache.kafka:kafka-streams [1.1.1 -> 4.3.1]
     https://kafka.apache.org
```

This PR names the projects behind each version:

```
 - org.apache.kafka:kafka-streams [0.11.0.3 -> 4.3.1]
     https://kafka.apache.org
     declared in :streams:upgrade-system-tests-0110
 - org.apache.kafka:kafka-streams [1.0.2 -> 4.3.1]
     https://kafka.apache.org
     declared in :streams:upgrade-system-tests-10
 - org.apache.kafka:kafka-streams [1.1.1 -> 4.3.1]
     https://kafka.apache.org
     declared in :streams:upgrade-system-tests-11
```

The jacoco split in #1032 reads the same way, with the root applying `jacoco` and no `toolVersion` while the subprojects set 0.8.15. Kafka declares it in 65 projects, so this is also where the list gets long:

```
 - org.jacoco:org.jacoco.agent:0.8.15
     declared in :clients, :clients:clients-integration-tests, :connect, :connect:api, :connect:basic-auth-extension and 60 others
 - org.jacoco:org.jacoco.agent [0.8.14 -> 0.8.15]
     http://jacoco.org
     declared in root project
```

The plain text and HTML reports name the first five projects and count the rest; the JSON and XML reports carry the complete list, so nothing is lost for a tool reading the report. Uncapped, that first line runs about 900 characters and becomes a monstrous cell in the HTML table:

```
 - org.jacoco:org.jacoco.agent:0.8.15
     declared in :clients, :clients:clients-integration-tests, :connect, :connect:api, :connect:basic-auth-extension, :connect:file, :connect:json, :connect:mirror, :connect:mirror-client, :connect:runtime, :connect:test-plugins, :connect:transforms, :coordinator-common, :core, :examples, :generator, :group-coordinator, :group-coordinator:group-coordinator-api, :jmh-benchmarks, :metadata, :raft, :server, :server-common, :share-coordinator, :shell, :storage, :storage:storage-api, :streams, :streams:examples, :streams:integration-tests, :streams:streams-scala, :streams:test-utils, :streams:upgrade-system-tests-0110, [43 more upgrade-system-tests projects], :test-common, :test-common:test-common-internal-api, :test-common:test-common-runtime, :test-common:test-common-util, :tools, :tools:tools-api, :transaction-coordinator, :trogdor
```

A coordinate with a single version across all projects prints exactly as it does today, and the partial result format is unchanged.
