### PR TITLE
Report where a plugin-contributed dependency's version comes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,17 @@ rather than the build declaring them, such as the Kotlin standard library and
 the tool versions of the `jacoco`, `checkstyle`, and `pmd` plugins. Their
 current version is whatever the contributing plugin supplies when the task
 runs, so a tool version the build never sets reports at the default bundled
-with Gradle—a version that appears nowhere in the build script. Set the
-extension's version, such as `jacoco.toolVersion`, to control what the report
-compares against.
+with Gradle—a version that appears nowhere in the build script. The reports
+mark such an entry so it does not read as a resolution bug, naming the
+configuration the plugin declared it against:
+
+```text
+ - org.jacoco:org.jacoco.ant [0.8.11 -> 0.8.13]
+     contributed by a plugin into the 'jacocoAnt' configuration
+```
+
+Set the extension's version, such as `jacoco.toolVersion`, to control what the
+report compares against.
 
 Gradle updates are checked for on the `current`, `release-candidate` and
 `nightly` release channels. The plain-text report displays Gradle updates as a

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -1,5 +1,6 @@
 package com.github.benmanes.gradle.versions.reporter
 
+import com.github.benmanes.gradle.versions.reporter.result.Dependency
 import java.io.OutputStream
 import java.io.PrintStream
 
@@ -24,18 +25,54 @@ fun OutputStream.println(s: String = "") {
   (this as PrintStream).println(s)
 }
 
-/** The number of projects named before a long list is elided in the human readable reports. */
-private const val MAX_LISTED_PROJECTS = 5
+/** The number of names listed before a long list is elided in the human readable reports. */
+private const val MAX_LISTED_NAMES = 5
+
+/** Returns the display list of names, eliding all but the first few of a long list. */
+private fun elidedLabel(names: List<String>): String =
+  if (names.size <= MAX_LISTED_NAMES + 1) {
+    names.joinToString(", ")
+  } else {
+    names.take(MAX_LISTED_NAMES).joinToString(", ") + " and ${names.size - MAX_LISTED_NAMES} others"
+  }
 
 /**
  * Returns the display list of the projects that declared a divergent version, eliding all but the
  * first few of a long list.
  */
