### PR TITLE
Test and document Gradle 9.7.0 as the current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The following dependencies have later milestone versions:
      https://spring.io/projects/spring-boot
 
 Gradle release-candidate updates:
- - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-2]
+ - Gradle: [8.4 -> 9.7.0]
 ```
 
 ### Configuring the task
@@ -860,7 +860,7 @@ Failed to determine the latest version for the following dependencies (use --inf
  - dom4j:dom4j
 
 Gradle release-candidate updates:
- - Gradle: [8.4 -> 9.6.1 -> 9.7.0-rc-2]
+ - Gradle: [8.4 -> 9.7.0]
 ```
 
 </details>
@@ -1050,13 +1050,13 @@ Alternatively, the report may be output to a structured file.
    "isFailure": false,
    "isUpdateAvailable": true,
    "reason": "",
-   "version": "9.6.1"
+   "version": "9.7.0"
   },
   "releaseCandidate": {
    "isFailure": false,
-   "isUpdateAvailable": true,
-   "reason": "",
-   "version": "9.7.0-rc-2"
+   "isUpdateAvailable": false,
+   "reason": "update check succeeded: no release available",
+   "version": ""
   },
   "nightly": {
    "isFailure": false,
@@ -1222,16 +1222,16 @@ Searched in the following locations:
             <reason/>
         </running>
         <current>
-            <version>9.6.1</version>
+            <version>9.7.0</version>
             <isUpdateAvailable>true</isUpdateAvailable>
             <isFailure>false</isFailure>
             <reason/>
         </current>
         <releaseCandidate>
-            <version>9.7.0-rc-2</version>
-            <isUpdateAvailable>true</isUpdateAvailable>
+            <version/>
+            <isUpdateAvailable>false</isUpdateAvailable>
             <isFailure>false</isFailure>
-            <reason/>
+            <reason>update check succeeded: no release available</reason>
         </releaseCandidate>
         <nightly>
             <version/>

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ApplyOrderSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ApplyOrderSpec.groovy
@@ -19,7 +19,7 @@ import spock.lang.Unroll
 @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1049')
 final class ApplyOrderSpec extends Specification {
   private static final String GRADLE_8 = '8.4'
-  private static final String GRADLE_9 = '9.7.0-rc-2'
+  private static final String GRADLE_9 = '9.7.0'
   private static final List<String> PLUGINS =
     ['io.github.ben-manes.versions', 'io.github.ben-manes.versions.contributor']
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -66,7 +66,7 @@ final class ContributorAggregationSpec extends Specification {
 
   private def run(String... arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-2')
+      .withGradleVersion('9.7.0')
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()
@@ -187,7 +187,7 @@ final class ContributorAggregationSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-2')
+      .withGradleVersion('9.7.0')
       .withProjectDir(testProjectDir.root)
       .withArguments(':dependencyUpdates')
       .withPluginClasspath()
@@ -209,7 +209,7 @@ final class ContributorAggregationSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-2')
+      .withGradleVersion('9.7.0')
       .withProjectDir(testProjectDir.root)
       .withArguments(':app:dependencyUpdates')
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
@@ -95,7 +95,7 @@ final class InitScriptAggregationSpec extends Specification {
 
   private def run(String... arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-2')
+      .withGradleVersion('9.7.0')
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -69,7 +69,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
 
   private def runWith(String task, List<String> arguments = []) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-2')
+      .withGradleVersion('9.7.0')
       .withProjectDir(testProjectDir.root)
       .withArguments([task, '-Dorg.gradle.isolated-projects=true',
         '--configuration-cache'] + arguments)

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
@@ -120,7 +120,7 @@ final class SettingsClasspathSpec extends Specification {
       'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]'
 
     when:
-    def stored = runOn('9.7.0-rc-2', arguments)
+    def stored = runOn('9.7.0', arguments)
 
     then:
     stored.task(':dependencyUpdates').outcome == SUCCESS
@@ -128,7 +128,7 @@ final class SettingsClasspathSpec extends Specification {
     stored.output.contains(expected)
 
     when:
-    def hit = runOn('9.7.0-rc-2', arguments)
+    def hit = runOn('9.7.0', arguments)
 
     then:
     hit.task(':dependencyUpdates').outcome == SUCCESS

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -74,7 +74,7 @@ final class SettingsPluginAggregationSpec extends Specification {
 
   private def runWith(List<String> arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0-rc-2')
+      .withGradleVersion('9.7.0')
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()


### PR DESCRIPTION
9.7.0 shipped and no release candidate follows it, so the specs that pinned 9.7.0-rc-2 run against the release instead. The sample reports were regenerated rather than edited: the breadcrumb loses a segment instead of gaining a version, since the release candidate check now reports no version at all and never compares greater than the current release.