### PR TITLE
Bound a module by the version constraints its platforms state (fixes #402, fixes #755)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,14 @@ The current version of a component can be retrieved with the `currentVersion`
 property, and the constraint its declaration stated with `versionConstraint`,
 Gradle's own
 [`VersionConstraint`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/VersionConstraint.html).
-The query that finds candidates is deliberately unbounded, so a rule that wants
-the report to respect what the build declared reads it from `versionConstraint`
-rather than restating it. It is null for a module no declaration was matched to,
-such as one a substitution rule resolved to, so guard for that. You can either
+A module the build declares with no version of its own carries the constraints
+the platforms it consumes state for that module in `platformVersionConstraints`,
+a list rather than a single value because more than one consumed platform can
+bound the same module. The query that finds candidates is deliberately unbounded,
+so a rule that wants the report to respect what the build declared reads it from
+`versionConstraint` rather than restating it. It is null for a module no
+declaration was matched to, such as one a substitution rule resolved to, so
+guard for that. You can either
 use the simplified syntax `rejectVersionIf { ... }` or configure a complete 
 resolution strategy. Multiple registrations compose, so a candidate is rejected 
 if any registered filter rejects it.
@@ -489,6 +493,68 @@ reads it, so `strictly "[5.3, 6["` admits 5.3.26 and excludes 6.0.1, and
 bound a candidate: a `require` version is a floor resolution may rise above, and
 a `prefer` version only breaks a tie, so a plain `implementation("group:name:1.2.3")`
 is not held back by this rule.
+
+A module declared with no version of its own is additionally bound by the
+version a consumed platform requires for it, since the build cannot take that
+upgrade without also bumping the platform. Given a platform BOM that pins
+`log4j-core` to `2.16.0`:
+
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+dependencies {
+  api(platform("org.apache.logging.log4j:log4j-bom:2.16.0"))
+  api("org.apache.logging.log4j:log4j-core")
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+dependencies {
+  api platform('org.apache.logging.log4j:log4j-bom:2.16.0')
+  api 'org.apache.logging.log4j:log4j-core'
+}
+```
+
+</details>
+
+`satisfiesDeclaredBound` holds `log4j-core` to `2.16.0` even though
+`versionConstraint` is empty for it, because the bound comes from the platform
+instead:
+
+```text
+The following dependencies are using the latest milestone version:
+ - org.apache.logging.log4j:log4j-core:2.16.0
+
+The following dependencies have later milestone versions:
+ - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.17.0]
+```
+
+The platform keeps its own report line, so the upgrade that is actually
+available, bumping the BOM, still shows. The bound is deliberately narrow:
+
+- A module the build states a version for anywhere in the configuration
+  hierarchy keeps the floor semantics above; a platform never tightens a
+  version declared directly.
+- A platform that states a range admits in-range upgrades, the same as a
+  declared range.
+- A platform that states only a `prefer` version does not bound, the same as
+  a declared `prefer`.
+- When more than one consumed platform bounds the same module, a candidate
+  must satisfy every one of them. That is stricter than the version resolution
+  itself would settle on, so the report offers an upgrade only when no
+  consumed platform stands against it; the version currently resolved is
+  always accepted, whichever platform supplied it.
+- Only a platform bounds. A constraint an ordinary library publishes in its
+  module metadata supplies a version without bounding the report.
+- An `enforcedPlatform` states its own version with `strictly`, so the rule
+  holds the platform itself to that version and a newer BOM stops being
+  offered; a plain `platform` keeps its own upgrade line.
 
 Three things to know before writing a rule against a declared bound. Rejecting
 every candidate for a module, including the version it currently resolves to,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -41,6 +41,14 @@ class Coordinate(
   var versionConstraint: VersionConstraint? = null
     private set
 
+  /**
+   * The constraints the platforms this module's consumer depends on state for it, empty when no
+   * declaration named this module without a version or no consumed platform bounds it. A release
+   * that moves the copying class leaves this empty rather than failing the whole report.
+   */
+  var platformVersionConstraints: List<VersionConstraint> = emptyList()
+    private set
+
   val key: Key
     get() = Key(groupId, artifactId)
 
@@ -56,6 +64,22 @@ class Coordinate(
         versionConstraint?.let { DefaultImmutableVersionConstraint.of(it) }
       } catch (e: LinkageError) {
         null
+      }
+  }
+
+  internal constructor(
+    groupId: String?,
+    artifactId: String?,
+    version: String?,
+    userReason: String?,
+    versionConstraint: VersionConstraint?,
+    platformVersionConstraints: List<VersionConstraint>,
+  ) : this(groupId, artifactId, version, userReason, versionConstraint) {
+    this.platformVersionConstraints =
+      try {
+        platformVersionConstraints.map { DefaultImmutableVersionConstraint.of(it) }
+      } catch (e: LinkageError) {
+        emptyList()
       }
   }
 
@@ -157,6 +181,24 @@ class Coordinate(
         identifier.version,
         declaration?.userReason,
         declaration?.versionConstraint,
+      )
+    }
+
+    /** As above, additionally attaching the constraints a consumed platform states for it. */
+    internal fun from(
+      identifier: ModuleVersionIdentifier,
+      declared: Map<Key, Coordinate?>,
+      platformConstraints: Map<Key, List<VersionConstraint>>,
+    ): Coordinate {
+      val key = Key(identifier.group, identifier.name)
+      val declaration = declared[key]
+      return Coordinate(
+        identifier.group,
+        identifier.name,
+        identifier.version,
+        declaration?.userReason,
+        declaration?.versionConstraint,
+        platformConstraints[key].orEmpty(),
       )
     }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -16,16 +16,20 @@ import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.HasConfigurableAttributes
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -366,6 +370,7 @@ class Resolver(
 
     disableAutoTargetJvm(copy)
     val root = copy.incoming.resolutionResult.root
+    val platformConstraints = getPlatformConstraints(copy.incoming.resolutionResult, versionedKeys(configuration))
 
     for (dependency in root.dependencies) {
       // Constraints are accumulated separately below via allDependencyConstraints.
@@ -375,7 +380,7 @@ class Resolver(
       when (dependency) {
         is ResolvedDependencyResult -> {
           val moduleVersion = dependency.selected.moduleVersion ?: continue
-          val coordinate = Coordinate.from(moduleVersion, declared)
+          val coordinate = Coordinate.from(moduleVersion, declared, platformConstraints)
           coordinates[coordinate.key] = coordinate
         }
         is UnresolvedDependencyResult -> {
@@ -441,6 +446,59 @@ class Resolver(
       configurationsOf(configuration, contributedKeys + declaringKeys),
     )
   }
+
+  /**
+   * Returns the version constraints the consumed platforms state for each module that is declared
+   * with no version of its own, keyed by that module.
+   *
+   * Only a constraint edge whose source resolved as a platform qualifies. One from the resolution
+   * root is the consumer's own `constraints {}` block, which is editable and thus governed by
+   * [Coordinate.versionConstraint] instead, and one an ordinary library ships in its module
+   * metadata is a resolution input rather than a platform's version choice. A module the build
+   * itself versions is also excluded, since the build controls that number and a plain declaration
+   * keeps its floor semantics.
+   * https://github.com/ben-manes/gradle-versions-plugin/issues/402
+   */
+  private fun getPlatformConstraints(
+    result: ResolutionResult,
+    versionedKeys: Set<Coordinate.Key>,
+  ): Map<Coordinate.Key, List<VersionConstraint>> {
+    val constraints = hashMapOf<Coordinate.Key, MutableList<VersionConstraint>>()
+    for (dependency in result.allDependencies) {
+      if (dependency !is ResolvedDependencyResult || !dependency.isConstraint) {
+        continue
+      }
+      if (dependency.from.id == result.root.id) {
+        continue
+      }
+      if (dependency.from.variants.none { isPlatform(it) }) {
+        continue
+      }
+      val requested = dependency.requested as? ModuleComponentSelector ?: continue
+      val versionConstraint = requested.versionConstraint
+      if (versionConstraint.requiredVersion.isEmpty() && versionConstraint.rejectedVersions.isEmpty()) {
+        continue
+      }
+      val key = Coordinate.Key(requested.group, requested.module)
+      if (key in versionedKeys) {
+        continue
+      }
+      constraints.getOrPut(key) { mutableListOf() }.add(versionConstraint)
+    }
+    return constraints
+  }
+
+  /**
+   * Returns the modules that any declaration in the configuration's hierarchy states a version for.
+   *
+   * The declared coordinates keep only the last declaration of a module, so a versionless one in a
+   * configuration can mask a versioned one in another it extends. Reading every declaration keeps a
+   * platform from bounding a version the build states somewhere it can edit.
+   */
+  private fun versionedKeys(configuration: Configuration): Set<Coordinate.Key> =
+    getResolvableDependencies(configuration)
+      .filterNot { it.version == "none" }
+      .mapTo(hashSetOf()) { it.key }
 
   /** Returns the modules that a resolution rule substituted for a declared one, by declared key. */
   private fun getSubstitutions(
@@ -605,6 +663,18 @@ class Resolver(
   companion object {
     private val PROJECT_PROPERTY = Regex("""\$\{project\.(groupId|artifactId|version)}""")
     private val ABSOLUTE_URL = Regex("""^[a-zA-Z][a-zA-Z0-9+.-]*://""")
+    private val DESUGARED_CATEGORY = Attribute.of(Category.CATEGORY_ATTRIBUTE.name, String::class.java)
+
+    /**
+     * Whether the variant is a platform's. A local project's variant carries the typed [Category]
+     * attribute while a published module's is desugared to a string, so both forms are read.
+     */
+    private fun isPlatform(variant: ResolvedVariantResult): Boolean {
+      val category =
+        variant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name
+          ?: variant.attributes.getAttribute(DESUGARED_CATEGORY)
+      return (category == Category.REGULAR_PLATFORM) || (category == Category.ENFORCED_PLATFORM)
+    }
 
     private fun getUrlFromPom(file: File): String? {
       val pom = XmlSlurper(false, false).parse(file)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
@@ -109,6 +109,11 @@ class ComponentSelectionRulesWithCurrent(
   private fun wrapComponentSelection(inner: ComponentSelection): ComponentSelectionWithCurrent? {
     val candidateCoordinate = Coordinate.from(inner.candidate)
     val current = currentCoordinates[candidateCoordinate.key] ?: return null
-    return ComponentSelectionWithCurrent(inner, current.version, current.versionConstraint)
+    return ComponentSelectionWithCurrent(
+      inner,
+      current.version,
+      current.versionConstraint,
+      current.platformVersionConstraints,
+    )
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -11,12 +11,27 @@ class ComponentSelectionWithCurrent(
   val currentVersion: String,
   /** The constraint the build declared for this module, null when no declaration named it. */
   val versionConstraint: VersionConstraint?,
+  /**
+   * The constraints the platforms this module's consumer depends on state for it, empty when this
+   * module's declaration states its own version or no consumed platform bounds it.
+   */
+  val platformVersionConstraints: List<VersionConstraint>,
 ) : ComponentSelection by delegate {
   /** Retained so the arity released before the constraint was added still links. */
   constructor(
     delegate: ComponentSelection,
     currentVersion: String,
-  ) : this(delegate, currentVersion, null)
+  ) : this(delegate, currentVersion, null, emptyList())
+
+  /**
+   * Retains the arity the declared [VersionConstraint] arrived with, in case a release ships it
+   * before this change.
+   */
+  constructor(
+    delegate: ComponentSelection,
+    currentVersion: String,
+    versionConstraint: VersionConstraint?,
+  ) : this(delegate, currentVersion, versionConstraint, emptyList())
 
   /**
    * Whether the candidate lies within the bound the declaration stated, read the way dependency
@@ -25,9 +40,15 @@ class ComponentSelectionWithCurrent(
    * Only `strictly` and `reject` bound a candidate. A `require` version is a floor that resolution
    * may rise above, and a `prefer` version is consulted only to break a tie, so neither excludes an
    * upgrade the build already permits. True for a module that declared no bound at all.
+   *
+   * A module whose declaration states no version is additionally bounded by the constraints the
+   * platforms the consumer depends on state for it, and the version currently selected is always
+   * within bound.
    */
   val satisfiesDeclaredBound: Boolean
-    get() = DeclaredBound.accepts(versionConstraint, candidate.version)
+    get() =
+      DeclaredBound.accepts(versionConstraint, candidate.version) &&
+        DeclaredBound.acceptsPlatformSupplied(platformVersionConstraints, currentVersion, candidate.version)
 
   override fun toString(): String {
     return """\
@@ -37,6 +58,7 @@ ComponentSelectionWithCurrent{
     version="${candidate.version}",
     currentVersion="$currentVersion",
     versionConstraint="$versionConstraint",
+    platformVersionConstraints="$platformVersionConstraints",
 }"""
   }
 }
@@ -70,6 +92,34 @@ private object DeclaredBound {
         false
       } else {
         constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
+      }
+    } catch (e: LinkageError) {
+      true
+    }
+  }
+
+  /**
+   * Whether the candidate lies within every one of the versions the consumed platforms require for
+   * this module, read the same way [accepts] reads a declared bound. Requiring each edge to admit
+   * the candidate is stricter than the version resolution itself settles on, which is deliberate:
+   * the report offers an upgrade only when no consumed platform stands against it. The version
+   * currently selected is always accepted, since a transitive requirement can push the merged
+   * selection above what a platform alone would choose.
+   */
+  fun acceptsPlatformSupplied(
+    constraints: List<VersionConstraint>,
+    currentVersion: String,
+    candidate: String,
+  ): Boolean {
+    val parser = scheme
+    if (parser == null || constraints.isEmpty() || candidate == currentVersion) {
+      return true
+    }
+    return try {
+      constraints.all { constraint ->
+        val required = constraint.requiredVersion
+        (required.isEmpty() || parser.parseSelector(required).accept(candidate)) &&
+          constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
       }
     } catch (e: LinkageError) {
       true

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -419,4 +419,493 @@ final class DeclaredVersionConstraintSpec extends Specification {
     then: 'the rule sees a null constraint and the build does not fail on it'
     result.output.contains('constraint=null')
   }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  @Unroll
+  def 'a module the platform supplies the version for is bounded by the platform, #label'() {
+    given: 'log4j-core is declared with no version and its version comes from the platform'
+    writeBuildFile(
+      """
+        api $platform
+        api 'org.apache.logging.log4j:log4j-core'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the platform-supplied module is held to the platform, so it reports as current'
+    report().current.dependencies*.name.contains('log4j-core')
+    !report().outdated.dependencies*.name.contains('log4j-core')
+
+    and: 'a platform declared as an external module still reports its own available upgrade'
+    (platformReportsOwnUpgrade
+      ? report().outdated.dependencies*.name.contains('log4j')
+      : !report().outdated.dependencies*.name.contains('log4j'))
+
+    where:
+    platform                                                    | platformReportsOwnUpgrade | label
+    "platform('org.apache.logging.log4j:log4j:2.16.0')"         | true                       | 'platform()'
+    "enforcedPlatform('org.apache.logging.log4j:log4j:2.16.0')" | false                      | 'enforcedPlatform()'
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'without the rule the platform-supplied module is offered every upgrade, so the rule is what changes it'() {
+    given: 'the bounded shape above, with no rule installed'
+    writeBuildFile(
+      """
+        api platform('org.apache.logging.log4j:log4j:2.16.0')
+        api 'org.apache.logging.log4j:log4j-core'
+      """,
+      '')
+
+    when:
+    run()
+
+    then: 'the platform and the module it supplies both still report their upgrades'
+    report().outdated.dependencies*.name.containsAll(['log4j', 'log4j-core'])
+    !report().current.dependencies*.name.contains('log4j-core')
+  }
+
+  // A project platform's own module is aggregated into the same build, so its own view of
+  // log4j-core (undeclared, unbounded from its own perspective) reaches the merged report too and
+  // the module name is identical: the current/outdated JSON split above cannot isolate the
+  // consumer's bounded view from the platform's own. Verify this shape via the rule directly
+  // instead, as 'the platform constraints reach the rule' does, and via the range check below,
+  // which discriminates the consumer's entry from the platform's by declared version text.
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a project platform still bounds the module its own build declares no version for'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'org.apache.logging.log4j:log4j-core:2.16.0'
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform(project(':platform'))
+        api 'org.apache.logging.log4j:log4j-core'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          if (candidate.module == 'log4j-core' && currentVersion == '2.16.0') {
+            println "PROBE \${candidate.module}@\${candidate.version} bound=\${satisfiesDeclaredBound}" +
+              " platformConstraints=\${platformVersionConstraints.collect { it.requiredVersion }}"
+          }
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'the consumer-declared, platform-bounded candidate is accepted only at the platform version'
+    result.output.contains('PROBE log4j-core@2.16.0 bound=true platformConstraints=[2.16.0]')
+    result.output.contains('PROBE log4j-core@2.17.0 bound=false platformConstraints=[2.16.0]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a constraint an ordinary library states does not bound the module'() {
+    given: 'the same constraint shape as above, stated by a java-library rather than a platform'
+    testProjectDir.newFile('settings.gradle') << "include 'lib'\n"
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        plugins { id 'java-library' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'org.apache.logging.log4j:log4j-core:2.16.0'
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api project(':lib')
+        api 'org.apache.logging.log4j:log4j-core'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          if (candidate.module == 'log4j-core') {
+            println "PROBE \${candidate.module}@\${candidate.version} bound=\${satisfiesDeclaredBound}" +
+              " platformConstraints=\${platformVersionConstraints.collect { it.requiredVersion }}"
+          }
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: "the library's constraint supplies the version, but no platform bound reaches the rule"
+    result.output.contains('PROBE log4j-core@2.17.0 bound=true platformConstraints=[]')
+
+    and: 'no configuration surfaced the library constraint as a platform bound'
+    !result.output.contains('platformConstraints=[2.16.0]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a range a platform declares still admits an in-range upgrade'() {
+    given: 'the platform bounds guice to [2.0, 3.1), which admits 3.0 but not 3.1'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api('com.google.inject:guice') {
+              version {
+                require '[2.0, 3.1['
+                prefer '2.0'
+              }
+            }
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform(project(':platform'))
+        api 'com.google.inject:guice'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the in-range upgrade is offered, the out-of-range one is not'
+    def guice = report().outdated.dependencies.find { it.name == 'guice' && it.version == '2.0' }
+    guice != null
+    guice.available.milestone == '3.0'
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'the platform constraints reach the rule'() {
+    given: 'a versionless module bound by a platform, and the platform itself'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'org.apache.logging.log4j:log4j-core:2.16.0'
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform('org.apache.logging.log4j:log4j:2.16.0')
+        api 'org.apache.logging.log4j:log4j-core'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          println "PROBE \${candidate.module} platformConstraints=" +
+            "\${platformVersionConstraints.collect { it.requiredVersion }}"
+          return false
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'the bounded module carries the platform-required version, the platform carries none'
+    result.output.contains('PROBE log4j-core platformConstraints=[2.16.0]')
+    result.output.contains('PROBE log4j platformConstraints=[]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a version the platform did not choose is not rejected'() {
+    given: 'a transitive requirement outbids the platform, so the merged selection sits above it'
+    writeBuildFile(
+      """
+        api platform('org.apache.logging.log4j:log4j:2.16.0')
+        api 'org.apache.logging.log4j:log4j-core'
+        api 'com.example:log4j-consumer:1.0'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the version resolution actually chose is reported as current, not falsely unresolved'
+    report().current.dependencies*.name.contains('log4j-core')
+    report().current.dependencies.find { it.name == 'log4j-core' }.version == '2.17.0'
+    report().unresolved.dependencies.isEmpty()
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a candidate must satisfy every consumed platform, not just one of them'() {
+    given: 'one platform admits a range up to 3.1, a second pins the module at 2.0'
+    testProjectDir.newFile('settings.gradle') << "include 'p1', 'p2'\n"
+    testProjectDir.newFolder('p1')
+    testProjectDir.newFile('p1/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api('com.google.inject:guice') {
+              version {
+                require '[2.0, 3.2['
+              }
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('p2')
+    testProjectDir.newFile('p2/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform(project(':p1'))
+        api platform(project(':p2'))
+        api 'com.google.inject:guice'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          if (candidate.module == 'guice' && currentVersion == '2.0') {
+            println "PROBE guice@\${candidate.version} bound=\${satisfiesDeclaredBound}"
+          }
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'p2 pins the merged selection at 2.0, so 3.1 must fail even though p1 alone would admit it'
+    result.output.contains('PROBE guice@3.1 bound=false')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a platform constraint that only rejects still bounds the module'() {
+    given: 'one platform rejects 3.1 outright, a second admits a range that includes it'
+    testProjectDir.newFile('settings.gradle') << "include 'p1', 'p2'\n"
+    testProjectDir.newFolder('p1')
+    testProjectDir.newFile('p1/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api('com.google.inject:guice') {
+              version {
+                reject '3.1'
+              }
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('p2')
+    testProjectDir.newFile('p2/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api('com.google.inject:guice') {
+              version {
+                require '[2.0, 3.2['
+              }
+            }
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform(project(':p1'))
+        api platform(project(':p2'))
+        api 'com.google.inject:guice'
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'resolution stops at 3.0 because p1 rejects 3.1, and the rule must not offer it either'
+    !report().outdated.dependencies.any { it.name == 'guice' && it.version == '3.0' }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a direct version beside a platform keeps its floor'() {
+    given: 'the build states its own version for guice, so the platform does not bound it'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform(project(':platform'))
+        api 'com.google.inject:guice:3.0'
+      """,
+      """
+        checkConstraints = true
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the declared floor is unaffected by the platform, every upgrade still shows'
+    def guice = report().outdated.dependencies.find { it.name == 'guice' && it.version == '3.0' }
+    guice != null
+    guice.available.milestone == '3.1'
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a direct version in another configuration of the hierarchy keeps its floor'() {
+    given: 'guice is versionless on one configuration and versioned on another that inherits it, ' +
+      'so only the last declaration read would call the module versionless'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    writeBuildFile(
+      """
+        api platform(project(':platform'))
+        api 'com.google.inject:guice'
+        testImplementation 'com.google.inject:guice:3.0'
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the version the build states is still offered its upgrade'
+    def guice = report().outdated.dependencies.find { it.name == 'guice' && it.version == '3.0' }
+    guice != null
+    guice.available.milestone == '3.1'
+
+    and: 'the versionless declaration stays bounded by the platform'
+    report().outdated.dependencies.every { it.version != '2.0' }
+    report().current.dependencies.any { it.name == 'guice' && it.version == '2.0' }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def "a consumer's own constraint is not a platform bound"() {
+    given: 'checkConstraints is off, so the declared map keeps the plain versionless declaration, ' +
+      'and only the root constraints {} edge could wrongly read as a platform bound'
+    writeBuildFile(
+      """
+        api 'com.google.inject:guice'
+        constraints {
+          api 'com.google.inject:guice:2.0'
+        }
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: "the root's own constraint edge is excluded, so the module stays unbound, not held to 2.0"
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.1'
+  }
 }

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/log4j-consumer/1.0/log4j-consumer-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/log4j-consumer/1.0/log4j-consumer-1.0.pom
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>log4j-consumer</artifactId>
+  <version>1.0</version>
+
+  <name>Example log4j consumer</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.17.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/log4j-consumer/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/log4j-consumer/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>log4j-consumer</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260725000000</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Fixes #402. Fixes #755.

This PR holds a module whose version a consumed platform supplies to the constraints those platforms state. @ben-manes's https://github.com/ben-manes/gradle-versions-plugin/issues/402#issuecomment-641399961 suggests rejecting every version except the current one for a dependency a BOM supplies. That needs the rule to detect which dependencies those are, and it could not. Such a module declares no version of its own, so the constraint #1059 exposes is empty for it. The report then offers upgrades the build cannot take without also bumping the BOM. The platforms' constraints now reach the rule as `platformVersionConstraints`, and `satisfiesDeclaredBound` holds the candidate to them. Nothing changes by default.

```kotlin
dependencies {
  api(platform("org.apache.logging.log4j:log4j-bom:2.16.0"))
  api("org.apache.logging.log4j:log4j-core")
}

tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
  rejectVersionIf {
    !satisfiesDeclaredBound
  }
}
```

Before:

```text
The following dependencies have later milestone versions:
 - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.17.0]
     https://logging.apache.org/log4j/2.x/
 - org.apache.logging.log4j:log4j-core [2.16.0 -> 2.17.0]
     https://logging.apache.org/log4j/2.x/
