### PR TITLE
Reject versions outside the version bound the build declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,15 +456,29 @@ tasks.named("dependencyUpdates").configure {
 
 #### Constraints
 
-If you use constraints, for example to define a BOM using the
-[`java-platform`](https://docs.gradle.org/current/userguide/java_platform_plugin.html)
-plugin or to
+If you
 [manage](https://docs.gradle.org/current/userguide/dependency_constraints.html)
-transitive dependency versions, you can enable checking of constraints by
-specifying the `checkConstraints` attribute of the `dependencyUpdates` task. If
-you want to check external constraints (defined in init scripts or by Gradle
-itself) you can do so by specifying the `checkBuildEnvironmentConstraints`
-attribute of the `dependencyUpdates` task.
+transitive dependency versions with a `constraints` block, you can enable
+checking of constraints by specifying the `checkConstraints` attribute of the
+`dependencyUpdates` task. If you want to check external constraints (defined in
+init scripts or by Gradle itself) you can do so by specifying the
+`checkBuildEnvironmentConstraints` attribute of the `dependencyUpdates` task.
+
+The attribute covers the constraints a project declares, on its own
+configurations or on ones they extend. A project applying the
+[`java-platform`](https://docs.gradle.org/current/userguide/java_platform_plugin.html)
+plugin to define a BOM declares its constraints that way, so running the task on
+the platform project reports them.
+
+A project that *consumes* a platform does not declare that platform's
+constraints, under any of `platform("group:artifact:version")`,
+`enforcedPlatform`, or `platform(project(":platform"))`. Gradle hands those
+versions to the consumer as resolution metadata, which `checkConstraints` does
+not read, so they are not enumerated in the consumer's report. This does not
+affect the modules the consumer declares itself: a versionless declaration whose
+version the platform supplies is reported and offered updates as usual. Only a
+module the consumer never declares is absent, and the platform project's own
+report covers those.
 
 <details open>
 <summary>Kotlin</summary>

--- a/README.md
+++ b/README.md
@@ -490,12 +490,17 @@ bound a candidate: a `require` version is a floor resolution may rise above, and
 a `prefer` version only breaks a tie, so a plain `implementation("group:name:1.2.3")`
 is not held back by this rule.
 
-Two things to know before writing a rule against a declared bound. Narrowing the
-candidate set can surface metadata that the unbounded query stepped over, which
-moves a module from an upgrade line to the unresolved section rather than
-failing the build. And a module whose only declaration is a constraint reports
-that constraint as its current version, so `currentVersion` may read
-`[2.0, 3.1[` rather than a resolved version.
+Three things to know before writing a rule against a declared bound. Rejecting
+every candidate for a module, including the version it currently resolves to,
+does not fail the build: the module moves to the unresolved section and its
+upgrade line goes with it. A bound naming a version that was never published
+does that, so a `strictly "1.2.3"` pointing at nothing reports as a resolution
+failure rather than as up to date.
+
+Narrowing the candidate set can also surface metadata that the unbounded query
+stepped over, with the same result. And a module whose only declaration is a
+constraint reports that constraint as its current version, so `currentVersion`
+may read `[2.0, 3.1[` rather than a resolved version.
 
 The declared `strictVersion`, `requiredVersion`, `preferredVersion` and
 `rejectedVersions` remain available on `versionConstraint` for rules that need
@@ -1665,13 +1670,18 @@ and *Note*s are things worth knowing that need no action.
 
 v0.60.0 names the configuration a dependency was declared directly against, so a
 plugin that fills a classpath of its own when it is applied no longer reads as
-the build declaring the dependency:
+the build declaring the dependency, and states the reason a dependency
+constraint was declared with:
 
 > [!IMPORTANT]
-> An entry can now carry an attribution line where it carried none, naming the
-> configuration the dependency was declared against. A tool that parses the plain
-> text report line by line has to skip it, as it already does for the other
-> attribution lines (see [Report format](#report-format)).
+> - An entry can now carry an attribution line where it carried none, naming the
+>   configuration the dependency was declared against. A tool that parses the plain
+>   text report line by line has to skip it, as it already does for the other
+>   attribution lines (see [Report format](#report-format)).
+> - An entry for a dependency constraint declared with `because` now carries that
+>   reason, where only a dependency's reason appeared before. It prints on the same
+>   line as a dependency's reason does, so a tool that already handles one handles
+>   both.
 
 ### v0.58.0
 

--- a/README.md
+++ b/README.md
@@ -318,9 +318,16 @@ def isNonStable = { String version ->
 You can then configure [Component Selection
 Rules](https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:component_selection_rules).
 The current version of a component can be retrieved with the `currentVersion`
-property. You can either use the simplified syntax `rejectVersionIf { ... }` or
-configure a complete resolution strategy. Multiple registrations compose, so a
-candidate is rejected if any registered filter rejects it.
+property, and the constraint its declaration stated with `versionConstraint`,
+Gradle's own
+[`VersionConstraint`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/VersionConstraint.html).
+The query that finds candidates is deliberately unbounded, so a rule that wants
+the report to respect what the build declared reads it from `versionConstraint`
+rather than restating it. It is null for a module no declaration was matched to,
+such as one a substitution rule resolved to, so guard for that. You can either
+use the simplified syntax `rejectVersionIf { ... }` or configure a complete 
+resolution strategy. Multiple registrations compose, so a candidate is rejected 
+if any registered filter rejects it.
 
 <details open>
 <summary>Kotlin</summary>
@@ -391,6 +398,18 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 }
 ```
 
+Example 5: do not offer a version the build already rejected
+
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  rejectVersionIf {
+    candidate.version in versionConstraint?.rejectedVersions.orEmpty()
+  }
+}
+```
+
 </details>
 
 <details>
@@ -452,7 +471,30 @@ tasks.named("dependencyUpdates").configure {
 }
 ```
 
+Example 5: do not offer a version the build already rejected
+
+```groovy
+tasks.named("dependencyUpdates").configure {
+  rejectVersionIf {
+    versionConstraint?.rejectedVersions?.contains(candidate.version)
+  }
+}
+```
+
 </details>
+
+Three things to know before writing a rule against a declared bound.
+`rejectedVersions` returns the selectors the build declared, so the comparison
+above matches an exact `reject("2.9.0")` but not a `reject("[2.9,)")`, which
+arrives as that string. Narrowing the candidate set can surface metadata that
+the unbounded query stepped over, which moves a module from an upgrade line to
+the unresolved section rather than failing the build. And a module whose only
+declaration is a constraint reports that constraint as its current version, so
+`currentVersion` may read `[2.0, 3.1[` rather than a resolved version.
+
+`strictVersion`, `requiredVersion` and `preferredVersion` are available for
+richer rules. Testing a candidate against a declared range needs your own
+version comparison, since Gradle does not expose its own to build scripts.
 
 #### Constraints
 

--- a/README.md
+++ b/README.md
@@ -398,14 +398,14 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 }
 ```
 
-Example 5: do not offer a version the build already rejected
+Example 5: keep the report inside the bound the build already declares
 
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
   rejectVersionIf {
-    candidate.version in versionConstraint?.rejectedVersions.orEmpty()
+    !satisfiesDeclaredBound
   }
 }
 ```
@@ -471,30 +471,35 @@ tasks.named("dependencyUpdates").configure {
 }
 ```
 
-Example 5: do not offer a version the build already rejected
+Example 5: keep the report inside the bound the build already declares
 
 ```groovy
 tasks.named("dependencyUpdates").configure {
   rejectVersionIf {
-    versionConstraint?.rejectedVersions?.contains(candidate.version)
+    !satisfiesDeclaredBound
   }
 }
 ```
 
 </details>
 
-Three things to know before writing a rule against a declared bound.
-`rejectedVersions` returns the selectors the build declared, so the comparison
-above matches an exact `reject("2.9.0")` but not a `reject("[2.9,)")`, which
-arrives as that string. Narrowing the candidate set can surface metadata that
-the unbounded query stepped over, which moves a module from an upgrade line to
-the unresolved section rather than failing the build. And a module whose only
-declaration is a constraint reports that constraint as its current version, so
-`currentVersion` may read `[2.0, 3.1[` rather than a resolved version.
+`satisfiesDeclaredBound` reads a declared range the way dependency resolution
+reads it, so `strictly "[5.3, 6["` admits 5.3.26 and excludes 6.0.1, and
+`reject "[3.0,)"` excludes everything from 3.0 up. Only `strictly` and `reject`
+bound a candidate: a `require` version is a floor resolution may rise above, and
+a `prefer` version only breaks a tie, so a plain `implementation("group:name:1.2.3")`
+is not held back by this rule.
 
-`strictVersion`, `requiredVersion` and `preferredVersion` are available for
-richer rules. Testing a candidate against a declared range needs your own
-version comparison, since Gradle does not expose its own to build scripts.
+Two things to know before writing a rule against a declared bound. Narrowing the
+candidate set can surface metadata that the unbounded query stepped over, which
+moves a module from an upgrade line to the unresolved section rather than
+failing the build. And a module whose only declaration is a constraint reports
+that constraint as its current version, so `currentVersion` may read
+`[2.0, 3.1[` rather than a resolved version.
+
+The declared `strictVersion`, `requiredVersion`, `preferredVersion` and
+`rejectedVersions` remain available on `versionConstraint` for rules that need
+something other than the bound.
 
 #### Constraints
 

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -88,7 +88,7 @@ dependencies {
   }
   upToDate 'backport-util-concurrent:backport-util-concurrent:3.1',
            'backport-util-concurrent:backport-util-concurrent-java12:3.1',
-	    'org.openjdk.jmh:jmh-parent:1.25.2'
+           'org.openjdk.jmh:jmh-parent:1.25.2'
   exceedLatest 'com.google.guava:guava:99.0-SNAPSHOT',
                'com.google.guava:guava-tests:99.0-SNAPSHOT'
   upgradesFound 'com.google.guava:guava:15.0',

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -71,9 +71,9 @@ tasks.named("dependencyUpdates").configure {
     maturityLevel(candidate.version) < maturityLevel(currentVersion)
   }
 
-  // Example 5: do not offer a version the build already rejected
+  // Example 5: keep the report inside the bound the build already declares
   rejectVersionIf {
-    versionConstraint?.rejectedVersions?.contains(candidate.version)
+    !satisfiesDeclaredBound
   }
 }
 
@@ -83,8 +83,7 @@ dependencies {
       'dom4j:dom4j'
   bounded('com.google.code.gson:gson') {
     version {
-      require '2.8.9'
-      reject '2.9.0'
+      strictly '[2.8, 2.11['
     }
   }
   upToDate 'backport-util-concurrent:backport-util-concurrent:3.1',

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 configurations {
   bom
+  bounded
   upToDate
   exceedLatest
   platform
@@ -69,12 +70,23 @@ tasks.named("dependencyUpdates").configure {
   rejectVersionIf {
     maturityLevel(candidate.version) < maturityLevel(currentVersion)
   }
+
+  // Example 5: do not offer a version the build already rejected
+  rejectVersionIf {
+    versionConstraint?.rejectedVersions?.contains(candidate.version)
+  }
 }
 
 dependencies {
   bom 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE',
       'com.google.code.gson:gson',
       'dom4j:dom4j'
+  bounded('com.google.code.gson:gson') {
+    version {
+      require '2.8.9'
+      reject '2.9.0'
+    }
+  }
   upToDate 'backport-util-concurrent:backport-util-concurrent:3.1',
            'backport-util-concurrent:backport-util-concurrent-java12:3.1',
 	    'org.openjdk.jmh:jmh-parent:1.25.2'

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -72,9 +72,9 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     maturityLevel(candidate.version) < maturityLevel(currentVersion)
   }
 
-  // Example 5: do not offer a version the build already rejected
+  // Example 5: keep the report inside the bound the build already declares
   rejectVersionIf {
-    candidate.version in versionConstraint?.rejectedVersions.orEmpty()
+    !satisfiesDeclaredBound
   }
 
   // optional parameters
@@ -90,8 +90,7 @@ dependencies {
   "bom"("dom4j:dom4j")
   "bounded"("com.google.code.gson:gson") {
     version {
-      require("2.8.9")
-      reject("2.9.0")
+      strictly("[2.8, 2.11[")
     }
   }
   "upToDate"("backport-util-concurrent:backport-util-concurrent:3.1")

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 
 configurations {
   register("bom")
+  register("bounded")
   register("upToDate")
   register("exceedLatest")
   register("platform")
@@ -71,6 +72,11 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     maturityLevel(candidate.version) < maturityLevel(currentVersion)
   }
 
+  // Example 5: do not offer a version the build already rejected
+  rejectVersionIf {
+    candidate.version in versionConstraint?.rejectedVersions.orEmpty()
+  }
+
   // optional parameters
   checkForGradleUpdate = true
   outputFormatter = "json"
@@ -82,6 +88,12 @@ dependencies {
   "bom"("org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE")
   "bom"("com.google.code.gson:gson")
   "bom"("dom4j:dom4j")
+  "bounded"("com.google.code.gson:gson") {
+    version {
+      require("2.8.9")
+      reject("2.9.0")
+    }
+  }
   "upToDate"("backport-util-concurrent:backport-util-concurrent:3.1")
   "upToDate"("backport-util-concurrent:backport-util-concurrent-java12:3.1")
   "exceedLatest"("com.google.guava:guava:99.0-SNAPSHOT")

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -2,11 +2,14 @@ package com.github.benmanes.gradle.versions.updates
 
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
+import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
+import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 
 /**
  * The dependency's coordinate.
@@ -16,12 +19,31 @@ class Coordinate(
   artifactId: String?,
   version: String?,
   val userReason: String? = null,
+  versionConstraint: VersionConstraint? = null,
 ) : Comparable<Coordinate> {
   val groupId: String = groupId ?: "none"
   val artifactId: String = artifactId ?: "none"
   val version: String = version ?: "none"
+
+  /**
+   * The constraint the declaration stated, which the resolved version alone does not carry. Held as
+   * an immutable copy, since a selection rule is handed this and the declaration's own constraint
+   * is mutable. Null for a coordinate no declaration was matched to, such as the module a
+   * substitution rule resolved to, or one rebuilt from a partial result.
+   */
+  val versionConstraint: VersionConstraint? =
+    versionConstraint?.let { DefaultImmutableVersionConstraint.of(it) }
+
   val key: Key
     get() = Key(groupId, artifactId)
+
+  /** Retains the arity that callers outside Kotlin construct this with. */
+  constructor(
+    groupId: String?,
+    artifactId: String?,
+    version: String?,
+    userReason: String?,
+  ) : this(groupId, artifactId, version, userReason, null)
 
   override fun toString(): String {
     return "$groupId:$artifactId:$version"
@@ -70,17 +92,25 @@ class Coordinate(
 
   companion object {
     fun from(dependency: ExternalModuleDependency): Coordinate {
-      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
+      return Coordinate(
+        dependency.group,
+        dependency.name,
+        dependency.version,
+        dependency.reason,
+        dependency.versionConstraint,
+      )
     }
 
-    // A dependency constraint reaches this overload as well, and unlike a bare selector it states
-    // a reason of its own.
+    // A dependency constraint reaches this overload as well, and unlike a bare selector it declares
+    // a version constraint and a reason of its own.
     fun from(selector: ModuleVersionSelector): Coordinate {
+      val constraint = selector as? DependencyConstraint
       return Coordinate(
         selector.group,
         selector.name,
         selector.version,
-        (selector as? DependencyConstraint)?.reason,
+        constraint?.reason,
+        constraint?.versionConstraint,
       )
     }
 
@@ -89,7 +119,13 @@ class Coordinate(
     }
 
     fun from(dependency: Dependency): Coordinate {
-      return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
+      return Coordinate(
+        dependency.group,
+        dependency.name,
+        dependency.version,
+        dependency.reason,
+        (dependency as? ExternalDependency)?.versionConstraint,
+      )
     }
 
     fun keyFrom(selector: ModuleVersionSelector): Key {
@@ -100,11 +136,13 @@ class Coordinate(
       identifier: ModuleVersionIdentifier,
       declared: Map<Key, Coordinate?>,
     ): Coordinate {
+      val declaration = declared[Key(identifier.group, identifier.name)]
       return Coordinate(
         identifier.group,
         identifier.name,
         identifier.version,
-        declared.getOrDefault(Key(identifier.group, identifier.name), null)?.userReason,
+        declaration?.userReason,
+        declaration?.versionConstraint,
       )
     }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -11,6 +11,11 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 
+// The parameter list is the one 0.59.0 released. A default argument compiles callers against a
+// synthetic constructor carrying the argument mask, so adding a parameter here, even a defaulted one,
+// leaves a caller of `Coordinate(group, name, version)` linking against a signature that no longer
+// exists. The constraint arrives through a secondary constructor instead.
+
 /**
  * The dependency's coordinate.
  */
@@ -19,7 +24,6 @@ class Coordinate(
   artifactId: String?,
   version: String?,
   val userReason: String? = null,
-  versionConstraint: VersionConstraint? = null,
 ) : Comparable<Coordinate> {
   val groupId: String = groupId ?: "none"
   val artifactId: String = artifactId ?: "none"
@@ -34,23 +38,26 @@ class Coordinate(
    * Copying it needs a class Gradle does not publish, and every coordinate passes through here, so a
    * release that moves the class leaves the constraint unknown rather than failing the whole report.
    */
-  val versionConstraint: VersionConstraint? =
-    try {
-      versionConstraint?.let { DefaultImmutableVersionConstraint.of(it) }
-    } catch (e: LinkageError) {
-      null
-    }
+  var versionConstraint: VersionConstraint? = null
+    private set
 
   val key: Key
     get() = Key(groupId, artifactId)
 
-  /** Retains the arity that callers outside Kotlin construct this with. */
   constructor(
     groupId: String?,
     artifactId: String?,
     version: String?,
     userReason: String?,
-  ) : this(groupId, artifactId, version, userReason, null)
+    versionConstraint: VersionConstraint?,
+  ) : this(groupId, artifactId, version, userReason) {
+    this.versionConstraint =
+      try {
+        versionConstraint?.let { DefaultImmutableVersionConstraint.of(it) }
+      } catch (e: LinkageError) {
+        null
+      }
+  }
 
   override fun toString(): String {
     return "$groupId:$artifactId:$version"

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -30,9 +30,16 @@ class Coordinate(
    * an immutable copy, since a selection rule is handed this and the declaration's own constraint
    * is mutable. Null for a coordinate no declaration was matched to, such as the module a
    * substitution rule resolved to, or one rebuilt from a partial result.
+   *
+   * Copying it needs a class Gradle does not publish, and every coordinate passes through here, so a
+   * release that moves the class leaves the constraint unknown rather than failing the whole report.
    */
   val versionConstraint: VersionConstraint? =
-    versionConstraint?.let { DefaultImmutableVersionConstraint.of(it) }
+    try {
+      versionConstraint?.let { DefaultImmutableVersionConstraint.of(it) }
+    } catch (e: LinkageError) {
+      null
+    }
 
   val key: Key
     get() = Key(groupId, artifactId)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -1,6 +1,7 @@
 package com.github.benmanes.gradle.versions.updates
 
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
@@ -72,8 +73,15 @@ class Coordinate(
       return Coordinate(dependency.group, dependency.name, dependency.version, dependency.reason)
     }
 
+    // A dependency constraint reaches this overload as well, and unlike a bare selector it states
+    // a reason of its own.
     fun from(selector: ModuleVersionSelector): Coordinate {
-      return Coordinate(selector.group, selector.name, selector.version)
+      return Coordinate(
+        selector.group,
+        selector.name,
+        selector.version,
+        (selector as? DependencyConstraint)?.reason,
+      )
     }
 
     fun from(identifier: ModuleVersionIdentifier): Coordinate {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
@@ -109,6 +109,6 @@ class ComponentSelectionRulesWithCurrent(
   private fun wrapComponentSelection(inner: ComponentSelection): ComponentSelectionWithCurrent? {
     val candidateCoordinate = Coordinate.from(inner.candidate)
     val current = currentCoordinates[candidateCoordinate.key] ?: return null
-    return ComponentSelectionWithCurrent(inner, current.version)
+    return ComponentSelectionWithCurrent(inner, current.version, current.versionConstraint)
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -2,6 +2,9 @@ package com.github.benmanes.gradle.versions.updates.resolutionstrategy
 
 import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 
 class ComponentSelectionWithCurrent(
   private val delegate: ComponentSelection,
@@ -9,6 +12,23 @@ class ComponentSelectionWithCurrent(
   /** The constraint the build declared for this module, null when no declaration named it. */
   val versionConstraint: VersionConstraint?,
 ) : ComponentSelection by delegate {
+  /** Retains the arity that callers outside Kotlin construct this with. */
+  constructor(
+    delegate: ComponentSelection,
+    currentVersion: String,
+  ) : this(delegate, currentVersion, null)
+
+  /**
+   * Whether the candidate lies within the bound the declaration stated, read the way dependency
+   * resolution reads it, so that a range is honored rather than compared as a string.
+   *
+   * Only `strictly` and `reject` bound a candidate. A `require` version is a floor that resolution
+   * may rise above, and a `prefer` version is consulted only to break a tie, so neither excludes an
+   * upgrade the build already permits. True for a module that declared no bound at all.
+   */
+  val satisfiesDeclaredBound: Boolean
+    get() = DeclaredBound.accepts(versionConstraint, candidate.version)
+
   override fun toString(): String {
     return """\
 ComponentSelectionWithCurrent{
@@ -18,5 +38,41 @@ ComponentSelectionWithCurrent{
     currentVersion="$currentVersion",
     versionConstraint="$versionConstraint",
 }"""
+  }
+}
+
+/**
+ * Reads a declared selector with the parser dependency resolution itself uses, as Gradle publishes
+ * no API for it; https://github.com/gradle/gradle/issues/13748 asks for one and remains open, and
+ * its own worked example is this. A release that moves the parser leaves the bound unknown rather
+ * than failing the report, which is why the linkage failure is answered instead of thrown.
+ */
+private object DeclaredBound {
+  private val scheme: DefaultVersionSelectorScheme? by lazy {
+    try {
+      DefaultVersionSelectorScheme(DefaultVersionComparator(), VersionParser())
+    } catch (e: LinkageError) {
+      null
+    }
+  }
+
+  fun accepts(
+    constraint: VersionConstraint?,
+    candidate: String,
+  ): Boolean {
+    val parser = scheme
+    if (parser == null || constraint == null) {
+      return true
+    }
+    return try {
+      val strict = constraint.strictVersion
+      if (strict.isNotEmpty() && !parser.parseSelector(strict).accept(candidate)) {
+        false
+      } else {
+        constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
+      }
+    } catch (e: LinkageError) {
+      true
+    }
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -1,10 +1,13 @@
 package com.github.benmanes.gradle.versions.updates.resolutionstrategy
 
 import org.gradle.api.artifacts.ComponentSelection
+import org.gradle.api.artifacts.VersionConstraint
 
 class ComponentSelectionWithCurrent(
   private val delegate: ComponentSelection,
   val currentVersion: String,
+  /** The constraint the build declared for this module, null when no declaration named it. */
+  val versionConstraint: VersionConstraint?,
 ) : ComponentSelection by delegate {
   override fun toString(): String {
     return """\
@@ -13,6 +16,7 @@ ComponentSelectionWithCurrent{
     module="${candidate.module}",
     version="${candidate.version}",
     currentVersion="$currentVersion",
+    versionConstraint="$versionConstraint",
 }"""
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -12,7 +12,7 @@ class ComponentSelectionWithCurrent(
   /** The constraint the build declared for this module, null when no declaration named it. */
   val versionConstraint: VersionConstraint?,
 ) : ComponentSelection by delegate {
-  /** Retains the arity that callers outside Kotlin construct this with. */
+  /** Retained so the arity released before the constraint was added still links. */
   constructor(
     delegate: ComponentSelection,
     currentVersion: String,

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -403,4 +403,83 @@ final class ConstraintsSpec extends Specification {
     result.output.contains('org.apache.logging.log4j:log4j-core')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  def "Report a module the consumer declares for a version the platform supplies"() {
+    given: 'log4j is a published BOM whose dependencyManagement names log4j-core'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api $platform('org.apache.logging.log4j:log4j:2.16.0')
+          api 'org.apache.logging.log4j:log4j-core'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the versionless declaration is checked, at the version the platform supplied'
+    result.output.contains('org.apache.logging.log4j:log4j-core [2.16.0 -> 2.17.0]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    platform << ['platform', 'enforcedPlatform']
+  }
+
+  def "Do not enumerate a consumed platform's own constraints"() {
+    given: 'the platform constrains log4j-core, and the consumer never declares it'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api platform('org.apache.logging.log4j:log4j:2.16.0')
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the platform itself is reported, the module it constrains is not'
+    result.output.contains('org.apache.logging.log4j:log4j [2.16.0 -> 2.17.0]')
+    !result.output.contains('log4j-core')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -404,6 +404,48 @@ final class ConstraintsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  def "Report the reason a constraint was declared with"() {
+    given: 'a dependency states its reason in the report, and a constraint should read the same'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api('com.google.inject:guice:2.0') {
+              because 'a constraint reason'
+            }
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('a constraint reason')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def "Report a module the consumer declares for a version the platform supplies"() {
     given: 'log4j is a published BOM whose dependencyManagement names log4j-core'
     buildFile = testProjectDir.newFile('build.gradle')
@@ -480,48 +522,6 @@ final class ConstraintsSpec extends Specification {
     then: 'the platform itself is reported, the module it constrains is not'
     result.output.contains('org.apache.logging.log4j:log4j [2.16.0 -> 2.17.0]')
     !result.output.contains('log4j-core')
-    result.task(':dependencyUpdates').outcome == SUCCESS
-  }
-
-  def "Report the reason a constraint was declared with"() {
-    given: 'a dependency states its reason in the report, and a constraint should read the same'
-    buildFile = testProjectDir.newFile('build.gradle')
-    buildFile <<
-      """
-        plugins {
-          id 'java-library'
-          id 'io.github.ben-manes.versions'
-        }
-
-        tasks.dependencyUpdates {
-          checkConstraints = true
-        }
-
-        repositories {
-          maven {
-            url '${mavenRepoUrl}'
-          }
-        }
-
-        dependencies {
-          constraints {
-            api('com.google.inject:guice:2.0') {
-              because 'a constraint reason'
-            }
-          }
-        }
-      """.stripIndent()
-
-    when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('dependencyUpdates')
-      .withPluginClasspath()
-      .build()
-
-    then:
-    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
-    result.output.contains('a constraint reason')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -404,6 +404,7 @@ final class ConstraintsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
   def "Report the reason a constraint was declared with"() {
     given: 'a dependency states its reason in the report, and a constraint should read the same'
     buildFile = testProjectDir.newFile('build.gradle')
@@ -446,8 +447,20 @@ final class ConstraintsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
   def "Report a module the consumer declares for a version the platform supplies"() {
     given: 'log4j is a published BOM whose dependencyManagement names log4j-core'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        dependencies {
+          constraints {
+            api 'org.apache.logging.log4j:log4j-core:2.16.0'
+          }
+        }
+      """.stripIndent()
     buildFile = testProjectDir.newFile('build.gradle')
     buildFile <<
       """
@@ -467,7 +480,7 @@ final class ConstraintsSpec extends Specification {
         }
 
         dependencies {
-          api $platform('org.apache.logging.log4j:log4j:2.16.0')
+          api $platform
           api 'org.apache.logging.log4j:log4j-core'
         }
       """.stripIndent()
@@ -484,9 +497,14 @@ final class ConstraintsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    platform << ['platform', 'enforcedPlatform']
+    platform << [
+      "platform('org.apache.logging.log4j:log4j:2.16.0')",
+      "enforcedPlatform('org.apache.logging.log4j:log4j:2.16.0')",
+      "platform(project(':platform'))",
+    ]
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
   def "Do not enumerate a consumed platform's own constraints"() {
     given: 'the platform constrains log4j-core, and the consumer never declares it'
     buildFile = testProjectDir.newFile('build.gradle')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -482,4 +482,46 @@ final class ConstraintsSpec extends Specification {
     !result.output.contains('log4j-core')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  def "Report the reason a constraint was declared with"() {
+    given: 'a dependency states its reason in the report, and a constraint should read the same'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api('com.google.inject:guice:2.0') {
+              because 'a constraint reason'
+            }
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('a constraint reason')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -6,8 +6,10 @@ import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * A component selection rule can only respect what the build declared if the declared
@@ -20,9 +22,21 @@ final class DeclaredVersionConstraintSpec extends Specification {
   private String reportFolder
   private String mavenRepoUrl
 
+  private String classpathString
+
   def 'setup'() {
     reportFolder = "${testProjectDir.root.path.replaceAll('\\\\', '/')}/build/dependencyUpdates"
     mavenRepoUrl = getClass().getResource('/maven/').toURI()
+
+    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        'Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+    classpathString = pluginClasspathResource.readLines()
+      .collect { it.replace('\\', '\\\\') }
+      .collect { "'$it'" }
+      .join(', ')
   }
 
   private void writeBuildFile(String declarations, String taskBody) {
@@ -115,7 +129,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
       """,
       """
         rejectVersionIf {
-          versionConstraint?.rejectedVersions?.contains(candidate.version)
+          !satisfiesDeclaredBound
         }
       """)
 
@@ -178,7 +192,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
           outputFormatter = "json"
           checkForGradleUpdate = false
           rejectVersionIf {
-            candidate.version in versionConstraint?.rejectedVersions.orEmpty()
+            !satisfiesDeclaredBound
           }
         }
       """.stripIndent()
@@ -189,6 +203,138 @@ final class DeclaredVersionConstraintSpec extends Specification {
     then:
     report().outdated.dependencies*.name == ['guice']
     report().outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  def 'a declared range bounds the report, and an in-range upgrade is still offered'() {
+    given: 'guice resolves to 2.0, while 2.1, 2.2 and 3.0 are inside the range and 3.1 is not'
+    writeBuildFile(
+      """
+        api 'com.google.inject:guice:2.0'
+        constraints {
+          api('com.google.inject:guice') {
+            version {
+              strictly '[2.0, 3.1['
+            }
+          }
+        }
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the top of the declared range, not the 3.1 the unbounded query finds'
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.0'
+    report().unresolved.dependencies.isEmpty()
+  }
+
+  def 'a module with no declared bound is not held back'() {
+    given: 'a plain declaration is a floor resolution may rise above, not a bound'
+    writeBuildFile(
+      """
+        api 'com.google.guava:guava:15.0'
+        api 'com.google.inject:guice:2.0'
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'every upgrade still shows; bounding on a bare require would empty the report'
+    report().outdated.dependencies*.name == ['guava', 'guice']
+    report().outdated.dependencies.find { it.name == 'guava' }.available.milestone == '16.0-rc1'
+    report().outdated.dependencies.find { it.name == 'guice' }.available.milestone == '3.1'
+  }
+
+  def 'a rejected range is honored, not compared as a string'() {
+    given: 'the rejected range names no version literally, so a string comparison would miss it'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '[3.1,)'
+          }
+        }
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: '3.1 falls inside the rejected range, so 3.0 is the offer'
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  // The bound is read with the parser dependency resolution uses, which Gradle does not publish, so
+  // the ends of the supported range are pinned. The versions between them do not move it
+  // independently of these two.
+  @IgnoreIf({ data.gradleVersion.startsWith('9') && !jvm.java17Compatible })
+  @Unroll
+  def 'a declared range is read the same way on Gradle #gradleVersion'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api('com.google.inject:guice') {
+            version {
+              strictly '[2.0, 3.1['
+            }
+          }
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withGradleVersion(gradleVersion)
+      .build()
+
+    then: '3.1 sits outside the declared range on both, so the report stops at 3.0'
+    result.output.contains('com.google.inject:guice')
+    !result.output.contains('-> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    gradleVersion << ['8.4', '9.6.1']
   }
 
   def 'a rule cannot rewrite the constraint the build declared'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -1,0 +1,251 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A component selection rule can only respect what the build declared if the declared
+ * {@code VersionConstraint} reaches the closure. Without it the rule has to restate in the build
+ * script a bound that is already stated in the declaration.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+final class DeclaredVersionConstraintSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String reportFolder
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    reportFolder = "${testProjectDir.root.path.replaceAll('\\\\', '/')}/build/dependencyUpdates"
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private void writeBuildFile(String declarations, String taskBody) {
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          $declarations
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          outputFormatter = 'json'
+          checkForGradleUpdate = false
+          $taskBody
+        }
+      """.stripIndent()
+  }
+
+  private def run() {
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+    assert result.task(':dependencyUpdates').outcome == SUCCESS
+    return result
+  }
+
+  private def report() {
+    return new JsonSlurper().parseText(new File(reportFolder, 'report.json').text)
+  }
+
+  def 'every declared field reaches the selection rule verbatim'() {
+    given: 'one module rejecting an exact version, one rejecting a range'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            strictly '[2.0, 3.1['
+            reject '2.2'
+          }
+        }
+        api('com.google.guava:guava') {
+          version {
+            require '15.0'
+            reject '[16.0,)'
+          }
+        }
+      """,
+      """
+        rejectVersionIf {
+          println "PROBE \${candidate.module} strict='\${versionConstraint?.strictVersion}'" +
+            " required='\${versionConstraint?.requiredVersion}'" +
+            " rejects=\${versionConstraint?.rejectedVersions}"
+          return false
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'the bound the build declared, not the "+" the query substitutes for it'
+    result.output.contains("PROBE guice strict='[2.0, 3.1[' required='[2.0, 3.1[' rejects=[2.2]")
+
+    and: 'a reject comes back as the selector that was declared, so a range arrives unexpanded'
+    result.output.contains("PROBE guava strict='' required='15.0' rejects=[[16.0,)]")
+  }
+
+  def 'the README recipe does not offer a version the build rejected'() {
+    given: 'guice rejects its own newest version, guava rejects nothing'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '3.1'
+          }
+        }
+        api 'com.google.guava:guava:15.0'
+      """,
+      """
+        rejectVersionIf {
+          versionConstraint?.rejectedVersions?.contains(candidate.version)
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'guice stops below the version it rejects, guava is unaffected'
+    report().outdated.dependencies*.name == ['guava', 'guice']
+    report().outdated.dependencies.find { it.name == 'guice' }.available.milestone == '3.0'
+    report().outdated.dependencies.find { it.name == 'guava' }.available.milestone == '16.0-rc1'
+    report().unresolved.dependencies.isEmpty()
+  }
+
+  def 'without the rule the rejected version is offered, so the rule is what changes it'() {
+    given:
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '3.1'
+          }
+        }
+      """,
+      '')
+
+    when:
+    run()
+
+    then: 'the unbounded query offers the very version the build rejects'
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.1'
+  }
+
+  def 'the README recipe compiles and applies under the Kotlin DSL'() {
+    given:
+    testProjectDir.newFile('build.gradle.kts') <<
+      """
+        import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+        plugins {
+          `java-library`
+          id("io.github.ben-manes.versions")
+        }
+
+        repositories {
+          maven(url = "${mavenRepoUrl}")
+        }
+
+        dependencies {
+          api("com.google.inject:guice") {
+            version {
+              require("2.0")
+              reject("3.1")
+            }
+          }
+        }
+
+        tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+          outputFormatter = "json"
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            candidate.version in versionConstraint?.rejectedVersions.orEmpty()
+          }
+        }
+      """.stripIndent()
+
+    when:
+    run()
+
+    then:
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  def 'a rule cannot rewrite the constraint the build declared'() {
+    given: 'the rule is handed a copy, so mutating it must not change what the report resolves'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            strictly '[2.0, 3.1['
+          }
+        }
+      """,
+      """
+        rejectVersionIf {
+          try {
+            versionConstraint?.strictly('9.9')
+            println "PROBE-MUTATED"
+          } catch (Exception e) {
+            println "PROBE-REFUSED \${e.getClass().simpleName}"
+          }
+          return false
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'the mutation is refused, and the reported current version is the resolved one'
+    result.output.contains('PROBE-REFUSED')
+    !result.output.contains('PROBE-MUTATED')
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].version == '3.0'
+  }
+
+  def 'a substituted module has no declared constraint, and the recipe tolerates it'() {
+    given: 'the substituted module is keyed differently than the declaration, so nothing matches it'
+    writeBuildFile(
+      "api 'com.google.guava:guava:15.0'",
+      """
+        rejectVersionIf {
+          println "PROBE \${candidate.module} constraint=\${versionConstraint}"
+          return versionConstraint?.rejectedVersions?.contains(candidate.version)
+        }
+      """)
+    testProjectDir.root.toPath().resolve('build.gradle').append(
+      """
+        configurations.all {
+          resolutionStrategy.dependencySubstitution {
+            substitute module('com.google.guava:guava') using module('com.google.inject:guice:2.0')
+          }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run()
+
+    then: 'the rule sees a null constraint and the build does not fail on it'
+    result.output.contains('constraint=null')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -337,6 +337,31 @@ final class DeclaredVersionConstraintSpec extends Specification {
     gradleVersion << ['8.4', '9.6.1']
   }
 
+  def 'a bound naming an unpublished version loses the report line to the unresolved section'() {
+    given: 'guice 2.1 is listed in the repository metadata but was never published'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            strictly '2.1'
+          }
+        }
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'every candidate is rejected, which does not fail the build but does move the entry'
+    report().outdated.dependencies.isEmpty()
+    report().current.dependencies.isEmpty()
+    report().unresolved.dependencies*.name == ['guice']
+  }
+
   def 'a rule cannot rewrite the constraint the build declared'() {
     given: 'the rule is handed a copy, so mutating it must not change what the report resolves'
     writeBuildFile(

--- a/gradle-versions-plugin/src/test/resources/maven/com/google/inject/guice/2.2/guice-2.2.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/google/inject/guice/2.2/guice-2.2.pom
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>guice</artifactId>
+  <version>2.2</version>
 
   <name>Google Guice - Core Library</name>
 


### PR DESCRIPTION
@ben-manes's https://github.com/ben-manes/gradle-versions-plugin/issues/755#issuecomment-1487553731 suggests a component selection rule for restricting the report, naming `rejectVersionIf` as the DSL for it. Following that means restating the declared bound in the task configuration, because the rule cannot see what the declaration carries, and [restating it is what I was trying to avoid](https://github.com/ben-manes/gradle-versions-plugin/issues/755#issuecomment-1487306483):

```kotlin
dependencies {
  api("org.springframework:spring-context") {
    version {
      strictly("[5.3, 6[")
      prefer("5.3.25")
    }
  }
}

// Before: the declared range is restated, per module
tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
  rejectVersionIf {
    candidate.group == "org.springframework" && candidate.version.startsWith("6")
  }
}

// After: one rule, reading what every declaration already states
tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
  rejectVersionIf {
    !satisfiesDeclaredBound
  }
}
```

This PR exposes the declared `VersionConstraint` on `ComponentSelectionWithCurrent`, and adds `satisfiesDeclaredBound`, which reads a declared range with the parser resolution itself uses rather than comparing selectors as strings. Only `strictly` and `reject` bound a candidate, since a `require` version is a floor resolution may rise above, so a plainly declared dependency is not held back. Nothing changes by default; the candidate query stays unbounded.

Reading a selector needs Gradle internal API, as Gradle publishes no public API for it ([gradle/gradle#13748](https://github.com/gradle/gradle/issues/13748)). It comes from the same internal package as `DefaultVersionComparator` and `VersionParser`, which `VersionMapping` has used since v0.43.0. Where this change reads it, a release that moves it leaves the bound unknown rather than failing the report.

A dependency's `because` reason reached the report and a constraint's did not, so constraints now state theirs the same way:

```text
The following dependencies have later milestone versions:
 - com.google.inject:guice [2.0 -> 3.1]
     the 3.x line drops the Guava dependency we rely on
     https://code.google.com/p/google-guice/
```

The README's constraints section named the `java-platform` plugin without saying which project `checkConstraints` reads, so I corrected that too.

This does not address #755 as reported. A consumed platform's constraints are still not visible to `checkConstraints`, so a module whose version the platform supplies has no declared bound here either and stays unbounded. This also relates to #402. I'm looking into a PR that might close them.