-internal fun projectsLabel(projects: List<String>): String {
-  val names = projects.map { if (it == ":") "root project" else it }
-  return if (names.size <= MAX_LISTED_PROJECTS + 1) {
-    names.joinToString(", ")
+internal fun projectsLabel(projects: List<String>): String = elidedLabel(projects.map { if (it == ":") "root project" else it })
+
+/** Returns the display list of the configurations a plugin contributed a dependency into. */
+private fun configurationsLabel(names: List<String>): String {
+  val quoted = names.map { "'$it'" }
+  val listed =
+    if (quoted.size <= MAX_LISTED_NAMES + 1) {
+      if (quoted.size == 1) {
+        quoted.single()
+      } else {
+        quoted.dropLast(1).joinToString(", ") + " and ${quoted.last()}"
+      }
+    } else {
+      quoted.take(MAX_LISTED_NAMES).joinToString(", ") + " and ${quoted.size - MAX_LISTED_NAMES} more"
+    }
+  val noun = if (names.size == 1) "configuration" else "configurations"
+  return "the $listed $noun"
+}
+
+/** Returns the line describing where the dependency's version came from, or null for a declared one. */
+internal fun sourceLabel(dependency: Dependency): String? {
+  val projects = dependency.projects
+  if (dependency.contributed != true) {
+    return projects?.let { "declared in ${projectsLabel(it)}" }
+  }
+  val into =
+    dependency.configurations
+      ?.takeIf { it.isNotEmpty() }
+      ?.let { " into ${configurationsLabel(it)}" }
+      .orEmpty()
+  return if (projects == null) {
+    "contributed by a plugin$into"
   } else {
-    names.take(MAX_LISTED_PROJECTS).joinToString(", ") + " and ${names.size - MAX_LISTED_PROJECTS} others"
+    "contributed by a plugin$into in ${projectsLabel(projects)}"
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
@@ -232,7 +232,7 @@ class HtmlReporter(
           dependency.group.orEmpty(),
           getUrlString(dependency.projectUrl),
           getVersionString(dependency.group.orEmpty(), dependency.name.orEmpty(), dependency.version) +
-            declaredIn(dependency),
+            origin(dependency),
           getVersionString(
             dependency.group.orEmpty(),
             dependency.name.orEmpty(),
@@ -355,7 +355,7 @@ class HtmlReporter(
               dependency.group.orEmpty(),
               dependency.name.orEmpty(),
               dependency.version,
-            ) + declaredIn(dependency),
+            ) + origin(dependency),
             dependency.userReason.orEmpty(),
           )
         rows.add(rowString)
@@ -388,7 +388,7 @@ class HtmlReporter(
               dependency.group.orEmpty(),
               dependency.name.orEmpty(),
               dependency.version,
-            ) + declaredIn(dependency),
+            ) + origin(dependency),
             getVersionString(
               dependency.group.orEmpty(),
               dependency.name.orEmpty(),
@@ -460,7 +460,7 @@ class HtmlReporter(
         )
     }
 
-    private fun declaredIn(dependency: Dependency): String = dependency.projects?.let { "<br>declared in ${projectsLabel(it)}" }.orEmpty()
+    private fun origin(dependency: Dependency): String = sourceLabel(dependency)?.let { "<br>$it" }.orEmpty()
 
     private fun getUrlString(url: String?): String {
       if (url == null) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/JsonReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/JsonReporter.kt
@@ -55,6 +55,17 @@ class JsonReporter(
   }
 }
 
+/** Writes a JSON null without leaking the writer's serializeNulls setting to its caller. */
+private fun JsonWriter.absentValue() {
+  val serializeNulls = this.serializeNulls
+  this.serializeNulls = false
+  try {
+    nullValue()
+  } finally {
+    this.serializeNulls = serializeNulls
+  }
+}
+
 /** Omits an absent optional property that serializeNulls would otherwise write as null. */
 private class AbsentWhenNullAdapter {
   @ToJson
@@ -63,13 +74,7 @@ private class AbsentWhenNullAdapter {
     @AbsentWhenNull projects: List<String>?,
   ) {
     if (projects == null) {
-      val serializeNulls = writer.serializeNulls
-      writer.serializeNulls = false
-      try {
-        writer.nullValue()
-      } finally {
-        writer.serializeNulls = serializeNulls
-      }
+      writer.absentValue()
     } else {
       writer.beginArray()
       for (project in projects) {
@@ -90,4 +95,20 @@ private class AbsentWhenNullAdapter {
     reader.endArray()
     return projects
   }
+
+  @ToJson
+  fun contributedToJson(
+    writer: JsonWriter,
+    @AbsentWhenNull contributed: Boolean?,
+  ) {
+    if (contributed == null) {
+      writer.absentValue()
+    } else {
+      writer.value(contributed)
+    }
+  }
+
+  @FromJson
+  @AbsentWhenNull
+  fun contributedFromJson(reader: JsonReader): Boolean? = reader.nextBoolean()
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -77,8 +77,8 @@ class PlainTextReporter
           dependency.userReason?.let {
             printStream.println("     $it")
           }
-          dependency.projects?.let {
-            printStream.println("     declared in ${projectsLabel(it)}")
+          sourceLabel(dependency)?.let {
+            printStream.println("     $it")
           }
         }
       }
@@ -103,8 +103,8 @@ class PlainTextReporter
           dependency.projectUrl?.let {
             printStream.println("     $it")
           }
-          dependency.projects?.let {
-            printStream.println("     declared in ${projectsLabel(it)}")
+          sourceLabel(dependency)?.let {
+            printStream.println("     $it")
           }
         }
       }
@@ -127,8 +127,8 @@ class PlainTextReporter
           dependency.projectUrl?.let {
             printStream.println("     $it")
           }
-          dependency.projects?.let {
-            printStream.println("     declared in ${projectsLabel(it)}")
+          sourceLabel(dependency)?.let {
+            printStream.println("     $it")
           }
         }
       }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
@@ -208,6 +208,14 @@ class XmlReporter(
         appendTextChild(document, element, "project", project)
       }
     }
+    appendTextChild(document, dependencyElement, "contributed", dependency.contributed)
+    dependency.configurations?.let { configurations ->
+      val element = document.createElement("configurations")
+      dependencyElement.appendChild(element)
+      for (configuration in configurations) {
+        appendTextChild(document, element, "configuration", configuration)
+      }
+    }
     return dependencyElement
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
@@ -19,6 +19,10 @@ open class Dependency
     open val projectUrl: String? = null,
     open val userReason: String? = null,
     @AbsentWhenNull open val projects: List<String>? = null,
+    /** True when only plugins contributed the dependency rather than the build declaring it. */
+    @AbsentWhenNull open val contributed: Boolean? = null,
+    /** The configurations a plugin contributed the dependency into, when it contributed it. */
+    @AbsentWhenNull open val configurations: List<String>? = null,
   ) : Comparable<Dependency> {
     override fun compareTo(other: Dependency): Int {
       return compareValuesBy(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
@@ -10,4 +10,6 @@ data class DependencyLatest
     override val userReason: String? = null,
     val latest: String,
     @AbsentWhenNull override val projects: List<String>? = null,
+    @AbsentWhenNull override val contributed: Boolean? = null,
+    @AbsentWhenNull override val configurations: List<String>? = null,
   ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
@@ -10,4 +10,6 @@ data class DependencyOutdated
     override val userReason: String? = null,
     val available: VersionAvailable,
     @AbsentWhenNull override val projects: List<String>? = null,
+    @AbsentWhenNull override val contributed: Boolean? = null,
+    @AbsentWhenNull override val configurations: List<String>? = null,
   ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
@@ -10,4 +10,6 @@ data class DependencyUnresolved
     override val userReason: String? = null,
     val reason: String,
     @AbsentWhenNull override val projects: List<String>? = null,
+    @AbsentWhenNull override val contributed: Boolean? = null,
+    @AbsentWhenNull override val configurations: List<String>? = null,
   ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -232,6 +232,19 @@ private fun registerProducer(
   if (tasks.names.contains(PARTIAL_TASK_NAME)) {
     return tasks.named(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java)
   }
+  // A default action runs only while the build has declared nothing of its own, so one registered
+  // here, ahead of the plugins that a project applies, names the configurations that a plugin alone
+  // filled. Reading the dependencies later cannot tell the two apart, as any configuration time
+  // reader of incoming.dependencies has by then run the actions that contribute them.
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/1028
+  val filledByPlugin = ConcurrentHashMap.newKeySet<String>()
+  project.configurations.configureEach { configuration ->
+    // Only a configuration that dependencies are declared against accepts a default action, which
+    // is every configuration that a plugin contributes to.
+    if (configuration.isCanBeDeclared) {
+      configuration.defaultDependencies { filledByPlugin.add(configuration.name) }
+    }
+  }
   val partial =
     tasks.register(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java) { task ->
       task.outputFile.convention(
@@ -263,12 +276,21 @@ private fun registerProducer(
           PartialResult(
             PartialResult.FORMAT_VERSION,
             project.path,
-            statusesOf(project, configurations, parameters, parameters.checkConstraints),
+            statusesOf(
+              project,
+              configurations,
+              parameters,
+              parameters.checkConstraints,
+              filledByPlugin,
+            ),
             statusesOf(
               project,
               buildscriptConfigurations,
               parameters,
               parameters.checkBuildEnvironmentConstraints,
+              // No default action is registered on the buildscript's configurations, so a project
+              // configuration sharing a name with one must not discount its declared dependencies.
+              filledByPlugin = emptySet(),
             ),
           ).toJson()
         },
@@ -333,14 +355,24 @@ private fun statusesOf(
   configurations: List<Configuration>,
   parameters: ResolvedParameters,
   checkConstraints: Boolean,
+  filledByPlugin: Set<String>,
 ): List<PartialStatus> {
   if (configurations.isEmpty()) {
     return emptyList()
   }
   val resolver = Resolver(project, parameters.resolutionStrategy, checkConstraints)
+  // Snapshotted for every configuration before the first resolution, as resolving one
+  // configuration runs the lazy actions of the configurations it extends. A build that read the
+  // dependencies while configuring has already run them, which the discount below corrects for.
+  val declaredKeys =
+    configurations.associateWith { runCatching { resolver.declaredKeys(it) }.getOrDefault(emptySet()) }
   return configurations.flatMap { configuration ->
     try {
-      resolver.resolve(configuration, parameters.revision).map { it.toPartialStatus() }
+      // Discounted after resolving, which is what runs the default actions that name the
+      // configurations whose every dependency a plugin contributed.
+      resolver.resolve(configuration, parameters.revision) {
+        declaredKeys.getValue(configuration) - keysOf(configuration, filledByPlugin)
+      }.map { it.toPartialStatus() }
     } catch (e: Exception) {
       project.logger.info("Skipping configuration ${project.path}:${configuration.name}", e)
       emptyList()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -14,19 +14,36 @@ class DependencyStatus {
   val latestVersion: String
   val unresolved: UnresolvedDependencyResult?
   val projectUrl: String?
+  val contributed: Boolean
+  val configurations: List<String>
 
-  constructor(coordinate: Coordinate, latestVersion: String, projectUrl: String?) {
+  constructor(
+    coordinate: Coordinate,
+    latestVersion: String,
+    projectUrl: String?,
+    contributed: Boolean = false,
+    configurations: List<String> = emptyList(),
+  ) {
     this.coordinate = coordinate
     this.latestVersion = latestVersion
     this.projectUrl = projectUrl
     this.unresolved = null
+    this.contributed = contributed
+    this.configurations = configurations
   }
 
-  constructor(coordinate: Coordinate, unresolved: UnresolvedDependencyResult?) {
+  constructor(
+    coordinate: Coordinate,
+    unresolved: UnresolvedDependencyResult?,
+    contributed: Boolean = false,
+    configurations: List<String> = emptyList(),
+  ) {
     this.coordinate = coordinate
     this.unresolved = unresolved
     latestVersion = "none"
     projectUrl = null
+    this.contributed = contributed
+    this.configurations = configurations
   }
 
   fun getLatestCoordinate(): Coordinate {
@@ -64,6 +81,8 @@ class DependencyStatus {
       latestVersion,
       projectUrl,
       info,
+      contributed,
+      configurations,
     )
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -42,7 +42,9 @@ import java.util.TreeSet
  * and gradle updates.
  * @property gradleReleaseChannel The gradle release channel to use for reporting.
  * @property latestByCurrent The latest version found for each declared version.
- * @property projectsByCoordinate The projects declaring each version of a coordinate whose versions diverge.
+ * @property projectsByCoordinate The projects behind each version of a coordinate whose versions diverge.
+ * @property contributedCoordinates The coordinates that only lazy actions contributed, no project declaring them.
+ * @property configurationsByCoordinate The configurations a plugin contributed each marked coordinate into.
  *
  */
 class DependencyUpdatesReporter(
@@ -64,6 +66,8 @@ class DependencyUpdatesReporter(
   val gradleReleaseChannel: String,
   val latestByCurrent: Map<Coordinate, Coordinate> = emptyMap(),
   val projectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
+  val contributedCoordinates: Set<Coordinate> = emptySet(),
+  val configurationsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
 ) {
   @Synchronized
   fun write() {
@@ -229,6 +233,8 @@ class DependencyUpdatesReporter(
       projectUrl = projectUrls[key],
       userReason = coordinate.userReason,
       projects = projectsByCoordinate[coordinate],
+      contributed = contributedFlag(coordinate),
+      configurations = configurationsByCoordinate[coordinate],
     )
   }
 
@@ -244,8 +250,13 @@ class DependencyUpdatesReporter(
       userReason = coordinate.userReason,
       latest = latestFor(coordinate, key).orEmpty(),
       projects = projectsByCoordinate[coordinate],
+      contributed = contributedFlag(coordinate),
+      configurations = configurationsByCoordinate[coordinate],
     )
   }
+
+  /** Returns true when the coordinate was only contributed by a plugin, otherwise null. */
+  private fun contributedFlag(coordinate: Coordinate): Boolean? = if (coordinate in contributedCoordinates) true else null
 
   /** Returns the latest version found for the declared version, if it was paired with one. */
   private fun latestFor(
@@ -256,13 +267,16 @@ class DependencyUpdatesReporter(
   }
 
   private fun buildUnresolvedDependency(info: UnresolvedInfo): DependencyUnresolved {
+    val coordinate = currentVersions[keyOf(info)]
     return DependencyUnresolved(
       group = info.selectorGroup,
       name = info.selectorName,
-      version = currentVersions[keyOf(info)]?.version,
+      version = coordinate?.version,
       projectUrl = projectUrls[keyOf(info)],
-      userReason = currentVersions[keyOf(info)]?.userReason,
+      userReason = coordinate?.userReason,
       reason = info.failureText,
+      contributed = coordinate?.let { contributedFlag(it) },
+      configurations = coordinate?.let { configurationsByCoordinate[it] },
     )
   }
 
@@ -285,6 +299,8 @@ class DependencyUpdatesReporter(
       userReason = coordinate.userReason,
       available = available,
       projects = projectsByCoordinate[coordinate],
+      contributed = contributedFlag(coordinate),
+      configurations = configurationsByCoordinate[coordinate],
     )
   }
 
@@ -360,6 +376,8 @@ fun reporterFor(
 ): DependencyUpdatesReporter {
   val versions = VersionMapping(logger, statuses)
   val projectsByCoordinate = divergentProjects(statuses)
+  val contributedCoordinates = contributedCoordinates(statuses, logger)
+  val configurationsByCoordinate = contributedConfigurations(statuses, contributedCoordinates)
   val unresolved = statuses.mapNotNullTo(mutableSetOf()) { it.unresolved }
   val projectUrls =
     statuses
@@ -384,11 +402,46 @@ fun reporterFor(
     projectPath, logger, revision, outputFormatterArgument, outputDir,
     reportfileName, currentVersions, latestVersions, upToDateVersions, downgradeVersions,
     upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
-    gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate,
+    gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate, contributedCoordinates,
+    configurationsByCoordinate,
   )
 }
 
-/** Returns the projects declaring each version of a key whose declared versions diverge. */
+/** Returns the coordinates that only lazy actions contributed, with no project declaring them. */
+private fun contributedCoordinates(
+  statuses: List<PartialStatus>,
+  logger: Logger,
+): Set<Coordinate> {
+  val byCoordinate = statuses.groupBy { it.coordinate }
+  // Withheld when the projects disagree, which is a mark that cannot be trusted rather than one
+  // that does not apply, so it is reported instead of passing as an ordinary unmarked entry.
+  for ((coordinate, group) in byCoordinate) {
+    if (group.any { it.contributed } && !group.all { it.contributed }) {
+      logger.info(
+        "The projects disagree on whether a plugin contributed ${coordinate.groupId}:" +
+          "${coordinate.artifactId}, so it is left unmarked: contributed by " +
+          group.filter { it.contributed }.mapNotNull { it.projectPath }.sorted().joinToString(", "),
+      )
+    }
+  }
+  return byCoordinate.filterValues { group -> group.all { it.contributed } }.keys
+}
+
+/**
+ * Returns the configurations each marked coordinate was contributed into, taken across the projects
+ * that observed it, so that a plugin which fills a differently named configuration per project is
+ * reported as filling both rather than either.
+ */
+private fun contributedConfigurations(
+  statuses: List<PartialStatus>,
+  contributed: Set<Coordinate>,
+): Map<Coordinate, List<String>> =
+  statuses
+    .filter { it.coordinate in contributed && it.configurations.isNotEmpty() }
+    .groupBy { it.coordinate }
+    .mapValues { (_, group) -> group.flatMap { it.configurations }.distinct().sorted() }
+
+/** Returns the projects behind each version of a key whose declared versions diverge. */
 private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, List<String>> {
   if (statuses.mapTo(mutableSetOf()) { it.projectPath }.size <= 1) {
     return emptyMap()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -14,6 +14,10 @@ data class PartialStatus
     val latestVersion: String,
     val projectUrl: String?,
     val unresolved: UnresolvedInfo?,
+    /** Whether only a lazy action contributed the dependency rather than the build declaring it. */
+    val contributed: Boolean = false,
+    /** The configurations a contributed dependency was declared against, empty when declared. */
+    val configurations: List<String> = emptyList(),
     /** The observing project, stamped by the accumulator rather than serialized. */
     @Transient val projectPath: String? = null,
   ) {
@@ -42,7 +46,10 @@ data class PartialResult(
   fun toJson(): String = adapter.toJson(this)
 
   companion object {
-    /** Bumped when the shape changes; stale partials are rejected rather than misread. */
+    /**
+     * Bumped when the shape changes incompatibly; a field with a compatible default reads from an
+     * older partial as that default.
+     */
     const val FORMAT_VERSION: Int = 1
 
     private val adapter =

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -50,10 +50,26 @@ class Resolver(
     logRepositories()
   }
 
+  /** Returns the declared dependency keys of the configuration, before lazy actions contribute. */
+  fun declaredKeys(configuration: Configuration): Set<Coordinate.Key> =
+    getResolvableDependencies(configuration).mapTo(hashSetOf()) { it.key }
+
   /** Returns the version status of the configuration's dependencies at the given revision. */
+  @JvmOverloads
   fun resolve(
     configuration: Configuration,
     revision: String,
+    declaredKeys: Set<Coordinate.Key> = declaredKeys(configuration),
+  ): Set<DependencyStatus> = resolve(configuration, revision) { declaredKeys }
+
+  /**
+   * Returns the version status of the configuration's dependencies at the given revision, where the
+   * keys the build declared are supplied once the lazy actions that contribute the rest have run.
+   */
+  fun resolve(
+    configuration: Configuration,
+    revision: String,
+    declaredKeys: () -> Set<Coordinate.Key>,
   ): Set<DependencyStatus> {
     // Runs the actions that contribute dependencies lazily, so that the declared set below is read
     // after them rather than before. A contribution missing from that set is discarded as an
@@ -61,17 +77,18 @@ class Resolver(
     // https://github.com/ben-manes/gradle-versions-plugin/issues/987
     configuration.incoming.dependencies
 
-    val current = getCurrentCoordinates(configuration)
+    val current = getCurrentCoordinates(configuration, declaredKeys())
     val latestConfiguration = createLatestConfiguration(configuration, revision, current)
     val root = latestConfiguration.incoming.resolutionResult.root
-    return getStatus(current.coordinates, root)
+    return getStatus(current, root)
   }
 
   /** Returns the version status of the configuration's dependencies. */
   private fun getStatus(
-    coordinates: Map<Coordinate.Key, Coordinate>,
+    current: CurrentCoordinates,
     root: ResolvedComponentResult,
   ): Set<DependencyStatus> {
+    val coordinates = current.coordinates
     val result = hashSetOf<DependencyStatus>()
     for (dependency in root.dependencies) {
       // Constraints do not carry a resolved version to report against.
@@ -85,14 +102,20 @@ class Resolver(
           val originalCoordinate = coordinates[resolvedCoordinate.key]
           val coord = originalCoordinate ?: resolvedCoordinate
           val projectUrl = getProjectUrl(moduleVersion)
-          result.add(DependencyStatus(coord, resolvedCoordinate.version, projectUrl))
+          val contributed = coord.key in current.contributedKeys
+          val configurations = current.contributedConfigurations[coord.key].orEmpty()
+          result.add(
+            DependencyStatus(coord, resolvedCoordinate.version, projectUrl, contributed, configurations),
+          )
         }
         is UnresolvedDependencyResult -> {
           val selector = dependency.attempted as? ModuleComponentSelector ?: continue
           val resolvedCoordinate = Coordinate.from(selector)
           val originalCoordinate = coordinates[resolvedCoordinate.key]
           val coord = originalCoordinate ?: resolvedCoordinate
-          result.add(DependencyStatus(coord, dependency))
+          val contributed = coord.key in current.contributedKeys
+          val configurations = current.contributedConfigurations[coord.key].orEmpty()
+          result.add(DependencyStatus(coord, dependency, contributed, configurations))
         }
       }
     }
@@ -306,7 +329,10 @@ class Resolver(
   }
 
   /** Returns the coordinates for the current (declared) dependency versions. */
-  private fun getCurrentCoordinates(configuration: Configuration): CurrentCoordinates {
+  private fun getCurrentCoordinates(
+    configuration: Configuration,
+    declaredBeforeActions: Set<Coordinate.Key>,
+  ): CurrentCoordinates {
     val declared =
       getResolvableDependencies(configuration)
         .associateBy { it.key }
@@ -314,7 +340,7 @@ class Resolver(
     // run by the time the declared set is read again. That resolution costs nothing. One holding
     // only project or file dependencies is skipped, as resolving it would not.
     if (declared.isEmpty() && configuration.allDependencies.isNotEmpty()) {
-      return CurrentCoordinates(emptyMap(), emptyMap())
+      return CurrentCoordinates(emptyMap(), emptyMap(), emptySet())
     }
 
     // https://github.com/ben-manes/gradle-versions-plugin/issues/231
@@ -380,7 +406,17 @@ class Resolver(
     // Ignore undeclared (hidden) dependencies that appear when resolving a configuration
     coordinates.keys.retainAll(declared.keys + contributed.map { it.key } + substitutions.values)
 
-    return CurrentCoordinates(coordinates, substitutions)
+    // A key only reached via a lazy action (withDependencies/defaultDependencies, or a resolution
+    // listener) is missing from the snapshot taken before any configuration was first resolved, and
+    // is not a substitution target, which traces to a real declaration.
+    val contributedKeys = coordinates.keys - declaredBeforeActions - substitutions.values.toSet()
+
+    return CurrentCoordinates(
+      coordinates,
+      substitutions,
+      contributedKeys,
+      configurationsOf(configuration, contributedKeys),
+    )
   }
 
   /** Returns the modules that a resolution rule substituted for a declared one, by declared key. */
@@ -532,10 +568,15 @@ class Resolver(
     return coordinates
   }
 
-  /** The declared dependencies as resolved, and the modules substituted for any of them. */
+  /**
+   * The declared dependencies as resolved, the modules substituted for any of them, and the keys
+   * that only a lazy action contributed rather than the build declaring them.
+   */
   private class CurrentCoordinates(
     val coordinates: Map<Coordinate.Key, Coordinate>,
     val substitutions: Map<Coordinate.Key, Coordinate.Key>,
+    val contributedKeys: Set<Coordinate.Key> = emptySet(),
+    val contributedConfigurations: Map<Coordinate.Key, List<String>> = emptyMap(),
   )
 
   companion object {
@@ -586,4 +627,67 @@ class Resolver(
       var url: String? = null
     }
   }
+}
+
+/**
+ * Returns the keys that only the named configurations hold, taken across the given one and the
+ * configurations it extends, so that the dependencies of a configuration a plugin alone filled are
+ * known.
+ *
+ * A key another configuration in the hierarchy also holds is left out, as the build declaring a
+ * module that a plugin happens to contribute elsewhere is a declaration of it and not a plugin's.
+ */
+internal fun keysOf(
+  configuration: Configuration,
+  names: Set<String>,
+): Set<Coordinate.Key> {
+  val filled = hashSetOf<Coordinate.Key>()
+  val declared = hashSetOf<Coordinate.Key>()
+  val pending = ArrayDeque(listOf(configuration))
+  val seen = hashSetOf<String>()
+  while (pending.isNotEmpty()) {
+    val next = pending.removeFirst()
+    if (!seen.add(next.name)) {
+      continue
+    }
+    next.dependencies
+      .filterIsInstance<ExternalDependency>()
+      .mapTo(if (next.name in names) filled else declared) { Coordinate.from(it as Dependency).key }
+    pending.addAll(next.extendsFrom)
+  }
+  return filled - declared
+}
+
+/**
+ * Returns the configurations that hold each of the given keys, taken across the given configuration
+ * and the ones it extends, so that a contributed dependency names where it was declared against
+ * rather than the resolvable configuration it was reached through.
+ */
+internal fun configurationsOf(
+  configuration: Configuration,
+  keys: Set<Coordinate.Key>,
+): Map<Coordinate.Key, List<String>> {
+  if (keys.isEmpty()) {
+    return emptyMap()
+  }
+  val names = hashMapOf<Coordinate.Key, MutableSet<String>>()
+  val pending = ArrayDeque(listOf(configuration))
+  val seen = hashSetOf<String>()
+  while (pending.isNotEmpty()) {
+    val next = pending.removeFirst()
+    if (!seen.add(next.name)) {
+      continue
+    }
+    val held =
+      next.dependencies.filterIsInstance<ExternalDependency>().map { Coordinate.from(it as Dependency).key } +
+        // A constraint contributes a key of its own, which the dependencies alone do not name.
+        next.dependencyConstraints.map { Coordinate.from(it).key }
+    for (key in held) {
+      if (key in keys) {
+        names.getOrPut(key) { sortedSetOf() }.add(next.name)
+      }
+    }
+    pending.addAll(next.extendsFrom)
+  }
+  return names.mapValues { (_, held) -> held.toList() }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributedDependencySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributedDependencySpec.groovy
@@ -1,0 +1,540 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import groovy.xml.XmlParser
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for marking a dependency that only a plugin's lazy action contributes, with no
+ * project declaring it, so that a version the build never set (e.g. jacoco's tool version) does
+ * not read as a resolution bug.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1028')
+final class ContributedDependencySpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  /** A 'tool' configuration whose guava dependency only {@code defaultDependencies} contributes. */
+  private static String toolConfiguration(String version = '15.0') {
+    """
+      configurations.create('tool') {
+        canBeResolved = true
+        canBeConsumed = false
+      }
+      configurations.tool.defaultDependencies { deps ->
+        deps.add(project.dependencies.create('com.google.guava:guava:$version'))
+      }
+    """.stripIndent()
+  }
+
+  private void writeBuild(String projectBody) {
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        $projectBody
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Marks a dependency that only a plugin contributes'() {
+    given:
+    writeBuild(toolConfiguration())
+
+    when:
+    def result = run(['dependencyUpdates'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     contributed by a plugin into the 'tool' configuration")
+    result.output.count('contributed by a plugin') == 1
+  }
+
+  def 'Reports the mark in the file reports'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        ${toolConfiguration()}
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json,xml,html'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def xmlReport = new XmlParser()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.xml'))
+    def htmlReport = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    jsonReport.outdated.dependencies[0].contributed == true
+    jsonReport.outdated.dependencies[0].configurations == ['tool']
+    !jsonReport.current.dependencies[0].containsKey('contributed')
+    !jsonReport.current.dependencies[0].containsKey('configurations')
+    xmlReport.outdated.dependencies.outdatedDependency[0].contributed.text() == 'true'
+    xmlReport.outdated.dependencies.outdatedDependency[0].configurations.configuration
+      *.text() == ['tool']
+    !xmlReport.current.dependencies.dependency[0].children()*.name().contains('contributed')
+    !xmlReport.current.dependencies.dependency[0].children()*.name().contains('configurations')
+    htmlReport.contains("contributed by a plugin into the 'tool' configuration")
+  }
+
+  def 'Omits the mark when the build also declares the version'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+
+        ${toolConfiguration()}
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json'])
+    def report = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(' - com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('contributed by a plugin')
+    !report.outdated.dependencies[0].containsKey('contributed')
+  }
+
+  def 'Names the contributing project behind a divergent version'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent())
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        ${toolConfiguration('16.0-rc1')}
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.guava:guava:16.0-rc1${nl}     contributed by a plugin into the 'tool' configuration in :app")
+    result.output.contains(
+      " - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     declared in root project")
+    result.output.count('contributed by a plugin') == 1
+  }
+
+  def 'Omits the mark when the build declares what a plugin filled a sibling with'() {
+    given:
+    writeBuild(
+      """
+        configurations.create('helper')
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+          extendsFrom configurations.helper
+        }
+        configurations.helper.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+
+        dependencies {
+          tool 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(' - com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('contributed by a plugin')
+  }
+
+  def 'Names the configuration a contributed constraint was declared against'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        def listener = new org.gradle.api.artifacts.DependencyResolutionListener() {
+          void beforeResolve(ResolvableDependencies dependencies) {
+            project.dependencies.constraints.add(
+              'implementation', 'com.google.guava:guava:15.0')
+            gradle.removeListener(this)
+          }
+
+          void afterResolve(ResolvableDependencies dependencies) { }
+        }
+        gradle.addListener(listener)
+
+        dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     contributed by a plugin into the 'implementation' configuration")
+  }
+
+  def 'Names every configuration a plugin contributed the coordinate into'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'\ninclude 'lib'"
+    writeBuild(
+      """
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent())
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') << toolConfiguration()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        configurations.create('helper') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        configurations.helper.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     contributed by a plugin into the 'helper' and 'tool' configurations")
+    result.output.count('contributed by a plugin') == 1
+  }
+
+  def 'Marks the dependency when the build read the dependencies while configuring'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'\ninclude 'lib'"
+    ['app', 'lib'].each {
+      testProjectDir.newFolder(it)
+      testProjectDir.newFile("$it/build.gradle") << ''
+    }
+    writeBuild(
+      """
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+
+          ${toolConfiguration()}
+
+          // Reading the incoming dependencies runs the actions that contribute them, so a build
+          // doing so while configuring leaves the dependencies indistinguishable from declared ones
+          // to anything reading the configuration afterwards.
+          afterEvaluate {
+            configurations.findAll { it.canBeResolved }.any { configuration ->
+              configuration.incoming.dependencies.any { it.name == 'guice' }
+            }
+          }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+    def partials = ['', 'app/', 'lib/'].collect {
+      new File(testProjectDir.root, "${it}build/dependencyUpdates/partial.json").text
+    }
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    partials.every { it.contains('"contributed":true') }
+    result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     contributed by a plugin into the 'tool' configuration")
+  }
+
+  def 'Leaves a buildscript dependency unmarked despite a same named project configuration'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            mavenCentral()
+          }
+          dependencies {
+            classpath 'com.google.code.findbugs:jsr305:3.0.1'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('classpath') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        configurations.classpath.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.inject:guice:2.0'))
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.inject:guice [2.0 -> 3.1]${nl}     https://code.google.com/p/google-guice/" +
+        "${nl}     contributed by a plugin into the 'classpath' configuration")
+    result.output.count('contributed by a plugin') == 1
+  }
+
+  def 'Reports a contributed dependency identically across consecutive runs'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'\ninclude 'lib'"
+    writeBuild(
+      """
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent())
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') << toolConfiguration()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        configurations.create('helper') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        configurations.helper.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+      """.stripIndent()
+
+    when:
+    run(['dependencyUpdates', '-DoutputFormatter=text,json,xml'])
+    def firstReports = ['txt', 'json', 'xml'].collectEntries {
+      [(it): new File(testProjectDir.root, "build/dependencyUpdates/report.$it").text]
+    }
+    def result = run(['dependencyUpdates', '-DoutputFormatter=text,json,xml'])
+    def secondReports = ['txt', 'json', 'xml'].collectEntries {
+      [(it): new File(testProjectDir.root, "build/dependencyUpdates/report.$it").text]
+    }
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    firstReports['txt'].contains("contributed by a plugin into the 'helper' and 'tool' configurations")
+    secondReports == firstReports
+  }
+
+  def 'Logs the disagreeing projects when only some contribute a version'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+    writeBuild(
+      """
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        configurations.create('declared') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          declared 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent())
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') << toolConfiguration()
+
+    when:
+    def result = run(['dependencyUpdates', '--info', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      'The projects disagree on whether a plugin contributed com.google.guava:guava, ' +
+        'so it is left unmarked: contributed by :app')
+    !result.output.contains('contributed by a plugin')
+  }
+
+  def 'Marks a contributed dependency that is already at the latest version'() {
+    given:
+    writeBuild(toolConfiguration('16.0-rc1'))
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=text,json'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.guava:guava:16.0-rc1${nl}     contributed by a plugin into the 'tool' configuration")
+    jsonReport.current.dependencies[0].contributed == true
+    jsonReport.current.dependencies[0].configurations == ['tool']
+  }
+
+  def 'Marks a contributed dependency that exceeds the version found'() {
+    given:
+    writeBuild(toolConfiguration('99.0-SNAPSHOT'))
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=text,json'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.guava:guava [99.0-SNAPSHOT <- 16.0-rc1]${nl}     contributed by a plugin into the 'tool' configuration")
+    jsonReport.exceeded.dependencies[0].contributed == true
+    jsonReport.exceeded.dependencies[0].configurations == ['tool']
+  }
+
+  def 'Marks a contributed dependency that fails to resolve'() {
+    given:
+    writeBuild(
+      """
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        configurations.tool.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.github.ben-manes:unresolvable:1.0'))
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    jsonReport.unresolved.dependencies[0].contributed == true
+    jsonReport.unresolved.dependencies[0].configurations == ['tool']
+  }
+
+  def 'Keeps the report byte-identical without contributed dependencies'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=text,json,xml'])
+    def reportFile = new File(testProjectDir.root, 'build/dependencyUpdates/report.txt')
+    def expected =
+      """
+    ------------------------------------------------------------
+    : Project Dependency Updates (report to plain text file)
+    ------------------------------------------------------------
+
+    The following dependencies have later milestone versions:
+     - com.google.inject:guice [2.0 -> 3.1]
+         https://code.google.com/p/google-guice/
+      """.stripIndent().replace('\r', '').replace('\n', System.lineSeparator())
+    def jsonReport = new File(testProjectDir.root, 'build/dependencyUpdates/report.json')
+    def xmlReport = new File(testProjectDir.root, 'build/dependencyUpdates/report.xml')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    reportFile.text == expected
+    !jsonReport.text.contains('"contributed"')
+    !xmlReport.text.contains('contributed')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDependencyUpdatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDependencyUpdatesSpec.groovy
@@ -57,13 +57,18 @@ final class KotlinDependencyUpdatesSpec extends Specification {
 
     then:
     def inheritedByJvmPlugin =
-      / - org\.jetbrains\.kotlin:kotlin-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n/
+      / - org\.jetbrains\.kotlin:kotlin-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n\s+contributed by a plugin into the 'kotlinCompilerClasspath' configuration\n/
     result.output.find(/The following dependencies have later milestone versions:\n/ +
       (applyJvmPlugin ? inheritedByJvmPlugin : '') +
       / - org\.jetbrains\.kotlin:kotlin-gradle-plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]/)
-    // Sorts after kotlin-gradle-plugin, so it falls past the tail of the match above.
+    // Sorts after kotlin-gradle-plugin, so it falls past the tail of the match above. Contributed
+    // via the plugin's own defaultDependencies action, unlike the classpath's own kotlin-stdlib.
     !applyJvmPlugin ||
-      result.output.contains("org.jetbrains.kotlin:kotlin-stdlib-jdk8 [$DECLARED_KOTLIN_VERSION -> 2.")
+      result.output.contains(
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8 [$DECLARED_KOTLIN_VERSION -> 2.")
+    !applyJvmPlugin ||
+      result.output.find(
+        /org\.jetbrains\.kotlin:kotlin-stdlib-jdk8 \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n\s+contributed by a plugin into the 'api' configuration/)
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
@@ -131,7 +136,10 @@ final class KotlinDependencyUpdatesSpec extends Specification {
       .build()
 
     then:
-    result.output.find(/The following dependencies have later milestone versions:\n - org\.jetbrains\.kotlin:kotlin-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-klib-commonizer-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-scripting-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-stdlib \[${explicitStdLibVersion ? DECLARED_KOTLIN_STD_VERSION : DECLARED_KOTLIN_VERSION} -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin\.jvm:org\.jetbrains\.kotlin\.jvm\.gradle\.plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n/)
+    // The compiler and klib artifacts are contributed by the plugin's own defaultDependencies
+    // action; the scripting compiler is added eagerly and kotlin-stdlib is the build's own
+    // declaration, so neither is marked.
+    result.output.find(/The following dependencies have later milestone versions:\n - org\.jetbrains\.kotlin:kotlin-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n\s+contributed by a plugin into the 'kotlinCompilerClasspath' configuration\n - org\.jetbrains\.kotlin:kotlin-klib-commonizer-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n\s+contributed by a plugin into the 'kotlinKlibCommonizerClasspath' configuration\n - org\.jetbrains\.kotlin:kotlin-scripting-compiler-embeddable \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin:kotlin-stdlib \[${explicitStdLibVersion ? DECLARED_KOTLIN_STD_VERSION : DECLARED_KOTLIN_VERSION} -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n - org\.jetbrains\.kotlin\.jvm:org\.jetbrains\.kotlin\.jvm\.gradle\.plugin \[$DECLARED_KOTLIN_VERSION -> 2\..*\]\n\s+https:\/\/kotlinlang\.org\/\n/)
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -32,7 +32,8 @@ final class PartialResultSpec extends Specification {
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
   def 'The observing project is not serialized'() {
     given:
-    def status = new PartialStatus('com.google.guava', 'guava', '1.0', null, '1.0', null, null, ':stamped-project')
+    def status = new PartialStatus(
+      'com.google.guava', 'guava', '1.0', null, '1.0', null, null, false, [], ':stamped-project')
     def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [status], [])
 
     when:
@@ -42,6 +43,39 @@ final class PartialResultSpec extends Specification {
     then:
     !json.contains('stamped-project')
     decoded.statuses[0].projectPath == null
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1028')
+  def 'A partial without the contributed key reads as declared'() {
+    given:
+    def json = '''
+      {"formatVersion":1,"projectPath":":","statuses":[{"group":"com.google.guava",
+      "name":"guava","declaredVersion":"1.0","latestVersion":"1.0"}],"buildscriptStatuses":[]}
+      '''.stripIndent()
+
+    when:
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    decoded.statuses[0].contributed == false
+    decoded.statuses[0].configurations == []
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1028')
+  def 'The contributed flag survives the round trip'() {
+    given:
+    def status =
+      new PartialStatus('com.google.guava', 'guava', '1.0', null, '1.0', null, null, true, ['tool'])
+    def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [status], [])
+
+    when:
+    def json = result.toJson()
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    json.contains('"contributed":true')
+    decoded.statuses[0].contributed
+    decoded.statuses[0].configurations == ['tool']
   }
 
   def 'Rejects an unknown format version'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ProjectEvaluator.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ProjectEvaluator.groovy
@@ -45,12 +45,17 @@ final class ProjectEvaluator {
       Action<ResolutionStrategyWithCurrent> resolutionStrategy, String revision,
       boolean checkConstraints) {
     def resolver = new Resolver(project, resolutionStrategy, checkConstraints)
-    return configurations.findAll { it.canBeResolved }.collectMany { Configuration configuration ->
+    def resolvable = configurations.findAll { it.canBeResolved }
+    // Snapshotted for every configuration before the first resolution, as resolving one
+    // configuration runs the lazy actions of the configurations it extends.
+    def declaredKeys = resolvable.collectEntries { [(it): resolver.declaredKeys(it)] }
+    return resolvable.collectMany { Configuration configuration ->
       try {
-        return resolver.resolve(configuration, revision).collect {
+        return resolver.resolve(configuration, revision, declaredKeys[configuration]).collect {
           def status = it.toPartialStatus()
           new PartialStatus(status.group, status.name, status.declaredVersion, status.userReason,
-            status.latestVersion, status.projectUrl, status.unresolved, project.path)
+            status.latestVersion, status.projectUrl, status.unresolved, status.contributed,
+            status.configurations, project.path)
         }
       } catch (Exception e) {
         project.logger.info("Skipping configuration ${project.path}:${configuration.name}", e)

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
@@ -119,6 +119,41 @@ final class ReportJoinSpec extends Specification {
     result.outdated.dependencies.find { it.version == '3.0' }.projects == [':app']
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1028')
+  def 'A version declared by any project is not marked contributed'() {
+    given:
+    def root = ProjectBuilder.builder().withName('root').build()
+    def a = ProjectBuilder.builder().withName('a').withParent(root).build()
+    def b = ProjectBuilder.builder().withName('b').withParent(root).build()
+    def localMavenRepo = getClass().getResource('/maven/')
+    for (project in [a, b]) {
+      project.repositories {
+        maven {
+          url localMavenRepo.toURI()
+        }
+      }
+    }
+    a.configurations {
+      app
+    }
+    a.dependencies {
+      app 'com.google.inject:guice:3.0'
+    }
+    b.configurations.create('tool') {
+      canBeResolved = true
+      canBeConsumed = false
+    }
+    b.configurations.tool.defaultDependencies { deps ->
+      deps.add(b.dependencies.create('com.google.inject:guice:3.0'))
+    }
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.outdated.dependencies.find { it.name == 'guice' }.contributed == null
+  }
+
   /**
    * A root project whose two children declare the same module, where the first child's repository
    * hides the versions matching {@code hiddenVersionRegex}. The latest version found therefore

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolutionListenerSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolutionListenerSpec.groovy
@@ -34,6 +34,8 @@ final class ResolutionListenerSpec extends Specification {
       it*.version == ['15.0', '2.0']
       it*.available*.milestone == ['16.0-rc1', '3.1']
     }
+    result.outdated.dependencies.find { it.name == 'guava' }.contributed == true
+    result.outdated.dependencies.find { it.name == 'guice' }.contributed == null
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/992')


### PR DESCRIPTION
This PR marks the dependencies that only a plugin contributed, and names the configuration each came from. Without the mark, a `jacoco`, `checkstyle` or `pmd` tool version the build never sets reports at a Gradle built-in that appears nowhere in the build script, and reads as a resolution bug. I couldn't find a way to associate a contributed dependency with the contributing plugin's coordinates, so naming the configuration seemed the next best thing.

Before, on a build applying those three plugins with no `toolVersion` set for any of them, plus a guava dependency the build declares explicitly as a control:

```
The following dependencies have later milestone versions:
 - com.google.guava:guava [31.1-jre -> 33.6.0-jre]
     https://github.com/google/guava
 - com.puppycrawl.tools:checkstyle [9.3 -> 13.9.0]
     https://checkstyle.org/
 - net.sourceforge.pmd:pmd-java [6.55.0 -> 7.26.0]
     https://pmd.github.io/
 - org.jacoco:org.jacoco.agent [0.8.9 -> 0.8.15]
     http://jacoco.org
 - org.jacoco:org.jacoco.ant [0.8.9 -> 0.8.15]
     http://jacoco.org
```

After:

```
The following dependencies have later milestone versions:
 - com.google.guava:guava [31.1-jre -> 33.6.0-jre]
     https://github.com/google/guava
 - com.puppycrawl.tools:checkstyle [9.3 -> 13.9.0]
     https://checkstyle.org/
     contributed by a plugin into the 'checkstyle' configuration
 - net.sourceforge.pmd:pmd-java [6.55.0 -> 7.26.0]
     https://pmd.github.io/
     contributed by a plugin into the 'pmd' configuration
 - org.jacoco:org.jacoco.agent [0.8.9 -> 0.8.15]
     http://jacoco.org
     contributed by a plugin into the 'jacocoAgent' configuration
 - org.jacoco:org.jacoco.ant [0.8.9 -> 0.8.15]
     http://jacoco.org
     contributed by a plugin into the 'jacocoAnt' configuration
```

On `dejan2609/kafka` @ `442120e47f4` from #1032, all 134 jacoco statuses across its 67 projects come back marked, identically across two consecutive runs.

Addresses #1028
