### PR TITLE
Document what the configurations report field now holds

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
@@ -21,7 +21,10 @@ open class Dependency
     @AbsentWhenNull open val projects: List<String>? = null,
     /** True when only plugins contributed the dependency rather than the build declaring it. */
     @AbsentWhenNull open val contributed: Boolean? = null,
-    /** The configurations a plugin contributed the dependency into, when it contributed it. */
+    /**
+     * The configurations the dependency was declared directly against, or the ones a plugin
+     * contributed it into when [contributed] is true.
+     */
     @AbsentWhenNull open val configurations: List<String>? = null,
   ) : Comparable<Dependency> {
     override fun compareTo(other: Dependency): Int {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributedDependencySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributedDependencySpec.groovy
@@ -266,6 +266,41 @@ final class ContributedDependencySpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1055')
+  def 'Reports the declared configuration in the file reports without the contributed mark'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        configurations.create('pluginClasspath') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          pluginClasspath 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json,xml,html'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def xmlReport = new XmlParser()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.xml'))
+    def htmlReport = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    jsonReport.outdated.dependencies[0].configurations == ['pluginClasspath']
+    !jsonReport.outdated.dependencies[0].containsKey('contributed')
+    xmlReport.outdated.dependencies.outdatedDependency[0].configurations.configuration
+      *.text() == ['pluginClasspath']
+    !xmlReport.outdated.dependencies.outdatedDependency[0].children()*.name().contains('contributed')
+    htmlReport.contains("declared in the 'pluginClasspath' configuration")
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1055')
   def 'Names the configuration when another resolvable one also reaches the dependency'() {
     given:
     writeBuild(


### PR DESCRIPTION
The `configurations` field of the JSON and XML reports carried only what a plugin contributed until #1056 also had it name a configuration the build declared directly against, and its KDoc still described the narrower contract. A tool that read the field as plugin-contributed only now gets a wider set, and `contributed` is what tells the two apart. The declared case was asserted against the console output alone, so this adds the file report assertions it was missing.