### PR TITLE
Test and document Gradle 9.7.0-rc-2 as the current release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following dependencies have later milestone versions:
      https://spring.io/projects/spring-boot
 
 Gradle release-candidate updates:
- - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-1]
+ - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-2]
 ```
 
 ### Configuring the task
@@ -670,7 +670,7 @@ Failed to determine the latest version for the following dependencies (use --inf
  - dom4j:dom4j
 
 Gradle release-candidate updates:
- - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-1]
+ - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-2]
 ```
 
 </details>
@@ -866,7 +866,7 @@ Alternatively, the report may be output to a structured file.
    "isFailure": false,
    "isUpdateAvailable": true,
    "reason": "",
-   "version": "9.7.0-rc-1"
+   "version": "9.7.0-rc-2"
   },
   "nightly": {
    "isFailure": false,
@@ -1038,7 +1038,7 @@ Searched in the following locations:
             <reason/>
         </current>
         <releaseCandidate>
-            <version>9.7.0-rc-1</version>
+            <version>9.7.0-rc-2</version>
             <isUpdateAvailable>true</isUpdateAvailable>
             <isFailure>false</isFailure>
             <reason/>

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -66,7 +66,7 @@ final class ContributorAggregationSpec extends Specification {
 
   private def run(String... arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
+      .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()
@@ -187,7 +187,7 @@ final class ContributorAggregationSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
+      .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
       .withArguments(':dependencyUpdates')
       .withPluginClasspath()
@@ -209,7 +209,7 @@ final class ContributorAggregationSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
+      .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
       .withArguments(':app:dependencyUpdates')
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
@@ -95,7 +95,7 @@ final class InitScriptAggregationSpec extends Specification {
 
   private def run(String... arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
+      .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -65,7 +65,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
 
   private def run() {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
+      .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
       .withArguments(':dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
         '--configuration-cache')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
@@ -120,7 +120,7 @@ final class SettingsClasspathSpec extends Specification {
       'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]'
 
     when:
-    def stored = runOn('9.7.0-rc-1', arguments)
+    def stored = runOn('9.7.0-rc-2', arguments)
 
     then:
     stored.task(':dependencyUpdates').outcome == SUCCESS
@@ -128,7 +128,7 @@ final class SettingsClasspathSpec extends Specification {
     stored.output.contains(expected)
 
     when:
-    def hit = runOn('9.7.0-rc-1', arguments)
+    def hit = runOn('9.7.0-rc-2', arguments)
 
     then:
     hit.task(':dependencyUpdates').outcome == SUCCESS

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -74,7 +74,7 @@ final class SettingsPluginAggregationSpec extends Specification {
 
   private def runWith(List<String> arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-1')
+      .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()


### PR DESCRIPTION
Gradle 9.7.0-rc-2 is out. The specs that pin a release candidate now run on it, and the sample reports name it.