### PR TITLE
Report the version a resolution found even when another one failed (fixes #1050)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,9 +1546,18 @@ and *Note*s are things worth knowing that need no action.
 
 ### v0.58.0
 
-v0.59.0 collects the partial result of every project under the project that
-aggregates them, so a project that exists only to hold a nested `include` no
-longer gains a `build` directory of its own:
+v0.59.0 reports the version another resolution found for a dependency that
+failed to resolve, and collects the partial result of every project under the
+project that aggregates them, so a project that exists only to hold a nested
+`include` no longer gains a `build` directory of its own:
+
+> [!IMPORTANT]
+> A declared version that resolved in one place and failed in another is now
+> reported twice: once with the version found for it, and again as unresolved.
+> A dependency declared without a version doubles the same way, as undeclared
+> and unresolved. The JSON and XML reports count it in each place. A tool
+> reading `count` as a dependency total, or treating the sections as disjoint,
+> has to allow for the overlap (see [Report format](#report-format)).
 
 > [!TIP]
 > Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt
@@ -5,7 +5,8 @@ import com.github.benmanes.gradle.versions.updates.gradle.GradleUpdateResults
 /**
  * The result of a dependency update analysis.
  *
- * @property count The overall number of dependencies in the project.
+ * @property count The number of dependencies reported, counting one that appears in more than one
+ * section once for each of them.
  * @property current The up-to-date dependencies.
  * @property outdated The dependencies that can be updated.
  * @property exceeded The dependencies whose versions are newer than the ones that are available

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
@@ -37,14 +37,12 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
 
   /** Groups the dependencies into up-to-date, upgrades available, or downgrade buckets.  */
   private fun organize() {
-    val latestByKey = latest.associateBy({ it.key }, { it })
     for (coordinate in current) {
       // A resolution that answered for this exact coordinate is the version to report, even when
       // another one failed on it. The failure is still carried by the unresolved set, so both the
       // update and the resolution that could not find it are reported.
       val resolved = latestByCurrent[coordinate]
-      val latestCoordinate = resolved ?: latestByKey[coordinate.key]
-      val version = latestCoordinate?.version
+      val version = resolved?.version
       logger
         .info("Comparing dependency (current: {}, latest: {})", coordinate, version ?: "unresolved")
       if (resolved == null && unresolved.contains(coordinate)) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
@@ -39,11 +39,15 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
   private fun organize() {
     val latestByKey = latest.associateBy({ it.key }, { it })
     for (coordinate in current) {
-      val latestCoordinate = latestByCurrent[coordinate] ?: latestByKey[coordinate.key]
+      // A resolution that answered for this exact coordinate is the version to report, even when
+      // another one failed on it. The failure is still carried by the unresolved set, so both the
+      // update and the resolution that could not find it are reported.
+      val resolved = latestByCurrent[coordinate]
+      val latestCoordinate = resolved ?: latestByKey[coordinate.key]
       val version = latestCoordinate?.version
       logger
         .info("Comparing dependency (current: {}, latest: {})", coordinate, version ?: "unresolved")
-      if (unresolved.contains(coordinate)) {
+      if (resolved == null && unresolved.contains(coordinate)) {
         continue
       } else if (coordinate.version == "none") {
         undeclared.add(coordinate)

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
@@ -184,6 +184,48 @@ final class ReportJoinSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
+  def 'A version declared without one is undeclared when a resolution answered for it'() {
+    given:
+    def root = ProjectBuilder.builder().withName('root').build()
+    // The script classpath can answer for the version-less declaration and the project cannot, so
+    // the module is both declared without a version and one a resolution failed on.
+    root.buildscript.repositories {
+      maven {
+        url getClass().getResource('/maven/').toURI()
+      }
+    }
+    root.buildscript.dependencies.add('classpath', 'com.google.inject:guice')
+    def blind = ProjectBuilder.builder().withName('blind').withParent(root).build()
+    blind.configurations {
+      app
+    }
+    blind.dependencies.add('app', 'com.google.inject:guice')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.undeclared.dependencies*.name == ['guice']
+    result.unresolved.dependencies*.name == ['guice']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
+  def 'A version reported against a failure is counted in each section that holds it'() {
+    given:
+    def root = blindAndSeeing()
+
+    when:
+    writeReport(root, 'json')
+
+    then:
+    def report = new JsonSlurper().parse(new File(root.projectDir, 'build/report.json'))
+    report.outdated.dependencies*.version == ['2.0']
+    report.unresolved.dependencies*.name == ['guice']
+    // The one module is reported twice, so the total counts it once per section it appears in.
+    report.count == 2
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
   def 'A project that could not resolve a version is still named behind it'() {
     given:
     def root = blindAndSeeing()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ReportJoinSpec.groovy
@@ -154,6 +154,122 @@ final class ReportJoinSpec extends Specification {
     result.outdated.dependencies.find { it.name == 'guice' }.contributed == null
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
+  def 'A version another project resolved is reported with the version it found'() {
+    given:
+    def root = blindAndSeeing()
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.outdated.dependencies*.version == ['2.0']
+    result.outdated.dependencies.first().available.milestone == '3.1'
+    // The resolution that could not answer is still reported, as it is the user's to see.
+    result.unresolved.dependencies*.name == ['guice']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
+  def 'A version that no project resolved is still reported as unresolved'() {
+    given:
+    // Only 2.0 is answered, so the failure on 3.0 is another version of an answered module.
+    def root = blindAndSeeing('3.0')
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.unresolved.dependencies*.name == ['guice']
+    result.outdated.dependencies*.version == ['2.0']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
+  def 'A project that could not resolve a version is still named behind it'() {
+    given:
+    def root = blindAndSeeing()
+    def ahead = ProjectBuilder.builder().withName('ahead').withParent(root).build()
+    ahead.repositories {
+      maven {
+        url getClass().getResource('/maven/').toURI()
+      }
+    }
+    ahead.configurations {
+      app
+    }
+    ahead.dependencies {
+      app 'com.google.inject:guice:3.0'
+    }
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    // Dropping the blind project's status outright would leave 2.0 named against :seeing alone.
+    result.outdated.dependencies.find { it.version == '2.0' }.projects == [':blind', ':seeing']
+    result.outdated.dependencies.find { it.version == '3.0' }.projects == [':ahead']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1050')
+  def 'A version a project declared but could not resolve is not marked contributed'() {
+    given:
+    def root = ProjectBuilder.builder().withName('root').build()
+    def blind = ProjectBuilder.builder().withName('blind').withParent(root).build()
+    def seeing = ProjectBuilder.builder().withName('seeing').withParent(root).build()
+    seeing.repositories {
+      maven {
+        url getClass().getResource('/maven/').toURI()
+      }
+    }
+    // Declared by the project with no repository to resolve it against, and contributed by a
+    // plugin in the project that can, so only the failing project's status marks it as declared.
+    blind.configurations {
+      app
+    }
+    blind.dependencies {
+      app 'com.google.inject:guice:2.0'
+    }
+    seeing.configurations.create('tool') {
+      canBeResolved = true
+      canBeConsumed = false
+    }
+    seeing.configurations.tool.defaultDependencies { deps ->
+      deps.add(seeing.dependencies.create('com.google.inject:guice:2.0'))
+    }
+
+    when:
+    def result = evaluate(root)
+
+    then:
+    result.outdated.dependencies.find { it.name == 'guice' }.contributed == null
+  }
+
+  /**
+   * A root project whose two children declare the same module, where only {@code :seeing} has a
+   * repository to resolve it against. It answers for 2.0, while {@code :blind} resolves nothing.
+   */
+  private def blindAndSeeing(String blindVersion = '2.0') {
+    def root = ProjectBuilder.builder().withName('root').build()
+    def blind = ProjectBuilder.builder().withName('blind').withParent(root).build()
+    def seeing = ProjectBuilder.builder().withName('seeing').withParent(root).build()
+    seeing.repositories {
+      maven {
+        url getClass().getResource('/maven/').toURI()
+      }
+    }
+    for (project in [blind, seeing]) {
+      project.configurations {
+        app
+      }
+    }
+    blind.dependencies {
+      app "com.google.inject:guice:$blindVersion"
+    }
+    seeing.dependencies {
+      app 'com.google.inject:guice:2.0'
+    }
+    return root
+  }
+
   /**
    * A root project whose two children declare the same module, where the first child's repository
    * hides the versions matching {@code hiddenVersionRegex}. The latest version found therefore


### PR DESCRIPTION
Fixes #1050

This PR reports the version a resolution found for a dependency even when another resolution failed on it. The failure is still reported, so a repository that cannot answer stays visible. Such a dependency now appears in two sections, and `count` includes it once per section.

Before, on the reproducer in #1050:

```
The following dependencies have later milestone versions:
 - ...

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.inject:guice:5.0.1
     https://github.com/google/guice
```

After:

```
The following dependencies have later milestone versions:
 - com.google.inject:guice [5.0.1 -> 7.0.0]
     https://github.com/google/guice
 - ...

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.inject:guice:5.0.1
     https://github.com/google/guice
```
