### PR TITLE
Accept an untyped Kotlin DSL lambda in the component selection rules (fixes #941)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,21 @@ jobs:
           cd examples/groovy/ && ../../gradlew dU && cd -
           cd examples/kotlin/ && ../../gradlew dU && cd -
 
+      # The wrapper pins the examples to the minimum supported Gradle, so the Kotlin DSL
+      # sample never sees the release line that binds its lambdas differently.
+      # https://github.com/ben-manes/gradle-versions-plugin/issues/941
+      - name: Provision Gradle 9
+        if: matrix.java-version == 17
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          gradle-version: '9.6.1'
+
+      - name: Run examples on Gradle 9
+        if: matrix.java-version == 17
+        run: |
+          cd examples/groovy/ && gradle dU && cd -
+          cd examples/kotlin/ && gradle dU && cd -
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v6
         if: always()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
@@ -21,6 +21,15 @@ class ComponentSelectionRulesWithCurrent(
     return this
   }
 
+  fun all(selectionAction: ComponentSelectionWithCurrent.() -> Unit): ComponentSelectionRulesWithCurrent {
+    delegate.all {
+      wrapComponentSelection(it)?.let { wrapped ->
+        wrapped.selectionAction()
+      }
+    }
+    return this
+  }
+
   fun all(closure: Closure<*>): ComponentSelectionRulesWithCurrent {
     delegate.all {
       wrapComponentSelection(it)?.let { wrapped ->
@@ -50,6 +59,18 @@ class ComponentSelectionRulesWithCurrent(
     delegate.withModule(id) {
       wrapComponentSelection(it)?.let { wrapped ->
         selectionAction.execute(wrapped)
+      }
+    }
+    return this
+  }
+
+  fun withModule(
+    id: Any,
+    selectionAction: ComponentSelectionWithCurrent.() -> Unit,
+  ): ComponentSelectionRulesWithCurrent {
+    delegate.withModule(id) {
+      wrapComponentSelection(it)?.let { wrapped ->
+        wrapped.selectionAction()
       }
     }
     return this

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
@@ -21,6 +21,7 @@ class ComponentSelectionRulesWithCurrent(
     return this
   }
 
+  @JvmSynthetic
   fun all(selectionAction: ComponentSelectionWithCurrent.() -> Unit): ComponentSelectionRulesWithCurrent {
     delegate.all {
       wrapComponentSelection(it)?.let { wrapped ->
@@ -64,6 +65,7 @@ class ComponentSelectionRulesWithCurrent(
     return this
   }
 
+  @JvmSynthetic
   fun withModule(
     id: Any,
     selectionAction: ComponentSelectionWithCurrent.() -> Unit,

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -79,6 +79,46 @@ final class KotlinDslUsageSpec extends Specification {
     gradleVersion << ['8.4', '9.6.1']
   }
 
+  // Gradle 9 requires JVM 17.
+  @IgnoreIf({ data.gradleVersion.startsWith('9') && !jvm.java17Compatible })
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/941')
+  @Unroll
+  def "withModule takes an untyped kotlin-dsl lambda with Gradle #gradleVersion"() {
+    given:
+    buildFile << '''
+      tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+          checkForGradleUpdate = true
+          outputFormatter = "json"
+          outputDir = "build/dependencyUpdates"
+          reportfileName = "report"
+          resolutionStrategy {
+            componentSelection {
+              withModule("com.google.inject:guice") {
+                if (candidate.version == "3.1" && currentVersion != "") {
+                  reject("Guice 3.1 not allowed")
+                }
+              }
+            }
+          }
+        }
+    '''
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion(gradleVersion)
+      .withPluginClasspath()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .build()
+
+    then:
+    result.output.contains('''com.google.inject:guice [2.0 -> 3.0]''')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    gradleVersion << ['8.4', '9.6.1']
+  }
+
   def 'rejectVersionIf binds to the ComponentFilter overload from kotlin-dsl'() {
     given:
     buildFile << '''

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -5,6 +5,8 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreIf
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -37,8 +39,11 @@ final class KotlinDslUsageSpec extends Specification {
         """.stripIndent()
   }
 
+  // Gradle 9 requires JVM 17.
+  @IgnoreIf({ data.gradleVersion.startsWith('9') && !jvm.java17Compatible })
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/941')
   @Unroll
-  def "user friendly kotlin-dsl"() {
+  def "user friendly kotlin-dsl with Gradle #gradleVersion"() {
     given:
     buildFile << '''
       tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
@@ -60,6 +65,7 @@ final class KotlinDslUsageSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
+      .withGradleVersion(gradleVersion)
       .withPluginClasspath()
       .withProjectDir(testProjectDir.root)
       .withArguments('dependencyUpdates')
@@ -68,6 +74,9 @@ final class KotlinDslUsageSpec extends Specification {
     then:
     result.output.contains('''com.google.inject:guice [2.0 -> 3.0]''')
     result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    gradleVersion << ['8.4', '9.6.1']
   }
 
   def 'rejectVersionIf binds to the ComponentFilter overload from kotlin-dsl'() {

--- a/gradle-versions-plugin/src/test/java/com/github/benmanes/gradle/versions/updates/resolutionstrategy/JavaCallerCompilation.java
+++ b/gradle-versions-plugin/src/test/java/com/github/benmanes/gradle/versions/updates/resolutionstrategy/JavaCallerCompilation.java
@@ -1,0 +1,20 @@
+package com.github.benmanes.gradle.versions.updates.resolutionstrategy;
+
+/**
+ * Compiling this file is the test. An implicitly-typed Java lambda is not pertinent to
+ * applicability, so if the {@code ComponentSelectionWithCurrent.() -> Unit} overloads of
+ * {@code all} and {@code withModule} lose their {@code @JvmSynthetic}, javac sees both them and
+ * the {@code Action} overloads, finds neither more specific, and fails with
+ * "reference to all is ambiguous".
+ */
+final class JavaCallerCompilation {
+  private JavaCallerCompilation() {}
+
+  static void callsAll(ComponentSelectionRulesWithCurrent rules) {
+    rules.all(selection -> selection.reject("nope"));
+  }
+
+  static void callsWithModule(ComponentSelectionRulesWithCurrent rules) {
+    rules.withModule("com.example:example", selection -> selection.reject("nope"));
+  }
+}


### PR DESCRIPTION
Fixes #941.

This PR adds Kotlin lambda overloads of `all` and `withModule`, so an untyped lambda in a `.gradle.kts` binds to one of those instead of the rule source `all(Any)` overload. Gradle passed `-XXLanguage:+DisableCompatibilityModeForNewInference` to the build script compiler through 8.14.5 and dropped it at 9.0.0. That is what moved the binding, not the Kotlin 2.x rewrite. Nothing is removed or retyped, and `@JvmSynthetic` keeps the new overloads out of Java's view, so a Java caller resolves the same candidates it did before.

The untyped `all { }` now routes through the new overload on every supported Gradle version, not only 9.x. `examples/kotlin` carries the form that stopped compiling in its Example 3, so the examples run on Gradle 9.6.1 in the Java 17 rows now. A new file in `src/test/java` pins the `@JvmSynthetic` part. Dropping the annotation makes javac reject an implicitly-typed lambda as ambiguous, so compiling that file is the test.