### PR TITLE
Recover a plugin marker's declared bound from the version catalog

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -16,6 +16,7 @@ import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.repositories.ArtifactRepository
@@ -49,6 +50,22 @@ class Resolver(
   private val checkConstraints: Boolean,
 ) {
   private var projectUrls = ConcurrentHashMap<ModuleVersionIdentifier, ProjectUrl>()
+
+  // Gradle flattens a version-catalog plugin alias to a bare required range on the marker
+  // dependency it synthesizes for the buildscript classpath, dropping strictly/prefer/reject.
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/755
+  private val pluginCatalogConstraints: Map<Coordinate.Key, List<VersionConstraint>> by lazy {
+    val catalogs = project.extensions.findByType(VersionCatalogsExtension::class.java)
+    val constraints = hashMapOf<Coordinate.Key, MutableList<VersionConstraint>>()
+    catalogs?.forEach { catalog ->
+      for (alias in catalog.pluginAliases) {
+        val plugin = catalog.findPlugin(alias).orElse(null)?.orNull ?: continue
+        val key = Coordinate.Key(plugin.pluginId, "${plugin.pluginId}.gradle.plugin")
+        constraints.getOrPut(key) { mutableListOf() }.add(plugin.version)
+      }
+    }
+    constraints
+  }
 
   init {
     logRepositories()
@@ -352,6 +369,7 @@ class Resolver(
     val declared =
       getResolvableDependencies(configuration)
         .associateBy { it.key }
+        .mapValues { (_, coordinate) -> recoverPluginCatalogConstraint(coordinate) }
     // An empty configuration is still resolved below, so that a listener contributing to it has
     // run by the time the declared set is read again. That resolution costs nothing. One holding
     // only project or file dependencies is skipped, as resolving it would not.
@@ -446,6 +464,38 @@ class Resolver(
       configurationsOf(configuration, contributedKeys + declaringKeys),
     )
   }
+
+  /**
+   * Returns the coordinate rebuilt with the catalog's constraint, when a plugin-catalog alias
+   * flattened to the coordinate's bare required version explains it unambiguously.
+   */
+  private fun recoverPluginCatalogConstraint(coordinate: Coordinate): Coordinate {
+    val declaredConstraint = coordinate.versionConstraint ?: return coordinate
+    // A versionless declaration states an empty required version, which an alias that only rejects
+    // would match, attaching a bound to a declaration that named no version to bound.
+    if (isRich(declaredConstraint) || declaredConstraint.requiredVersion.isEmpty()) {
+      return coordinate
+    }
+    val candidates =
+      pluginCatalogConstraints[coordinate.key].orEmpty()
+        .filter { isRich(it) && (it.requiredVersion == declaredConstraint.requiredVersion) }
+        .distinctBy { listOf(it.requiredVersion, it.strictVersion, it.preferredVersion, it.rejectedVersions) }
+    if (candidates.size > 1) {
+      project.logger.info(
+        "Multiple version catalog aliases for ${coordinate.key} state differing version constraints; " +
+          "keeping the declared constraint",
+      )
+      return coordinate
+    }
+    val recovered = candidates.singleOrNull() ?: return coordinate
+    return Coordinate(coordinate.groupId, coordinate.artifactId, coordinate.version, coordinate.userReason, recovered)
+  }
+
+  /** Whether the constraint carries more than a bare required version. */
+  private fun isRich(constraint: VersionConstraint): Boolean =
+    constraint.strictVersion.isNotEmpty() ||
+      constraint.preferredVersion.isNotEmpty() ||
+      constraint.rejectedVersions.isNotEmpty()
 
   /**
    * Returns the version constraints the consumed platforms state for each module that is declared

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
@@ -1,0 +1,419 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Gradle flattens a version-catalog plugin alias to a bare required range on the buildscript
+ * classpath marker, dropping {@code strictly}/{@code prefer}/{@code reject}. These specs pin the
+ * recovery that rebuilds the marker's constraint from the catalog it came from.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+final class PluginMarkerCatalogSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private void catalog(String toml) {
+    testProjectDir.newFolder('gradle')
+    testProjectDir.newFile('gradle/libs.versions.toml') << toml.stripIndent()
+  }
+
+  private void pluginManagementSettings(String resolutionStrategyBody = '') {
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        pluginManagement {
+          repositories {
+            maven {
+              url = '${mavenRepoUrl}'
+            }
+          }
+          $resolutionStrategyBody
+        }
+      """.stripIndent()
+  }
+
+  private void buildFile(String pluginsExtra, String taskBody) {
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+          $pluginsExtra
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          $taskBody
+        }
+      """.stripIndent()
+  }
+
+  private def runOn(String gradleVersion, List<String> extraArgs = []) {
+    def runner = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(['dependencyUpdates'] + extraArgs)
+      .withPluginClasspath()
+    if (gradleVersion != 'current') {
+      runner = runner.withGradleVersion(gradleVersion)
+    }
+    return runner.build()
+  }
+
+  @Unroll
+  def 'a catalog plugin alias with a strictly range bounds the marker on Gradle #gradleVersion'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    buildFile(
+      'alias(libs.plugins.demo) apply false',
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn(gradleVersion)
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
+
+    where:
+    gradleVersion << ['current', '8.4']
+  }
+
+  def 'the rule sees the catalog declaration verbatim'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    buildFile(
+      'alias(libs.plugins.demo) apply false',
+      """
+        rejectVersionIf {
+          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+            println "PROBE strict='\${versionConstraint?.strictVersion}'" +
+              " prefer='\${versionConstraint?.preferredVersion}'" +
+              " required='\${versionConstraint?.requiredVersion}'"
+          }
+          return false
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      "PROBE strict='[1.0, 2[' prefer='1.0' required='[1.0, 2['")
+  }
+
+  def 'a version rewritten by eachPlugin recovers nothing'() {
+    given:
+    pluginManagementSettings(
+      """
+        resolutionStrategy {
+          eachPlugin {
+            if (requested.id.id == 'com.example.settings-demo') {
+              useVersion('2.0')
+            }
+          }
+        }
+      """)
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    buildFile(
+      'alias(libs.plugins.demo) apply false',
+      """
+        rejectVersionIf {
+          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+            println "PROBE strict='\${versionConstraint?.strictVersion}'" +
+              " required='\${versionConstraint?.requiredVersion}'"
+          }
+          return false
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains("PROBE strict='' required='2.0'")
+    result.output.contains(
+      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:2.0')
+  }
+
+  def 'two aliases for one id with differing constraints recover nothing'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [versions]
+        demoAlpha = { strictly = "[1.0, 2[", prefer = "1.0" }
+        demoBeta = { strictly = "[1.0, 2[", prefer = "1.1" }
+
+        [plugins]
+        demoAlpha = { id = "com.example.settings-demo", version.ref = "demoAlpha" }
+        demoBeta = { id = "com.example.settings-demo", version.ref = "demoBeta" }
+      """)
+    buildFile(
+      'alias(libs.plugins.demoAlpha) apply false',
+      """
+        rejectVersionIf {
+          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+            println "PROBE strict='\${versionConstraint?.strictVersion}'"
+          }
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn('current', ['--info'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains("PROBE strict=''")
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      'Multiple version catalog aliases for com.example.settings-demo:com.example.settings-demo.gradle.plugin ' +
+        'state differing version constraints; keeping the declared constraint')
+  }
+
+  def 'two aliases for one id with identical constraints still recover'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demoAlpha = { id = "com.example.settings-demo", version.ref = "demo" }
+        demoBeta = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    buildFile(
+      'alias(libs.plugins.demoAlpha) apply false',
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
+  }
+
+  def 'a project dependency on the marker coordinate keeps its declared range as the bound'() {
+    given:
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:[1.0, 2['
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
+  }
+
+  def 'a versionless declaration recovers nothing from a reject-only alias'() {
+    given:
+    catalog(
+      """
+        [plugins]
+        demo = { id = "com.example.settings-demo", version = { reject = ["2.0"] } }
+      """)
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+          }
+          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+              println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
+            }
+            return false
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('PROBE rejects=[]')
+  }
+
+  def 'a declaration stating its own rich constraint keeps it'() {
+    given:
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", reject = ["1.0"] }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation('com.example.settings-demo:com.example.settings-demo.gradle.plugin') {
+            version {
+              strictly '[1.0, 2['
+            }
+          }
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+              println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
+            }
+            return false
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('PROBE rejects=[]')
+  }
+
+  def 'a plain string plugin version recovers nothing'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    buildFile(
+      "id 'com.example.settings-demo' version '1.0' apply false",
+      """
+        rejectVersionIf {
+          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+            println "PROBE strict='\${versionConstraint?.strictVersion}'"
+          }
+          return false
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains("PROBE strict=''")
+  }
+}


### PR DESCRIPTION
This PR recovers a plugin marker's declared bound from the version catalog the plugin was declared in. Gradle flattens a catalog plugin alias to a bare required range on the `<id>:<id>.gradle.plugin` marker it synthesizes for the buildscript classpath, so the rule reads that range as a floor and offers an upgrade past it. The recovery only applies when the flattened required version identifies one catalog alias unambiguously, so a second catalog stating a different rich version for the same plugin id leaves the marker as it is today and logs the skip at `--info` level.

With `demo = { strictly = "[1.0, 2[", prefer = "1.0" }` in the catalog, `alias(libs.plugins.demo) apply false`, and a `rejectVersionIf { !satisfiesDeclaredBound }` rule, before:

```
The following dependencies have later milestone versions:
 - com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]
```

After:

```
The following dependencies are using the latest milestone version:
 - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0
```

This relates to #755, which #1060 closed for a module's platform-sourced bound but not for a plugin marker's catalog-sourced one.
