### PR TITLE
Write the partial results under the project that aggregates them (fixes #1040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
 - [Samples](#samples)
 - [Compatibility](#compatibility)
 - [Migrating from prior versions](#migrating-from-prior-versions)
+  - [v0.58.0](#v0580)
   - [v0.57.0](#v0570)
   - [v0.56.0](#v0560)
   - [v0.55.0](#v0550)
@@ -1511,6 +1512,17 @@ projects (see [Isolated projects](#isolated-projects)) are supported.
 Start at the subsection for the version your build is on and work upward: each
 subsection migrates to the version covered by the subsection above it, and the
 topmost migrates to the current release.
+
+### v0.58.0
+
+v0.59.0 collects the partial result of every project under the project that
+aggregates them, so a project that exists only to hold a nested `include` no
+longer gains a `build` directory of its own:
+
+* Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the
+  `build/dependencyUpdates/partial.json` that earlier releases wrote into each
+  project. `clean` removes it from a project that applies a plugin of its own,
+  but a project with no build script has no `clean` task to reach it.
 
 ### v0.57.0
 

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,35 @@ configuration cache the dependency metadata read during resolution is tracked as
 an input, so a newly published version invalidates the cached entry rather than
 serving a stale report.
 
+The merged report and the partial results it merges live in the aggregating
+project's build directory. `clean` removes them only if that project has a
+`clean` task, which the `base` plugin supplies. A root project that applies no
+other plugin can add `base` for that alone; the task itself does not need it.
+
+<details open>
+<summary>Kotlin</summary>
+
+"build.gradle.kts":
+```kotlin
+plugins {
+  base
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+"build.gradle":
+```groovy
+plugins {
+  id 'base'
+}
+```
+
+</details>
+
 When a coordinate's declared version differs across the aggregated projects, the
 plain text, JSON, XML, and HTML reports name the projects that declared each
 version, so the entry no longer reads as self-contradictory:

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -208,8 +208,10 @@ internal fun registerAggregation(
         // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
         val outputFile = partialsDirectory.map { it.file(partialFileName(aggregated.path)) }
         val partial = registerProducer(aggregated, service, outputFile)
+        val legacy = aggregated.layout.buildDirectory.file("dependencyUpdates/partial.json")
         accumulator.configure { task ->
           task.partialResults.from(partial.flatMap { it.outputFile })
+          task.legacyPartials.from(legacy)
         }
       }
     }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -9,6 +9,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
+import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.provider.Provider
@@ -157,10 +158,12 @@ internal fun registerAggregation(
   val aggregatedPaths =
     project.allprojects.filter { it.buildFile.exists() }.map { it.path }.toSet()
 
+  val partialsDirectory = project.layout.buildDirectory.dir("dependencyUpdates/partials")
   accumulator.configure { task ->
     task.projectPath = project.path
     task.aggregatedProjectPaths = aggregatedPaths
     task.projectDirectory.set(project.layout.projectDirectory)
+    task.partialsDirectory.set(partialsDirectory)
     task.partialResults.from(
       results.incoming
         .artifactView { view ->
@@ -198,7 +201,13 @@ internal fun registerAggregation(
       // A project that another copy of the plugin claimed holds a producer of that copy's type,
       // which this one cannot wire to its accumulator. That copy reports the project instead.
       if (claims(aggregated)) {
-        val partial = registerProducer(aggregated, service)
+        // Written under the project that aggregates rather than each project's own build
+        // directory, so that a project which exists only to hold a nested include gains no build
+        // directory of its own. Isolated projects keeps the per-project default instead, as there
+        // every producer belongs to a project that applied the plugin itself.
+        // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
+        val outputFile = partialsDirectory.map { it.file(partialFileName(aggregated.path)) }
+        val partial = registerProducer(aggregated, service, outputFile)
         accumulator.configure { task ->
           task.partialResults.from(partial.flatMap { it.outputFile })
         }
@@ -224,9 +233,19 @@ private fun parametersService(gradle: Gradle): Provider<DependencyUpdatesParamet
   gradle.sharedServices
     .registerIfAbsent(PARAMETERS_SERVICE, DependencyUpdatesParametersService::class.java) { }
 
+/**
+ * Returns a distinct file name for the partial result of the project at [path]. The hash keeps
+ * paths that flatten alike apart, as `:lib:core` and `:lib-core` may both exist in one build.
+ */
+private fun partialFileName(path: String): String {
+  val name = if (path == ":") "root" else path.removePrefix(":").replace(':', '-')
+  return "$name-${Integer.toHexString(path.hashCode())}.json"
+}
+
 private fun registerProducer(
   project: Project,
   service: Provider<DependencyUpdatesParametersService>,
+  outputFile: Provider<RegularFile>? = null,
 ): TaskProvider<DependencyUpdatesPartialTask> {
   val tasks = project.tasks
   if (tasks.names.contains(PARTIAL_TASK_NAME)) {
@@ -248,7 +267,7 @@ private fun registerProducer(
   val partial =
     tasks.register(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java) { task ->
       task.outputFile.convention(
-        project.layout.buildDirectory.file("dependencyUpdates/partial.json"),
+        outputFile ?: project.layout.buildDirectory.file("dependencyUpdates/partial.json"),
       )
       task.partialJson.set(
         // Realized after every project has been evaluated, so that the settings are read as last

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -171,6 +171,10 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   @Internal
   var aggregatedProjectPaths: Set<String> = emptySet()
 
+  /** The directory the partial results are collected under, wired by the plugin. */
+  @get:Internal
+  val partialsDirectory: DirectoryProperty = project.objects.directoryProperty()
+
   /** Captured at configuration time; replaces `project.file()` at execution. */
   @get:Internal
   val projectDirectory: DirectoryProperty =
@@ -185,6 +189,16 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   /** Merges the partial results of every project and writes the report. */
   @TaskAction
   fun dependencyUpdates() {
+    // Sweeps the partial of any project that has left the build, which no remaining task owns. The
+    // files are wired by path rather than discovered, so a stale one is never read, only left
+    // behind. The directory stays undeclared as an output, as declaring it would overlap the
+    // producers' own output files.
+    val expected = partialResults.files
+    partialsDirectory.asFile.orNull
+      ?.listFiles()
+      ?.filter { it.isFile && it !in expected }
+      ?.forEach { it.delete() }
+
     val partials =
       partialResults.files
         .map { PartialResult.fromJson(it.readText()) }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 import java.io.File
 import javax.annotation.Nullable
 
@@ -175,6 +176,22 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   @get:Internal
   val partialsDirectory: DirectoryProperty = project.objects.directoryProperty()
 
+  /** Where each project's partial result was written before they were collected as one. */
+  @get:Internal
+  val legacyPartials: ConfigurableFileCollection = project.files()
+
+  /**
+   * Whether to remove the partial results that an earlier release wrote into each project's own
+   * build directory. Opt in, as the task otherwise writes nothing outside the project it reports
+   * from, and `clean` reaches these files in every project that applies a plugin of its own.
+   */
+  @get:Internal
+  @set:Option(
+    option = "clean-legacy-partials",
+    description = "Removes the partial results that earlier releases wrote into each project.",
+  )
+  var cleanLegacyPartials: Boolean = false
+
   /** Captured at configuration time; replaces `project.file()` at execution. */
   @get:Internal
   val projectDirectory: DirectoryProperty =
@@ -198,6 +215,23 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
       ?.listFiles()
       ?.filter { it.isFile && it !in expected }
       ?.forEach { it.delete() }
+
+    // Removes what an earlier release wrote into each project's own build directory, which `clean`
+    // cannot reach in a project that applies no plugin of its own, as `clean` comes from the base
+    // plugin. A file that a producer still writes there is held back, as one does under isolated
+    // projects. The directories are removed only while empty, which is all that delete() will do.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
+    if (cleanLegacyPartials) {
+      for (legacy in legacyPartials.files - expected) {
+        if (legacy.delete()) {
+          val reports = legacy.parentFile
+          val buildDirectory = reports.parentFile
+          if (reports.delete()) {
+            buildDirectory.delete()
+          }
+        }
+      }
+    }
 
     val partials =
       partialResults.files

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -295,6 +295,84 @@ final class AggregationSpec extends Specification {
     !result.output.contains('com.google.guava:guava')
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'A project without a build script gains no build directory'() {
+    given:
+    new File(testProjectDir.root, 'settings.gradle').text = "include ':apps:app-a'"
+    testProjectDir.newFolder('apps', 'app-a')
+    testProjectDir.newFile('apps/app-a/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('The dependency updates report is missing')
+    !new File(testProjectDir.root, 'apps/build').exists()
+    // The partial results are written under the project that aggregates them instead.
+    new File(testProjectDir.root, 'build/dependencyUpdates/partials').list().length == 3
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Sweeps the partial result of a project removed from the build'() {
+    given:
+    def partialsDir = new File(testProjectDir.root, 'build/dependencyUpdates/partials')
+
+    when:
+    run(['dependencyUpdates'])
+
+    then:
+    partialsDir.list().length == 3
+
+    when:
+    new File(testProjectDir.root, 'settings.gradle').text = "include 'app'"
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    partialsDir.list().length == 2
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('guava')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Aggregates a dependency declared on a project without a build script'() {
+    given:
+    new File(testProjectDir.root, 'settings.gradle').text = "include ':apps:app-a'"
+    testProjectDir.newFolder('apps', 'app-a')
+    testProjectDir.newFile('apps/app-a/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    new File(testProjectDir.root, 'build.gradle') <<
+      """
+        project(':apps') {
+          dependencies {
+            implementation 'com.example:jvm-library:1.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // The container project itself observes this dependency, so a producer skipped for the lack
+    // of a build script would silently drop it from the report.
+    result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !new File(testProjectDir.root, 'apps/build').exists()
+  }
+
   def 'Resolves the aggregation results without traversing the projects dependencies'() {
     given:
     new File(testProjectDir.root, 'build.gradle') <<

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -320,6 +320,52 @@ final class AggregationSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Removes the partial results of an earlier release when asked'() {
+    given:
+    new File(testProjectDir.root, 'settings.gradle').text = "include ':apps:app-a'"
+    testProjectDir.newFolder('apps', 'app-a')
+    testProjectDir.newFile('apps/app-a/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    // As 0.55.0 through 0.57.0 left them, in a project that no clean task reaches.
+    def container = new File(testProjectDir.root, 'apps/build/dependencyUpdates/partial.json')
+    container.parentFile.mkdirs()
+    container.text = '{"formatVersion":1,"projectPath":":apps","statuses":[],"buildscriptStatuses":[]}'
+    def module = new File(testProjectDir.root, 'apps/app-a/build/dependencyUpdates/partial.json')
+    module.parentFile.mkdirs()
+    module.text = '{"formatVersion":1,"projectPath":":apps:app-a","statuses":[],"buildscriptStatuses":[]}'
+    def kept = new File(testProjectDir.root, 'apps/app-a/build/reports/keep.txt')
+    kept.parentFile.mkdirs()
+    kept.text = 'output of another task'
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // Left alone until asked for, as the task otherwise writes nothing into another project.
+    container.exists()
+    module.exists()
+
+    when:
+    result = run(['dependencyUpdates', '--clean-legacy-partials'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !container.exists()
+    !module.exists()
+    // The directory a container project gained goes with it, while a build directory holding
+    // anything else stays.
+    !new File(testProjectDir.root, 'apps/build').exists()
+    !new File(testProjectDir.root, 'apps/app-a/build/dependencyUpdates').exists()
+    kept.exists()
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
   def 'Sweeps the partial result of a project removed from the build'() {
     given:
     def partialsDir = new File(testProjectDir.root, 'build/dependencyUpdates/partials')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributedDependencySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributedDependencySpec.groovy
@@ -306,13 +306,13 @@ final class ContributedDependencySpec extends Specification {
 
     when:
     def result = run(['dependencyUpdates', '--no-parallel'])
-    def partials = ['', 'app/', 'lib/'].collect {
-      new File(testProjectDir.root, "${it}build/dependencyUpdates/partial.json").text
-    }
+    def partials = new File(testProjectDir.root, 'build/dependencyUpdates/partials')
+      .listFiles().collect { it.text }
     def nl = System.lineSeparator()
 
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
+    partials.size() == 3
     partials.every { it.contains('"contributed":true') }
     result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}     contributed by a plugin into the 'tool' configuration")
   }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -63,12 +63,12 @@ final class IsolatedProjectsAggregationSpec extends Specification {
       """.stripIndent()
   }
 
-  private def run() {
+  private def run(List<String> arguments = []) {
     return GradleRunner.create()
       .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
-      .withArguments(':dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
-        '--configuration-cache')
+      .withArguments([':dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+        '--configuration-cache'] + arguments)
       .withPluginClasspath()
       .build()
   }
@@ -82,6 +82,23 @@ final class IsolatedProjectsAggregationSpec extends Specification {
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
     !result.output.contains('The dependency updates report is missing')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Keeps every projects partial result where the producer wrote it'() {
+    when:
+    def result = run(['--clean-legacy-partials'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // Every producer belongs to the project that applied the plugin, so each writes to its own
+    // build directory and the cleanup must reach none of them.
+    new File(testProjectDir.root, 'build/dependencyUpdates/partial.json').exists()
+    new File(testProjectDir.root, 'app/build/dependencyUpdates/partial.json').exists()
+    new File(testProjectDir.root, 'lib/build/dependencyUpdates/partial.json').exists()
+    !new File(testProjectDir.root, 'build/dependencyUpdates/partials').exists()
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
   }
 
   def 'Honors the root task settings in every projects producer'() {


### PR DESCRIPTION
Fixes #1040.

This PR writes the partial results under the project that aggregates them instead of each project's own build directory. For the issue's reproducer, `./gradlew dependencyUpdates` used to leave:

```
apps/app-a/build/dependencyUpdates/partial.json
apps/app-b/build/dependencyUpdates/partial.json
apps/build/dependencyUpdates/partial.json
build/dependencyUpdates/partial.json
```

and now leaves only:

```
build/dependencyUpdates/partials/apps-35f1dac.json
build/dependencyUpdates/partials/apps-app-a-c809bc67.json
build/dependencyUpdates/partials/apps-app-b-c809bc68.json
build/dependencyUpdates/partials/root-3a.json
```

I didn't filter the producers to the projects with a build script, because a build can declare dependencies on a container project (`project(':apps') { dependencies { ... } }`) and skipping its producer would silently drop them from the report. A `--clean-legacy-partials` option removes what earlier releases left behind, which `clean` cannot reach in a project that applies no plugin of its own.
