### PR TITLE
Skip a refused plugin mark, collect the partials, and aggregate a fallback publisher (fixes #1046, #1047, #1048, #1049)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,14 +1551,10 @@ aggregates them, so a project that exists only to hold a nested `include` no
 longer gains a `build` directory of its own:
 
 > [!TIP]
-> * Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the
->   `build/dependencyUpdates/partial.json` that earlier releases wrote into each
->   project. `clean` removes it from a project that applies a plugin of its own,
->   but a project with no build script has no `clean` task to reach it.
-> * Under isolated projects the flag removes nothing, as the report reads the
->   results as artifacts and those do not carry where an earlier release wrote
->   them. Delete the leftover `build` directory of any project that has no build
->   script of its own.
+> Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the
+> `build/dependencyUpdates/partial.json` that earlier releases wrote into each
+> project. `clean` removes it from a project that applies a plugin of its own,
+> but a project with no build script has no `clean` task to reach it.
 
 ### v0.57.0
 

--- a/README.md
+++ b/README.md
@@ -1551,10 +1551,14 @@ aggregates them, so a project that exists only to hold a nested `include` no
 longer gains a `build` directory of its own:
 
 > [!TIP]
-> Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the
-> `build/dependencyUpdates/partial.json` that earlier releases wrote into each
-> project. `clean` removes it from a project that applies a plugin of its own,
-> but a project with no build script has no `clean` task to reach it.
+> * Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the
+>   `build/dependencyUpdates/partial.json` that earlier releases wrote into each
+>   project. `clean` removes it from a project that applies a plugin of its own,
+>   but a project with no build script has no `clean` task to reach it.
+> * Under isolated projects the flag removes nothing, as the report reads the
+>   results as artifacts and those do not carry where an earlier release wrote
+>   them. Delete the leftover `build` directory of any project that has no build
+>   script of its own.
 
 ### v0.57.0
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -7,6 +7,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
@@ -169,8 +170,21 @@ internal fun registerAggregation(
       }
     }
   // Mirrored rather than extended, which a detached configuration forbids, so that a project
-  // declared in the build's own dependencies block is still aggregated.
-  aggregation.get().dependencies.all { dependency -> results.dependencies.add(dependency) }
+  // declared in the build's own dependencies block is still aggregated. The producer's
+  // configuration is named on the way through, as it is for the projects below, so that a project
+  // declaring no variant of its own is read by name rather than fallen back to its `default`
+  // configuration, whose artifacts are the project's own and not a partial result. Every module
+  // dependency is named rather than the project ones alone, as an included build is declared by
+  // its coordinates and substituted onto its project only once the graph resolves.
+  aggregation.get().dependencies.all { dependency ->
+    results.dependencies.add(
+      if (dependency is ModuleDependency) {
+        dependency.copy().apply { targetConfiguration = ELEMENTS_CONFIGURATION }
+      } else {
+        dependency
+      },
+    )
+  }
 
   // Reading the paths across projects is permitted under isolated projects, unlike configuring. A
   // project with no build script cannot apply the plugin there, so naming it in the completeness

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -82,6 +82,16 @@ internal abstract class DependencyUpdatesParametersService :
   @Volatile
   var partialsDirectory: Provider<Directory>? = null
 
