### PR TITLE
Prepare the 0.59.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,8 +1566,10 @@ project that aggregates them, so a project that exists only to hold a nested
 > [!TIP]
 > Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the
 > `build/dependencyUpdates/partial.json` that earlier releases wrote into each
-> project. `clean` removes it from a project that applies a plugin of its own,
-> but a project with no build script has no `clean` task to reach it.
+> project. The `clean` task removes it from a project that directly or
+> indirectly applies the
+> [Base plugin](https://docs.gradle.org/current/userguide/base_plugin.html), but
+> a project with no build script has no `clean` task.
 
 ### v0.57.0
 

--- a/README.md
+++ b/README.md
@@ -1552,12 +1552,16 @@ project that aggregates them, so a project that exists only to hold a nested
 `include` no longer gains a `build` directory of its own:
 
 > [!IMPORTANT]
-> A declared version that resolved in one place and failed in another is now
-> reported twice: once with the version found for it, and again as unresolved.
-> A dependency declared without a version doubles the same way, as undeclared
-> and unresolved. The JSON and XML reports count it in each place. A tool
-> reading `count` as a dependency total, or treating the sections as disjoint,
-> has to allow for the overlap (see [Report format](#report-format)).
+> * A declared version that resolved in one place and failed in another is now
+>   reported twice: once with the version found for it, and again as
+>   unresolved. A dependency declared without a version doubles the same way, as
+>   undeclared and unresolved. The JSON and XML reports count it in each place.
+>   A tool reading `count` as a dependency total, or treating the sections as
+>   disjoint, has to allow for the overlap (see
+>   [Report format](#report-format)).
+> * The unresolved section of the plain text report now names the declared
+>   version, as every other section does. A tool that parses that section line
+>   by line has to allow it.
 
 > [!TIP]
 > Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the

--- a/README.md
+++ b/README.md
@@ -665,10 +665,10 @@ Failed to compare versions for the following dependencies because they were decl
  - com.google.code.gson:gson
 
 Failed to determine the latest version for the following dependencies (use --info for details):
- - com.github.ben-manes:unresolvable
- - com.github.ben-manes:unresolvable2
- - com.google.guava:guava
-     23.0
+ - com.github.ben-manes:unresolvable:1.0
+ - com.github.ben-manes:unresolvable2:1.0
+ - com.google.guava:guava:15.0
+     https://github.com/google/guava
  - dom4j:dom4j
 
 Gradle release-candidate updates:
@@ -836,7 +836,7 @@ Alternatively, the report may be output to a structured file.
     "group": "com.google.guava",
     "name": "guava",
     "version": "15.0",
-    "projectUrl": "23.0",
+    "projectUrl": "https://github.com/google/guava",
     "userReason": null,
     "reason": "Could not resolve com.google.guava:guava:+."
    },
@@ -1014,7 +1014,7 @@ Searched in the following locations:
                 <group>com.google.guava</group>
                 <name>guava</name>
                 <version>15.0</version>
-                <projectUrl>23.0</projectUrl>
+                <projectUrl>https://github.com/google/guava</projectUrl>
                 <reason>Could not resolve com.google.guava:guava:+.</reason>
             </unresolvedDependency>
             <unresolvedDependency>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ben-manes
-VERSION_NAME=0.58.0
+VERSION_NAME=0.59.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps the version for the v0.59.0 release. It also adds the migration note owed to #1044, which changed the plain text unresolved section to carry the declared version.

Draft release notes below. Let me know if there's anything more you want included in this release.

---

* Report the version a resolution found for a dependency that another resolution failed on, which the failure used to suppress everywhere (#1050, #1052)
* Report the version that actually failed to resolve, rather than the lowest version the build declares for that module, and name it in the plain text report's unresolved section as every other section does (#1043, #1044)
* Collect the partial result of every project under the project that aggregates them, isolated projects included, so a project that exists only to hold a nested `include` no longer gains a `build` directory of its own (#1040, #1041, #1051)
* Skip the plugin-contributed marking on a configuration that has already been resolved, which failed the apply of any project that resolved one before the plugin was applied (#1049, #1051)
* Attribute the statuses only where a project has a variant of its own, so a project that publishes through its `default` configuration is aggregated under isolated projects rather than left out of the report, and its own consumers are no longer served the partial result in place of the artifact they asked for (#1046, #1047, #1051)
* Name the producer's configuration when mirroring an aggregation dependency, so a project named in the build's own `dependencyUpdatesAggregation` block no longer has its jar read as a partial result (#1048, #1051)
* Document how a change lands and how a release is published, and check on deploy that the version being published matches the release tag (#1042)
* Sort the migration notes into the same alerts the release notes use (#1045)

> [!IMPORTANT]
> * A declared version that resolved in one place and failed in another is now reported twice: once with the version found for it, and again as unresolved. A dependency declared without a version doubles the same way, as undeclared and unresolved. The JSON and XML reports count it in each place. A tool reading `count` as a dependency total, or treating the sections as disjoint, has to allow for the overlap.
> * The unresolved section of the plain text report now names the declared version, which a tool parsing that section line by line has to allow.
>
> See [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#v0580).

> [!TIP]
> Run `./gradlew dependencyUpdates --clean-legacy-partials` once to remove the `build/dependencyUpdates/partial.json` that earlier releases wrote into each project. The `clean` task removes it from a project that directly or indirectly applies the [Base plugin](https://docs.gradle.org/current/userguide/base_plugin.html), but a project with no build script has no `clean` task.