```

After:

```text
The following dependencies are using the latest milestone version:
 - org.apache.logging.log4j:log4j-core:2.16.0

The following dependencies have later milestone versions:
 - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.17.0]
     https://logging.apache.org/log4j/2.x/
```

The platform keeps its own report line, so the upgrade that is actually available, bumping the BOM, still shows. The bound is deliberately narrow:

- A module the build states a version for anywhere in the configuration hierarchy keeps the floor semantics #1059 gave a plain declaration; a platform never tightens a version declared directly.
- A platform that states a range admits in-range upgrades, the same as a declared range.
- A platform that states only a `prefer` version does not bound, the same as a declared `prefer`.
- When more than one consumed platform bounds the same module, a candidate must satisfy every one of them. That is stricter than the version resolution itself would settle on, so the report offers an upgrade only when no consumed platform stands against it; the version currently resolved is always accepted, whichever platform supplied it.
- Only a platform bounds. A constraint an ordinary library publishes in its module metadata supplies a version without bounding the report.
- An `enforcedPlatform` states its own version with `strictly`, so the rule holds the platform itself to that version and a newer BOM stops being offered; a plain `platform` keeps its own upgrade line.

For #755, this PR and #1059 together take the place of the fix its title names. `checkConstraints` still cannot see a BOM's constraints, but the bound a BOM states now reaches the selection rule per module, which is what I was after when I filed it.