+  private val legacy = ConcurrentHashMap.newKeySet<Provider<RegularFile>>()
+
+  /** Publishes where an earlier release wrote a project's partial result. */
+  fun registerLegacy(file: Provider<RegularFile>) {
+    legacy.add(file)
+  }
+
+  /** Returns where an earlier release wrote the partial result of each project of the build. */
+  fun legacyPartials(): List<RegularFile> = legacy.map { it.get() }
+
   /** Publishes the settings of the given project's task to the projects that resolve with them. */
   fun register(
     path: String,
@@ -209,8 +219,15 @@ internal fun registerAggregation(
     // aggregate reads the projects it does not own as variant artifacts, which never cared where
     // the file lives. Compared by path rather than to project.rootProject, which is forbidden here.
     // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
+    //
+    // The projects publish where an earlier release wrote their results as well, which the cleanup
+    // reaches through the same channel. Realized while the work graph is assembled, as a cached
+    // entry configures no project to publish them a second time.
     if (project.path == ":") {
       service.get().partialsDirectory = partialsDirectory
+      accumulator.configure { task ->
+        task.legacyPartials.from(project.provider { service.get().legacyPartials() })
+      }
     }
     registerProducer(project, service)
   } else {
@@ -282,6 +299,7 @@ private fun registerProducer(
   // configuration cache cannot serialize.
   val path = project.path
   val ownFile = project.layout.buildDirectory.file("dependencyUpdates/partial.json")
+  service.get().registerLegacy(ownFile)
   // A default action runs only while the build has declared nothing of its own, so one registered
   // here, ahead of the plugins that a project applies, names the configurations that a plugin alone
   // filled. Reading the dependencies later cannot tell the two apart, as any configuration time

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -419,15 +419,18 @@ private fun registerProducer(
 }
 
 /**
- * Publishes the project's statuses as an outgoing variant, unless the project publishes through its
- * `default` configuration, as one that exposes a local aar or jar file does.
+ * Publishes the project's statuses as an outgoing variant, which carries no attributes where the
+ * project declares no variant of its own, as one that exposes a local aar or jar file through its
+ * `default` configuration does.
  *
- * A project that declares no variant of its own is resolved by falling back to that configuration
- * whatever the consumer asks for. Gradle drops the fallback as soon as the project declares any
- * variant, so publishing one here would leave every consumer of such a project without a match. The
- * artifacts are read rather than the variants alone, as a plugin may declare its variants from its
- * own `afterEvaluate` and so after this runs, while a project publishes by fallback from the build
- * script that this is ordered behind.
+ * Such a project is resolved by falling back to that configuration whatever the consumer asks for,
+ * and Gradle drops the fallback as soon as the project declares an attributed variant. Attributing
+ * this one would then serve the statuses to a consumer in place of the artifact it asked for, so it
+ * is attributed only where the project has a variant of its own to be selected by instead. Whether
+ * the `default` configuration holds an artifact yet is not asked, as a plugin may add its
+ * publication from its own `afterEvaluate` and so after this runs, while the variants that decide
+ * the fallback are declared as a plugin applies. The aggregate names this configuration rather than
+ * matching it by attributes, so it reads the statuses either way.
  * https://github.com/ben-manes/gradle-versions-plugin/issues/1022
  */
 private fun publishResults(
@@ -437,23 +440,22 @@ private fun publishResults(
   val configurations = project.configurations
   val fallback = configurations.findByName(Dependency.DEFAULT_CONFIGURATION)
   val publishesByFallback =
-    fallback != null && fallback.isCanBeConsumed && fallback.artifacts.isNotEmpty() &&
+    fallback != null && fallback.isCanBeConsumed &&
       configurations.none { it.isCanBeConsumed && it.attributes.keySet().isNotEmpty() }
-  if (publishesByFallback) {
-    return
-  }
 
   configurations.consumable(ELEMENTS_CONFIGURATION) { configuration ->
     configuration.description = "The dependency update statuses of ${project.path}."
-    configuration.attributes { attributes ->
-      attributes.attribute(
-        Category.CATEGORY_ATTRIBUTE,
-        project.objects.named(Category::class.java, Category.VERIFICATION),
-      )
-      attributes.attribute(
-        VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
-        project.objects.named(VerificationType::class.java, VERIFICATION_TYPE),
-      )
+    if (!publishesByFallback) {
+      configuration.attributes { attributes ->
+        attributes.attribute(
+          Category.CATEGORY_ATTRIBUTE,
+          project.objects.named(Category::class.java, Category.VERIFICATION),
+        )
+        attributes.attribute(
+          VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
+          project.objects.named(VerificationType::class.java, VERIFICATION_TYPE),
+        )
+      }
     }
     configuration.outgoing.artifact(partial.flatMap { it.outputFile })
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -10,6 +10,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.VerificationType
+import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.invocation.Gradle
@@ -72,6 +73,14 @@ internal abstract class DependencyUpdatesParametersService :
    */
   @Volatile
   var settingsConfigurations: List<Configuration> = emptyList()
+
+  /**
+   * The directory that the partial results are collected under, which the project at the root path
+   * publishes here rather than each producer reading its layout, as isolated projects forbids that
+   * between projects. Null outside an isolated projects build where that project aggregates.
+   */
+  @Volatile
+  var partialsDirectory: Provider<Directory>? = null
 
   /** Publishes the settings of the given project's task to the projects that resolve with them. */
   fun register(
@@ -164,7 +173,6 @@ internal fun registerAggregation(
     task.projectPath = project.path
     task.aggregatedProjectPaths = aggregatedPaths
     task.projectDirectory.set(project.layout.projectDirectory)
-    task.partialsDirectory.set(partialsDirectory)
     task.partialResults.from(
       results.incoming
         .artifactView { view ->
@@ -194,8 +202,24 @@ internal fun registerAggregation(
     // not apply the plugin has no producer and is omitted, which only a settings plugin could fix;
     // gradle.lifecycle.beforeProject is never invoked for a callback added by a project.
     // https://docs.gradle.org/current/userguide/isolated_projects.html
+    //
+    // The destination is published for the producers that those projects register, as a settings
+    // plugin reaches a project that has no build script and it would otherwise be given a build
+    // directory to hold nothing else. Only the project at the root path publishes, as a mid tree
+    // aggregate reads the projects it does not own as variant artifacts, which never cared where
+    // the file lives. Compared by path rather than to project.rootProject, which is forbidden here.
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
+    if (project.path == ":") {
+      service.get().partialsDirectory = partialsDirectory
+    }
     registerProducer(project, service)
   } else {
+    // Swept only here, as the artifacts are all that name the projects under isolated projects and
+    // they omit the ones that conflict resolution merges away, whose results their own report still
+    // reads from where its producer wrote them. A result that no project of the build still owns is
+    // left behind there rather than risk removing one in use, and is never read, as the results are
+    // wired by path rather than discovered.
+    accumulator.configure { task -> task.partialsDirectory.set(partialsDirectory) }
     // The results are wired as task outputs too, as module conflict resolution would otherwise drop
     // every project that shares a group and name with a sibling from the artifacts.
     project.allprojects { aggregated ->
@@ -204,8 +228,8 @@ internal fun registerAggregation(
       if (claims(aggregated)) {
         // Written under the project that aggregates rather than each project's own build
         // directory, so that a project which exists only to hold a nested include gains no build
-        // directory of its own. Isolated projects keeps the per-project default instead, as there
-        // every producer belongs to a project that applied the plugin itself.
+        // directory of its own. Passed rather than published, as this project registers the
+        // producer itself and so needs no channel to reach it.
         // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
         val outputFile = partialsDirectory.map { it.file(partialFileName(aggregated.path)) }
         val partial = registerProducer(aggregated, service, outputFile)
@@ -254,6 +278,10 @@ private fun registerProducer(
   if (tasks.names.contains(PARTIAL_TASK_NAME)) {
     return tasks.named(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java)
   }
+  // Read here so that the destination below captures these rather than the project, which the
+  // configuration cache cannot serialize.
+  val path = project.path
+  val ownFile = project.layout.buildDirectory.file("dependencyUpdates/partial.json")
   // A default action runs only while the build has declared nothing of its own, so one registered
   // here, ahead of the plugins that a project applies, names the configurations that a plugin alone
   // filled. Reading the dependencies later cannot tell the two apart, as any configuration time
@@ -282,7 +310,12 @@ private fun registerProducer(
   val partial =
     tasks.register(PARTIAL_TASK_NAME, DependencyUpdatesPartialTask::class.java) { task ->
       task.outputFile.convention(
-        outputFile ?: project.layout.buildDirectory.file("dependencyUpdates/partial.json"),
+        outputFile ?: project.provider {
+          // Realized once every project is configured, so the destination is read whatever order
+          // the projects that publish and consume it were configured in. A build where no project
+          // aggregates, as one that only contributes to another build's report, keeps its own.
+          service.get().partialsDirectory?.get()?.file(partialFileName(path)) ?: ownFile.get()
+        },
       )
       task.partialJson.set(
         // Realized after every project has been evaluated, so that the settings are read as last

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions.updates
 import com.github.benmanes.gradle.versions.claims
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
@@ -263,7 +264,19 @@ private fun registerProducer(
     // Only a configuration that dependencies are declared against accepts a default action, which
     // is every configuration that a plugin contributes to.
     if (configuration.isCanBeDeclared) {
-      configuration.defaultDependencies { filledByPlugin.add(configuration.name) }
+      try {
+        configuration.defaultDependencies { filledByPlugin.add(configuration.name) }
+      } catch (e: GradleException) {
+        // A configuration that has taken part in a resolution refuses a default action, so a
+        // project that applies this plugin after one did would fail to apply it at all. The mark
+        // is a best effort attribution, which is worth losing for that configuration but not the
+        // build. Its state does not answer this, as a configuration observed by another's
+        // resolution refuses one while still reporting itself as unresolved.
+        project.logger.info(
+          "Skipping the plugin mark for configuration ${project.path}:${configuration.name}",
+          e,
+        )
+      }
     }
   }
   val partial =

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -172,7 +172,10 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   @Internal
   var aggregatedProjectPaths: Set<String> = emptySet()
 
-  /** The directory the partial results are collected under, wired by the plugin. */
+  /**
+   * The directory the partial results are collected under, wired by the plugin only where it also
+   * knows every project that owns one, as the sweep below would otherwise remove a result in use.
+   */
   @get:Internal
   val partialsDirectory: DirectoryProperty = project.objects.directoryProperty()
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -221,8 +221,8 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
     // Removes what an earlier release wrote into each project's own build directory, which `clean`
     // cannot reach in a project that applies no plugin of its own, as `clean` comes from the base
-    // plugin. A file that a producer still writes there is held back, as one does under isolated
-    // projects. The directories are removed only while empty, which is all that delete() will do.
+    // plugin. A file that a producer still writes is held back. The directories are removed only
+    // while empty, which is all that delete() will do.
     // https://github.com/ben-manes/gradle-versions-plugin/issues/1040
     if (cleanLegacyPartials) {
       for (legacy in legacyPartials.files - expected) {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -419,6 +419,58 @@ final class AggregationSpec extends Specification {
     !new File(testProjectDir.root, 'apps/build').exists()
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1048')
+  def 'Aggregates a project declared from outside the aggregating projects tree'() {
+    given:
+    new File(testProjectDir.root, 'settings.gradle').text = "include 'agg', 'tool'"
+    new File(testProjectDir.root, 'build.gradle').text = ''
+    testProjectDir.newFolder('agg')
+    new File(testProjectDir.root, 'agg/build.gradle').text =
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        // Named rather than reached by allprojects, which does not cover a sibling.
+        dependencies {
+          dependencyUpdatesAggregation project(':tool')
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('tool')
+    // Applies base, so it has a consumable default configuration and no variant of its own, which
+    // is what decides whether its statuses carry attributes.
+    new File(testProjectDir.root, 'tool/build.gradle').text =
+      """
+        plugins {
+          id 'base'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        dependencies {
+          tool 'com.example:jvm-library:1.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run([':agg:dependencyUpdates'])
+
+    then:
+    result.task(':agg:dependencyUpdates').outcome == SUCCESS
+    // Reached by naming the producer's configuration, so it does not depend on the statuses
+    // carrying attributes for a match.
+    result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+  }
+
   def 'Resolves the aggregation results without traversing the projects dependencies'() {
     given:
     new File(testProjectDir.root, 'build.gradle') <<

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ApplyOrderSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ApplyOrderSpec.groovy
@@ -1,0 +1,223 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * A specification for applying the plugin to a project where a configuration has already resolved.
+ * A convention plugin is applied alongside others whose order its consumer chooses, so a plugin
+ * that resolves one of its own configurations while it applies may run first.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1049')
+final class ApplyOrderSpec extends Specification {
+  private static final String GRADLE_8 = '8.4'
+  private static final String GRADLE_9 = '9.7.0-rc-2'
+  private static final List<String> PLUGINS =
+    ['io.github.ben-manes.versions', 'io.github.ben-manes.versions.contributor']
+
+  /**
+   * How each Gradle version refuses a default action, for the configuration that resolved and for
+   * the one that resolution only observed. Gradle 9 reworded both. Pinning them fails the spec if a
+   * case stops refusing, rather than passing on coverage it no longer has.
+   */
+  private static final Map<String, Map<String, String>> REFUSALS = [
+    (GRADLE_8): [
+      resolved: "Cannot change dependencies of dependency configuration ':probe' after it has" +
+        ' been resolved.',
+      observed: "Cannot change dependencies of dependency configuration ':base' after it has been" +
+        ' included in dependency resolution.',
+    ],
+    (GRADLE_9): [
+      resolved: "Cannot mutate the state of configuration ':probe' after the configuration was" +
+        ' resolved.',
+      observed: "Cannot mutate the state of configuration ':base' after the configuration's child" +
+        " configuration ':probe' was resolved.",
+    ],
+  ]
+
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  /** Applies the plugin after a resolution that both resolves 'probe' and observes 'base'. */
+  private static String applyAfterResolution(String plugin) {
+    """
+      plugins {
+        id '$plugin' apply false
+      }
+
+      // Stands in for a plugin that resolves one of its own configurations while it applies.
+      // Resolving 'probe' also observes 'base', which refuses a default action while still
+      // reporting itself as unresolved.
+      configurations.create('base')
+      configurations.create('probe') { extendsFrom configurations.base }
+      configurations.probe.resolve()
+
+      apply plugin: '$plugin'
+    """.stripIndent()
+  }
+
+  /** A 'tool' configuration whose guava dependency only {@code defaultDependencies} contributes. */
+  private static String toolConfiguration() {
+    """
+      configurations.create('tool') {
+        canBeResolved = true
+        canBeConsumed = false
+      }
+      configurations.tool.defaultDependencies { deps ->
+        deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+      }
+    """.stripIndent()
+  }
+
+  private def run(String gradleVersion, String... arguments) {
+    return GradleRunner.create()
+      .withGradleVersion(gradleVersion)
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  // Gradle 9 requires JVM 17.
+  @IgnoreIf({ data.gradleVersion.startsWith('9') && !jvm.java17Compatible })
+  @Unroll
+  def 'Applies #plugin on Gradle #gradleVersion to a project that already resolved a configuration'() {
+    given:
+    testProjectDir.newFile('build.gradle') << applyAfterResolution(plugin)
+
+    when:
+    def result = run(gradleVersion, 'help', '--info')
+
+    then:
+    result.task(':help').outcome == SUCCESS
+
+    // A root project's path is ':', so its qualified configuration names read '::probe'.
+    and: 'the skipped mark is logged rather than dropped in silence'
+    result.output.contains('Skipping the plugin mark for configuration ::probe')
+    result.output.contains('Skipping the plugin mark for configuration ::base')
+
+    and: 'this Gradle still refuses both, in the wordings the guard has to catch'
+    result.output.contains(REFUSALS[gradleVersion].resolved)
+    result.output.contains(REFUSALS[gradleVersion].observed)
+
+    where:
+    [plugin, gradleVersion] << [PLUGINS, [GRADLE_8, GRADLE_9]].combinations()
+  }
+
+  def 'Marks a contributed dependency alongside a configuration that already resolved'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        ${applyAfterResolution('io.github.ben-manes.versions')}
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        ${toolConfiguration()}
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(GRADLE_8, 'dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains("contributed by a plugin into the 'tool' configuration")
+  }
+
+  def 'Reports what a plugin contributed to a configuration that already resolved as declared'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions' apply false
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        ${toolConfiguration()}
+
+        // Resolves the graph alone, as the test repository publishes poms without jars.
+        configurations.tool.incoming.resolutionResult.root
+
+        apply plugin: 'io.github.ben-manes.versions'
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(GRADLE_8, 'dependencyUpdates', '--info')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Skipping the plugin mark for configuration ::tool')
+
+    and: 'the attribution the mark carries is what giving it up costs'
+    result.output.contains(' - com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('contributed by a plugin')
+  }
+
+  // Only under isolated projects does a subproject's own plugin register its producer, as the root
+  // otherwise registers one for every project before their scripts have resolved anything, and the
+  // second registration returns early. Gradle 9 requires JVM 17.
+  @Requires({ jvm.java17Compatible })
+  def 'Marks a dependency the contributor plugin adds after its project already resolved'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        ${applyAfterResolution('io.github.ben-manes.versions.contributor')}
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        ${toolConfiguration()}
+      """.stripIndent()
+
+    when:
+    def result = run(GRADLE_9, 'dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      '--configuration-cache')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains("contributed by a plugin into the 'tool' configuration")
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -357,6 +357,68 @@ final class CompositeBuildSpec extends Specification {
     result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1048')
+  def 'Aggregates an included build named by its coordinates that publishes by fallback'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencies {
+          dependencyUpdatesAggregation 'com.example:child:1.0'
+        }
+      """.stripIndent()
+    // Substituted onto the included build's project, so the aggregation holds a module dependency
+    // rather than a project one, and its artifact is added late enough to leave the project without
+    // a variant of its own to be selected by.
+    includedBuild(
+      'child',
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'io.github.ben-manes.versions'
+
+        group = 'com.example'
+        version = '1.0'
+
+        configurations.maybeCreate('default')
+        afterEvaluate {
+          artifacts.add('default', file('child.jar'))
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          tool 'com.example:jvm-library:1.0'
+        }
+      """.stripIndent(),
+    )
+    testProjectDir.newFile('child/child.jar')
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+  }
+
   def 'Reuses the configuration cache across runs of a composite build'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -64,10 +64,14 @@ final class IsolatedProjectsAggregationSpec extends Specification {
   }
 
   private def run(List<String> arguments = []) {
+    return runWith(':dependencyUpdates', arguments)
+  }
+
+  private def runWith(String task, List<String> arguments = []) {
     return GradleRunner.create()
       .withGradleVersion('9.7.0-rc-2')
       .withProjectDir(testProjectDir.root)
-      .withArguments([':dependencyUpdates', '-Dorg.gradle.isolated-projects=true',
+      .withArguments([task, '-Dorg.gradle.isolated-projects=true',
         '--configuration-cache'] + arguments)
       .withPluginClasspath()
       .build()
@@ -85,20 +89,42 @@ final class IsolatedProjectsAggregationSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
-  def 'Keeps every projects partial result where the producer wrote it'() {
+  def 'Collects every projects partial result under the aggregating project'() {
     when:
     def result = run(['--clean-legacy-partials'])
 
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
-    // Every producer belongs to the project that applied the plugin, so each writes to its own
-    // build directory and the cleanup must reach none of them.
-    new File(testProjectDir.root, 'build/dependencyUpdates/partial.json').exists()
-    new File(testProjectDir.root, 'app/build/dependencyUpdates/partial.json').exists()
-    new File(testProjectDir.root, 'lib/build/dependencyUpdates/partial.json').exists()
-    !new File(testProjectDir.root, 'build/dependencyUpdates/partials').exists()
+    // Guards the flag itself: the property is a silent no-op on a Gradle whose spelling differs
+    // (pre-9.7 uses org.gradle.unsafe.isolated-projects), which would pass the non-isolated branch.
+    result.output.contains('Isolated Projects is an incubating feature.')
+    // The root publishes where the results are collected and each project's own producer reads it
+    // from there, so isolated projects writes them where every other mode does.
+    new File(testProjectDir.root, 'build/dependencyUpdates/partials').list().length == 3
+    !new File(testProjectDir.root, 'build/dependencyUpdates/partial.json').exists()
+    !new File(testProjectDir.root, 'app/build/dependencyUpdates/partial.json').exists()
+    !new File(testProjectDir.root, 'lib/build/dependencyUpdates/partial.json').exists()
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Keeps its own partial result where the root project collects none'() {
+    given:
+    new File(testProjectDir.root, 'build.gradle').text = ''
+
+    when:
+    def result = runWith(':app:dependencyUpdates')
+
+    then:
+    result.task(':app:dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Isolated Projects is an incubating feature.')
+    // Only the project at the root path publishes where the results are collected, as one that
+    // aggregates from further down reads the projects it does not own as variant artifacts, which
+    // never cared where the file lives. Its own producer falls back to its build directory.
+    new File(testProjectDir.root, 'app/build/dependencyUpdates/partial.json').exists()
+    !new File(testProjectDir.root, 'build/dependencyUpdates/partials').exists()
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
   }
 
   def 'Honors the root task settings in every projects producer'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -239,6 +239,42 @@ final class SettingsPluginAggregationSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Removes what an earlier release wrote into each project with isolated projects'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+    new File(testProjectDir.root, 'settings.gradle') << "include 'container:nested'\n"
+    testProjectDir.newFolder('container', 'nested')
+    write('container/nested/build.gradle', false, 'com.google.inject:guice:2.0')
+    // What a release before the results were collected under one directory left in each project.
+    def legacies = ['', 'app/', 'lib/', 'container/'].collect {
+      new File(testProjectDir.root, "${it}build/dependencyUpdates/partial.json")
+    }
+    legacies.each { it.parentFile.mkdirs(); it.text = '{}' }
+
+    when:
+    def result = run(ISOLATED + ['--clean-legacy-partials'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Isolated Projects is an incubating feature.')
+    // A project with no build script has no clean task to reach it, as clean comes from the base
+    // plugin, so the opt in cleanup is the only thing that can.
+    legacies.every { !it.exists() }
+    !new File(testProjectDir.root, 'container/build').exists()
+
+    when:
+    legacies.each { it.parentFile.mkdirs(); it.text = '{}' }
+    def hit = run(ISOLATED + ['--clean-legacy-partials'])
+
+    then:
+    hit.output.contains('Configuration cache entry reused')
+    // The paths are realized before the entry is stored, as a hit configures no project to publish
+    // them again.
+    legacies.every { !it.exists() }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
   def 'Keeps the partial result of a project that conflict resolution drops'() {
     given:
     new File(testProjectDir.root, 'settings.gradle').text =

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -316,6 +316,124 @@ final class SettingsPluginAggregationSpec extends Specification {
     partial.exists()
   }
 
+  @Issue([
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/1022',
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/1046',
+  ])
+  def 'Aggregates a project that publishes through its default configuration'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+    new File(testProjectDir.root, 'settings.gradle') << "include 'local'\n"
+    testProjectDir.newFolder('local')
+    testProjectDir.newFile('local/local.jar')
+    // Declares no variant of its own, so that a consumer resolves it through the fallback to its
+    // default configuration, as a project that exposes a local aar or jar file does. The reported
+    // dependency is declared on a plain resolvable configuration rather than through the `java`
+    // plugin, which would give the project variants of its own and void the case.
+    new File(testProjectDir.root, 'local/build.gradle').text =
+      """
+        configurations.maybeCreate('default')
+        artifacts.add('default', file('local.jar'))
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        dependencies {
+          tool 'com.example:jvm-library:1.0'
+        }
+      """.stripIndent()
+    // Resolved on its own configuration rather than the runtime classpath, which also carries the
+    // external dependency this build reports on, whose poms the test repository publishes without
+    // the files to resolve them to.
+    new File(testProjectDir.root, 'app/build.gradle') <<
+      """
+        configurations.create('local') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        dependencies {
+          local project(':local')
+        }
+
+        tasks.register('resolve', Copy) {
+          from configurations.local
+          into layout.buildDirectory.dir('resolved')
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(ISOLATED)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+    !result.output.contains('The dependency updates report is missing')
+
+    when: 'a consumer resolves the project the statuses were published from'
+    def consumed = runWith([':app:resolve'] + ISOLATED)
+
+    then: 'the unattributed publication left its fallback to the default configuration intact'
+    consumed.task(':app:resolve').outcome == SUCCESS
+    new File(testProjectDir.root, 'app/build/resolved/local.jar').exists()
+  }
+
+  @Issue([
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/1022',
+    'https://github.com/ben-manes/gradle-versions-plugin/issues/1047',
+  ])
+  def 'Consumes a project that publishes through its default configuration from afterEvaluate'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+    new File(testProjectDir.root, 'settings.gradle') << "include 'late'\n"
+    testProjectDir.newFolder('late')
+    testProjectDir.newFile('late/late.jar')
+    // Puts its artifact on the default configuration from its own afterEvaluate, as a plugin that
+    // declares its publication there does. The settings plugin reaches the project before its build
+    // script runs, so this callback is registered after the one that publishes the statuses.
+    new File(testProjectDir.root, 'late/build.gradle').text =
+      """
+        configurations.maybeCreate('default')
+        afterEvaluate {
+          artifacts.add('default', file('late.jar'))
+        }
+      """.stripIndent()
+    new File(testProjectDir.root, 'app/build.gradle') <<
+      """
+        configurations.create('late') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        dependencies {
+          late project(':late')
+        }
+
+        tasks.register('resolveLate', Copy) {
+          from configurations.late
+          into layout.buildDirectory.dir('late')
+        }
+
+      """.stripIndent()
+
+    when:
+    def consumed = runWith([':app:resolveLate'] + ISOLATED)
+
+    then: 'the statuses did not cost the project the fallback its consumers resolve through'
+    consumed.task(':app:resolveLate').outcome == SUCCESS
+    new File(testProjectDir.root, 'app/build/late/late.jar').exists()
+    // Served in the artifact's place before this was left out of variant selection, rather than
+    // failing, so the consumer took the statuses onto its classpath and carried on.
+    !new File(testProjectDir.root, 'app/build/late/partial.json').exists()
+  }
+
   def 'Applies once when a project also applies the plugin itself'() {
     given:
     createBuild([':app'])

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -188,6 +188,98 @@ final class SettingsPluginAggregationSpec extends Specification {
     invocation << [':dependencyUpdates', 'dependencyUpdates']
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Collects the partial results under the root with isolated projects'() {
+    given:
+    createBuild([])
+    new File(testProjectDir.root, 'settings.gradle').text =
+      """
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+        }
+
+        include 'app', 'lib', 'container:nested'
+
+        gradle.lifecycle.beforeProject { project ->
+          if (project.path == ':container') {
+            project.pluginManager.apply('java')
+            project.repositories.maven { url = '${mavenRepoUrl}' }
+            project.dependencies.add('implementation', 'com.example:jvm-library:1.0')
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('container', 'nested')
+    write('container/nested/build.gradle', false, 'com.google.inject:guice:2.0')
+
+    when:
+    def result = run(ISOLATED)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // Guards the flag itself: the property is a silent no-op on a Gradle whose spelling differs
+    // (pre-9.7 uses org.gradle.unsafe.isolated-projects), which would pass the non-isolated branch.
+    result.output.contains('Isolated Projects is an incubating feature.')
+    // A project that exists only to hold a nested include has no build script to apply a plugin
+    // from, so the settings plugin reaches it and an earlier release gave it a build directory to
+    // hold the partial result. The producer writes under the aggregating project instead.
+    !new File(testProjectDir.root, 'container/build').exists()
+    new File(testProjectDir.root, 'build/dependencyUpdates/partials').list().length == 5
+    // The container is still resolved, as the settings script can carry a dependency into a project
+    // that has no build script of its own.
+    result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+
+    when:
+    def hit = run(ISOLATED)
+
+    then:
+    hit.output.contains('Configuration cache entry reused')
+    // The destination is realized before the entry is stored, so a hit writes where the store did.
+    !new File(testProjectDir.root, 'container/build').exists()
+    hit.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1040')
+  def 'Keeps the partial result of a project that conflict resolution drops'() {
+    given:
+    new File(testProjectDir.root, 'settings.gradle').text =
+      """
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+        }
+
+        include 'core:api', 'feature:api'
+
+        gradle.lifecycle.beforeProject { project ->
+          project.group = 'com.example'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('core', 'api')
+    testProjectDir.newFolder('feature', 'api')
+    write('build.gradle', false, null)
+    write('core/api/build.gradle', false, 'com.google.guava:guava:15.0')
+    write('feature/api/build.gradle', true, 'com.google.inject:guice:2.0')
+
+    when:
+    def own = runWith([':feature:api:dependencyUpdates'] + ISOLATED)
+    def partial = new File(testProjectDir.root, 'build/dependencyUpdates/partials')
+      .listFiles().find { it.name.startsWith('feature-api-') }
+
+    then:
+    own.task(':feature:api:dependencyUpdates').outcome == SUCCESS
+    own.output.contains('Isolated Projects is an incubating feature.')
+    partial != null
+
+    when:
+    def root = runWith([':dependencyUpdates'] + ISOLATED)
+
+    then:
+    root.task(':dependencyUpdates').outcome == SUCCESS
+    // Module conflict resolution aggregates two projects that share a group and name as one, so the
+    // artifacts name fewer projects than the build has producers. The results of the other project
+    // are still its own, and its report reads them from where it wrote them.
+    partial.exists()
+  }
+
   def 'Applies once when a project also applies the plugin itself'() {
     given:
     createBuild([':app'])


### PR DESCRIPTION
Fixes #1046, fixes #1047, fixes #1048 and fixes #1049.

This PR skips the plugin-contributed marking on a configuration that refuses a default action, instead of failing the apply. The mark is a best effort attribution, so it seemed better to lose it for that configuration than to lose the build. I couldn't find a state to test the configuration on, so the registration is wrapped instead. A configuration that another's resolution only observed refuses a default action while still reporting itself as unresolved. Gradle words the refusal four ways across the cases and versions I hit, which the added spec covers on 8.4 and 9.7.0-rc-2.

The root project also publishes its partials directory through the parameters service, so a producer registered by its own project's plugin writes there too. #1041 collects them only where the plugin registers every producer itself, which leaves a project with no build script holding a build directory under isolated projects. I couldn't find a way for a producer to read the aggregating project's layout there, so publishing it through the service that already carries the task settings seemed the next best thing.

Before, on a build whose `apps` container has no build script:

```
$ find . -name '*.json'
./build/dependencyUpdates/partial.json
./apps/build/dependencyUpdates/partial.json
./apps/app-a/build/dependencyUpdates/partial.json
```

After:

```
$ find . -name '*.json'
./build/dependencyUpdates/partials/apps-35f1dac.json
./build/dependencyUpdates/partials/root-3a.json
./build/dependencyUpdates/partials/apps-app-a-c809bc67.json
```

The `--clean-legacy-partials` flag carries through the same channel, so upgrading an isolated projects build removes what an earlier release left in each project rather than stranding it where no `clean` task reaches.

A project that publishes through its `default` configuration now gets an unattributed statuses configuration rather than none, so the aggregate reads it by name and the project keeps the fallback its own consumers resolve through. The mirrored `dependencyUpdatesAggregation` dependency names the producer's configuration too, so a project declared in the build's own dependencies block is no longer matched by attribute and its own artifact read in place of a partial result.

Addresses #1040
