### PR TITLE
Report the version that actually failed to resolve (fixes 1043)

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -162,7 +162,9 @@ class PlainTextReporter
           "Failed to determine the latest version for the following dependencies$hint:",
         )
         for (dependency in unresolved) {
-          printStream.println(" - " + label(dependency))
+          val version = dependency.version
+          val versionSuffix = if (version.isNullOrEmpty() || version == "none") "" else ":$version"
+          printStream.println(" - ${label(dependency)}$versionSuffix")
           dependency.userReason?.let {
             printStream.println("     $it")
           }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -71,6 +71,8 @@ class DependencyStatus {
           selector.module,
           selector.version,
           reason,
+          coordinate.version,
+          coordinate.userReason,
         )
       }
     return PartialStatus(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -267,16 +267,16 @@ class DependencyUpdatesReporter(
   }
 
   private fun buildUnresolvedDependency(info: UnresolvedInfo): DependencyUnresolved {
-    val coordinate = currentVersions[keyOf(info)]
+    val declared = Coordinate(info.selectorGroup, info.selectorName, info.declaredVersion)
     return DependencyUnresolved(
       group = info.selectorGroup,
       name = info.selectorName,
-      version = coordinate?.version,
+      version = info.declaredVersion,
       projectUrl = projectUrls[keyOf(info)],
-      userReason = coordinate?.userReason,
+      userReason = info.userReason,
       reason = info.failureText,
-      contributed = coordinate?.let { contributedFlag(it) },
-      configurations = coordinate?.let { configurationsByCoordinate[it] },
+      contributed = contributedFlag(declared),
+      configurations = configurationsByCoordinate[declared],
     )
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -29,12 +29,17 @@ data class PartialStatus
   }
 
 /** A resolution failure, as a value that survives the project boundary. */
-data class UnresolvedInfo(
-  val selectorGroup: String,
-  val selectorName: String,
-  val selectorVersion: String,
-  val failureText: String,
-)
+data class UnresolvedInfo
+  @JvmOverloads
+  constructor(
+    val selectorGroup: String,
+    val selectorName: String,
+    val selectorVersion: String,
+    val failureText: String,
+    /** The version of the declaration that failed, "none" when it declared none. */
+    val declaredVersion: String = "none",
+    val userReason: String? = null,
+  )
 
 /** The statuses one project observed, as written by its producer task. */
 data class PartialResult(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
@@ -7,6 +7,7 @@ import groovy.xml.XmlParser
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
 import spock.lang.Specification
 
 final class OutputFormatterSpec extends Specification {
@@ -456,6 +457,43 @@ final class OutputFormatterSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1043')
+  def 'outputFormatter plain - omits the version an unresolved dependency never declared'() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        dependencies {
+          implementation 'com.github.ben-manes:unresolvable'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+        """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains(' - com.github.ben-manes:unresolvable\n')
+    !result.output.contains('unresolvable:none')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def 'outputFormatter plain - outputs text output with user reasons'() {
     given:
     def reportFile = new File(reportFolder, "report.txt")
@@ -523,9 +561,9 @@ The following dependencies have later milestone versions:
      https://code.google.com/p/google-guice/
 
 Failed to determine the latest version for the following dependencies (use --info for details):
- - com.github.ben-manes:unresolvable
+ - com.github.ben-manes:unresolvable:1.0
      Life is hard
- - com.github.ben-manes:unresolvable2
+ - com.github.ben-manes:unresolvable2:1.0
 """.replace('\r', '').replace('\n', System.lineSeparator())
     def actual = reportFile.text
 
@@ -612,10 +650,10 @@ The following dependencies have later milestone versions:
      https://code.google.com/p/google-guice/
 
 Failed to determine the latest version for the following dependencies (use --info for details):
- - com.github.ben-manes:unresolvable
+ - com.github.ben-manes:unresolvable:1.0
      Life is hard
- - com.github.ben-manes:unresolvable2
- - com.github.ben-manes:unresolvable3
+ - com.github.ben-manes:unresolvable2:1.0
+ - com.github.ben-manes:unresolvable3:1.0
 """.replace('\r', '').replace('\n', System.lineSeparator())
 
     then:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -78,6 +78,24 @@ final class PartialResultSpec extends Specification {
     decoded.statuses[0].configurations == ['tool']
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1043')
+  def 'A partial without the declared unresolved version reads as none'() {
+    given:
+    def json = '''
+      {"formatVersion":1,"projectPath":":","statuses":[{"group":"com.google.guava",
+      "name":"guava","declaredVersion":"none","latestVersion":"none","unresolved":
+      {"selectorGroup":"com.google.guava","selectorName":"guava","selectorVersion":"+",
+      "failureText":"boom"}}],"buildscriptStatuses":[]}
+      '''.stripIndent()
+
+    when:
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    decoded.statuses[0].unresolved.declaredVersion == 'none'
+    decoded.statuses[0].unresolved.userReason == null
+  }
+
   def 'Rejects an unknown format version'() {
     given:
     def json = new PartialResult(99, ':', [], []).toJson()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/UnresolvedVersionSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/UnresolvedVersionSpec.groovy
@@ -1,0 +1,136 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for reporting the declaration whose resolution failed, rather than another
+ * declaration of the same module.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1043')
+final class UnresolvedVersionSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private void writeRoot(List<String> projects) {
+    testProjectDir.newFile('settings.gradle') << "include ${projects.collect { "'$it'" }.join(', ')}"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+  }
+
+  /** Writes a project holding the given body, seeing a repository only when one is asked for. */
+  private void writeProject(String name, String body, boolean seeing = false) {
+    def repositories = seeing ? "repositories { maven { url '${mavenRepoUrl}' } }" : ''
+    testProjectDir.newFolder(name)
+    testProjectDir.newFile("$name/build.gradle") <<
+      """
+        apply plugin: 'java'
+
+        $repositories
+
+        $body
+      """.stripIndent()
+  }
+
+  private static String declaring(String coordinate, String reason = null) {
+    def because = reason ? "{ because '$reason' }" : ''
+    return "dependencies { implementation('$coordinate') $because }"
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  private def unresolved() {
+    return new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+      .unresolved.dependencies
+  }
+
+  def 'Reports the version that failed to resolve rather than the lowest declared'() {
+    given:
+    writeRoot(['blind', 'seeing'])
+    writeProject('blind', declaring('com.google.inject:guice:3.0', 'blind pinned 3.0'))
+    writeProject('seeing', declaring('com.google.inject:guice:2.0', 'seeing declared 2.0'), true)
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+    def unresolved = unresolved()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    unresolved.size() == 1
+    unresolved[0].version == '3.0'
+    unresolved[0].userReason == 'blind pinned 3.0'
+    def unresolvedSection = result.output.substring(result.output.indexOf('Failed to determine'))
+    unresolvedSection.contains(' - com.google.inject:guice:3.0')
+    unresolvedSection.contains('blind pinned 3.0')
+    !unresolvedSection.contains('seeing declared 2.0')
+  }
+
+  def 'Reports every declared version that failed to resolve'() {
+    given:
+    writeRoot(['blind', 'alsoBlind'])
+    writeProject('blind', declaring('com.google.inject:guice:2.0'))
+    writeProject('alsoBlind', declaring('com.google.inject:guice:3.0'))
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json', '--no-parallel'])
+    def unresolved = unresolved()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    unresolved.size() == 2
+    unresolved*.version.sort() == ['2.0', '3.0']
+  }
+
+  def 'Marks the contributed declaration that failed to resolve'() {
+    given:
+    writeRoot(['blind', 'seeing'])
+    writeProject(
+      'blind',
+      """
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        configurations.tool.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:16.0-rc1'))
+        }
+      """.stripIndent())
+    writeProject('seeing', declaring('com.google.guava:guava:15.0'), true)
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json', '--no-parallel'])
+    def unresolved = unresolved()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    unresolved.size() == 1
+    unresolved[0].version == '16.0-rc1'
+    unresolved[0].contributed == true
+    unresolved[0].configurations == ['tool']
+  }
+}


### PR DESCRIPTION
Fixes #1043

This PR reports the declared version whose resolution failed, along with its `because` reason, in place of the lowest declared version of the same module. It also prints that version in the plain text unresolved section, which was the one section of the report that carried no version. The new field on the partial result takes a default, so the format version is unchanged.

Before, with `:blind` declaring guice 7.0.0 against no repository and `:seeing` declaring 5.0.1 against Maven Central:

```
Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.inject:guice
     seeing declared 5.0.1
     https://github.com/google/guice
```

After:

```
Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.inject:guice:7.0.0
     blind pinned 7.0.0
     https://github.com/google/guice
```

A dependency declared without a version still prints the bare coordinate, as the undeclared section does.

Two projects failing the same module at different versions now report both entries, where one of the two used to be invisible, so `unresolved.count` counts failing declarations rather than failing modules.
