### PR TITLE
Prepare the 0.58.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
 - [Samples](#samples)
 - [Compatibility](#compatibility)
 - [Migrating from prior versions](#migrating-from-prior-versions)
+  - [v0.57.0](#v0570)
   - [v0.56.0](#v0560)
   - [v0.55.0](#v0550)
   - [v0.54.0 and earlier](#v0540-and-earlier)
@@ -1510,6 +1511,23 @@ projects (see [Isolated projects](#isolated-projects)) are supported.
 Start at the subsection for the version your build is on and work upward: each
 subsection migrates to the version covered by the subsection above it, and the
 topmost migrates to the current release.
+
+### v0.57.0
+
+v0.58.0 routes the reporters through the build's logger and adds attribution
+lines to the reports:
+
+* The console summary now prints at the lifecycle log level, so `--quiet`
+  suppresses it. The report file is still written; read it, or drop `--quiet`,
+  if a script was piping the console output (see [Report
+  format](#report-format)).
+* An entry may carry an indented attribution line naming the projects that
+  declared a divergent version (see [Multi-project
+  builds](#multi-project-builds)) or the configuration a plugin contributed it
+  into (see [The `dependencyUpdates`
+  task](#the-dependencyupdates-task)). A tool that parses the plain
+  text report line by line has to skip them; the JSON and XML reports carry the
+  same signal as fields instead.
 
 ### v0.56.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ben-manes
-VERSION_NAME=0.57.0
+VERSION_NAME=0.58.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps the version for the v0.58.0 release. Let me know if there's anything more you want included in this release.

Draft release notes below.

---

* Honor the build's log level in the reporters: the console summary prints at the lifecycle level, so `--quiet` suppresses it; a skipped report file is logged at the info level; the "use --info for details" hint is dropped when the build already runs at that level; and an unresolved dependency no longer reports a version string as its project url (#278, #388, #726, #844, #1033)
* Report a module published only as a snapshot as up to date, rather than as a failure to determine its latest version (#475, #1034)
* Skip the buildscript classpath of a project that declares no repository, which previously reported each of that project's buildscript dependencies as a failure to determine its latest version (#756, #1038)
* Name the projects that declared each version when one coordinate resolves to more than one, so the merged report of a multi-project build no longer prints the same dependency several times with nothing telling the entries apart (#1032, #1035)
* Mark a dependency that only a plugin contributed and name the configuration it came from, so a `jacoco`, `checkstyle` or `pmd` tool version the build never sets no longer reads as a resolution bug (#1028, #1032, #1036)

> [!NOTE]
>
> The console summary now honors the log level, so a script running the task under `--quiet` no longer sees it. The report file is still written. Report entries may also carry an indented attribution line naming the projects that declared a divergent version or the configuration a plugin contributed the dependency into, which a tool parsing the plain text report line by line has to skip. See [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#v0570).
