### PR TITLE
Fix issues found testing the v0.60.0 release snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,9 +780,9 @@ tasks.named("dependencyUpdates").configure {
 `satisfiesDeclaredBound` reads a declared range the way dependency resolution
 reads it, so `strictly "[5.3, 6["` admits 5.3.26 and excludes 6.0.1, and
 `reject "[3.0,)"` excludes everything from 3.0 up. Only `strictly` and `reject`
-bound a candidate: a `require` version is a floor resolution may rise above, and
-a `prefer` version only breaks a tie, so a plain `implementation("group:name:1.2.3")`
-is not held back by this rule.
+bound a candidate: a `require` version is a floor resolution may rise above, a
+range included, and a `prefer` version only breaks a tie, so a plain
+`implementation("group:name:1.2.3")` is not held back by this rule.
 
 A module declared with no version of its own is additionally bound by the
 version a consumed platform requires for it, since the build cannot take that

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 fun String.isNonStable(): Boolean {
   val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { uppercase().contains(it) }
-  val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+  val regex = "^[0-9,.v-]+(-r|-jre|-android)?$".toRegex()
   val isStable = stableKeyword || regex.matches(this)
   return isStable.not()
 }
@@ -300,7 +300,7 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 ```groovy
 def isNonStable = { String version ->
   def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-  def regex = /^[0-9,.v-]+(-r)?$/
+  def regex = /^[0-9,.v-]+(-r|-jre|-android)?$/
   return !stableKeyword && !(version ==~ regex)
 }
 
@@ -570,7 +570,7 @@ point:
 ```kotlin
 fun String.isNonStable(): Boolean {
   val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { uppercase().contains(it) }
-  val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+  val regex = "^[0-9,.v-]+(-r|-jre|-android)?$".toRegex()
   val isStable = stableKeyword || regex.matches(this)
   return isStable.not()
 }
@@ -584,12 +584,17 @@ fun String.isNonStable(): Boolean {
 ```groovy
 def isNonStable = { String version ->
   def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-  def regex = /^[0-9,.v-]+(-r)?$/
+  def regex = /^[0-9,.v-]+(-r|-jre|-android)?$/
   return !stableKeyword && !(version ==~ regex)
 }
 ```
 
 </details>
+
+The trailing `-jre` and `-android` keep Guava's ordinary releases out of the
+unstable set. A library that states its qualifier some other way, such as
+`13.4.0.jre11`, still reads as unstable and needs the pattern extended, so check
+this against the versions your own build sees before relying on it.
 
 You can then configure [Component Selection
 Rules](https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:component_selection_rules).
@@ -830,7 +835,10 @@ available, bumping the BOM, still shows. That line is there only when the
 report covers the project declaring the platform. A build that centralizes its
 platforms in an included build holds the modules with nothing naming the BOM to
 bump, since an included build is reported separately (see [Composite
-builds](#composite-builds)).
+builds](#composite-builds)). A bound the build states on the platform itself
+holds that line too: a BOM whose own version says `strictly "[2.0, 3.0["`,
+inline or through a version catalog, reports the newest version inside that
+range and never the major beyond it.
 
 The bound is deliberately narrow:
 

--- a/gradle-versions-plugin/build.gradle.kts
+++ b/gradle-versions-plugin/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
 
   testImplementation(localGroovy())
   testImplementation(gradleTestKit())
+  testImplementation(libs.kotlin.reflect)
   testImplementation(libs.spock) { exclude(module = "groovy-all") }
 }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -393,6 +393,7 @@ private fun registerProducer(
               parameters.checkConstraints,
               filledByPlugin,
               nameDeclaringConfiguration = true,
+              scriptClasspaths = false,
             ),
             statusesOf(
               project,
@@ -405,6 +406,9 @@ private fun registerProducer(
               // Every buildscript dependency is declared directly on the resolvable classpath
               // configuration, so naming it would describe a script rather than a plugin.
               nameDeclaringConfiguration = false,
+              // The plugins block deposits its flattened markers only on these classpaths, so
+              // only they recover a catalog plugin constraint.
+              scriptClasspaths = true,
             ),
           ).toJson()
         },
@@ -473,6 +477,7 @@ private fun statusesOf(
   checkConstraints: Boolean,
   filledByPlugin: Set<String>,
   nameDeclaringConfiguration: Boolean,
+  scriptClasspaths: Boolean,
 ): List<PartialStatus> {
   if (configurations.isEmpty()) {
     return emptyList()
@@ -487,7 +492,7 @@ private fun statusesOf(
     try {
       // Discounted after resolving, which is what runs the default actions that name the
       // configurations whose every dependency a plugin contributed.
-      resolver.resolve(configuration, parameters.revision, nameDeclaringConfiguration) {
+      resolver.resolve(configuration, parameters.revision, nameDeclaringConfiguration, scriptClasspaths) {
         declaredKeys.getValue(configuration) - keysOf(configuration, filledByPlugin)
       }.map { it.toPartialStatus() }
     } catch (e: Exception) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -52,7 +52,7 @@ class Coordinate(
   val key: Key
     get() = Key(groupId, artifactId)
 
-  constructor(
+  internal constructor(
     groupId: String?,
     artifactId: String?,
     version: String?,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -1,6 +1,7 @@
 package com.github.benmanes.gradle.versions.updates
 
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.statesVersionRange
 import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
 import groovy.xml.slurpersupport.NodeChildren
@@ -91,16 +92,19 @@ class Resolver(
     configuration: Configuration,
     revision: String,
     declaredKeys: () -> Set<Coordinate.Key>,
-  ): Set<DependencyStatus> = resolve(configuration, revision, false, declaredKeys)
+  ): Set<DependencyStatus> = resolve(configuration, revision, nameDeclaringConfiguration = false, scriptClasspath = false, declaredKeys)
 
   /**
    * Returns the version status as above, naming the configuration of a dependency declared directly
-   * against it when asked, which the buildscript's configurations are resolved without.
+   * against it when asked, which the buildscript's configurations are resolved without, and
+   * recovering catalog plugin constraints only on a script classpath, the sole route by which a
+   * plugin marker enters a build.
    */
   internal fun resolve(
     configuration: Configuration,
     revision: String,
     nameDeclaringConfiguration: Boolean,
+    scriptClasspath: Boolean,
     declaredKeys: () -> Set<Coordinate.Key>,
   ): Set<DependencyStatus> {
     // Runs the actions that contribute dependencies lazily, so that the declared set below is read
@@ -109,7 +113,7 @@ class Resolver(
     // https://github.com/ben-manes/gradle-versions-plugin/issues/987
     configuration.incoming.dependencies
 
-    val current = getCurrentCoordinates(configuration, declaredKeys(), nameDeclaringConfiguration)
+    val current = getCurrentCoordinates(configuration, declaredKeys(), nameDeclaringConfiguration, scriptClasspath)
     val latestConfiguration = createLatestConfiguration(configuration, revision, current)
     val root = latestConfiguration.incoming.resolutionResult.root
     return getStatus(current, root)
@@ -365,11 +369,14 @@ class Resolver(
     configuration: Configuration,
     declaredBeforeActions: Set<Coordinate.Key>,
     nameDeclaringConfiguration: Boolean,
+    scriptClasspath: Boolean,
   ): CurrentCoordinates {
     val declared =
       getResolvableDependencies(configuration)
         .associateBy { it.key }
-        .mapValues { (_, coordinate) -> recoverPluginCatalogConstraint(coordinate) }
+        .mapValues { (_, coordinate) ->
+          if (scriptClasspath) recoverPluginCatalogConstraint(coordinate) else coordinate
+        }
     // An empty configuration is still resolved below, so that a listener contributing to it has
     // run by the time the declared set is read again. That resolution costs nothing. One holding
     // only project or file dependencies is skipped, as resolving it would not.
@@ -471,10 +478,11 @@ class Resolver(
    *
    * An alias stating no more than that required version explains the declaration just as well as a
    * rich one, so it counts toward the ambiguity rather than being passed over for stating too
-   * little. What survives is the assumption the recovery rests on: any declaration of the marker
-   * coordinate at a version one alias explains is credited to that alias. A version stated inline
-   * in the plugins block cannot be told apart from one the catalog supplied once Gradle has
-   * flattened it, and neither can an ordinary dependency the build declares on that coordinate.
+   * little. An exact required version recovers nothing even when one alias explains it: a version
+   * stated inline in the plugins block cannot be told apart from one the catalog supplied once
+   * Gradle has flattened it, and crediting the alias's bound to an inline declaration would hide
+   * upgrades it never rejected. A required range keeps its own interval as the declared bound
+   * either way, so recovering it can add no more than the alias's preference and in-range rejects.
    */
   private fun recoverPluginCatalogConstraint(coordinate: Coordinate): Coordinate {
     val declaredConstraint = coordinate.versionConstraint ?: return coordinate
@@ -492,6 +500,9 @@ class Resolver(
         "Multiple version catalog aliases for ${coordinate.key} state differing version constraints; " +
           "keeping the declared constraint",
       )
+      return coordinate
+    }
+    if (!statesVersionRange(declaredConstraint.requiredVersion)) {
       return coordinate
     }
     val recovered = candidates.singleOrNull()?.takeIf { isRich(it) } ?: return coordinate

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -468,6 +468,13 @@ class Resolver(
   /**
    * Returns the coordinate rebuilt with the catalog's constraint, when a plugin-catalog alias
    * flattened to the coordinate's bare required version explains it unambiguously.
+   *
+   * An alias stating no more than that required version explains the declaration just as well as a
+   * rich one, so it counts toward the ambiguity rather than being passed over for stating too
+   * little. What survives is the assumption the recovery rests on: any declaration of the marker
+   * coordinate at a version one alias explains is credited to that alias. A version stated inline
+   * in the plugins block cannot be told apart from one the catalog supplied once Gradle has
+   * flattened it, and neither can an ordinary dependency the build declares on that coordinate.
    */
   private fun recoverPluginCatalogConstraint(coordinate: Coordinate): Coordinate {
     val declaredConstraint = coordinate.versionConstraint ?: return coordinate
@@ -478,7 +485,7 @@ class Resolver(
     }
     val candidates =
       pluginCatalogConstraints[coordinate.key].orEmpty()
-        .filter { isRich(it) && (it.requiredVersion == declaredConstraint.requiredVersion) }
+        .filter { it.requiredVersion == declaredConstraint.requiredVersion }
         .distinctBy { listOf(it.requiredVersion, it.strictVersion, it.preferredVersion, it.rejectedVersions) }
     if (candidates.size > 1) {
       project.logger.info(
@@ -487,7 +494,7 @@ class Resolver(
       )
       return coordinate
     }
-    val recovered = candidates.singleOrNull() ?: return coordinate
+    val recovered = candidates.singleOrNull()?.takeIf { isRich(it) } ?: return coordinate
     return Coordinate(coordinate.groupId, coordinate.artifactId, coordinate.version, coordinate.userReason, recovered)
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -544,7 +544,12 @@ class Resolver(
       }
       val requested = dependency.requested as? ModuleComponentSelector ?: continue
       val versionConstraint = requested.versionConstraint
-      if (versionConstraint.requiredVersion.isEmpty() && versionConstraint.rejectedVersions.isEmpty()) {
+      // A strictly-only constraint arrives with an empty required version; Gradle's own publisher
+      // writes requires beside strictly, but other tooling's module metadata need not.
+      if (versionConstraint.requiredVersion.isEmpty() &&
+        versionConstraint.strictVersion.isEmpty() &&
+        versionConstraint.rejectedVersions.isEmpty()
+      ) {
         continue
       }
       val key = Coordinate.Key(requested.group, requested.module)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -114,7 +114,7 @@ private object DeclaredBound {
   }
 
   /**
-   * Whether the candidate lies within every one of the versions the consumed platforms require for
+   * Whether the candidate lies within every one of the versions the consumed platforms state for
    * this module, read the same way [accepts] reads a declared bound. Requiring each edge to admit
    * the candidate is stricter than the version resolution itself settles on, which is deliberate:
    * the report offers an upgrade only when no consumed platform stands against it. The version
@@ -132,8 +132,10 @@ private object DeclaredBound {
     }
     return try {
       constraints.all { constraint ->
+        val strict = constraint.strictVersion
         val required = constraint.requiredVersion
-        (required.isEmpty() || parser.parseSelector(required).accept(candidate)) &&
+        (strict.isEmpty() || parser.parseSelector(strict).accept(candidate)) &&
+          (required.isEmpty() || parser.parseSelector(required).accept(candidate)) &&
           constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
       }
     } catch (e: LinkageError) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -5,6 +5,7 @@ import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector
 
 class ComponentSelectionWithCurrent(
   private val delegate: ComponentSelection,
@@ -38,8 +39,9 @@ class ComponentSelectionWithCurrent(
    * resolution reads it, so that a range is honored rather than compared as a string.
    *
    * Only `strictly` and `reject` bound a candidate. A `require` version is a floor that resolution
-   * may rise above, and a `prefer` version is consulted only to break a tie, so neither excludes an
-   * upgrade the build already permits. True for a module that declared no bound at all.
+   * may rise above, a range included, and a `prefer` version is consulted only to break a tie, so
+   * neither excludes an upgrade the build already permits. True for a module that declared no
+   * bound at all.
    *
    * A module whose declaration states no version is additionally bounded by the constraints the
    * platforms the consumer depends on state for it, and the version currently selected is always
@@ -98,6 +100,19 @@ private object DeclaredBound {
     }
   }
 
+  /** Whether the version parses as a range selector, the form a rich constraint flattens to. */
+  fun statesRange(version: String): Boolean {
+    val parser = scheme
+    if (parser == null || version.isEmpty()) {
+      return false
+    }
+    return try {
+      parser.parseSelector(version) is VersionRangeSelector
+    } catch (e: Exception) {
+      false
+    }
+  }
+
   /**
    * Whether the candidate lies within every one of the versions the consumed platforms require for
    * this module, read the same way [accepts] reads a declared bound. Requiring each edge to admit
@@ -126,3 +141,6 @@ private object DeclaredBound {
     }
   }
 }
+
+/** Whether the version parses as a range selector, the form a rich constraint flattens to. */
+internal fun statesVersionRange(version: String): Boolean = DeclaredBound.statesRange(version)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -7,7 +7,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector
 
-class ComponentSelectionWithCurrent(
+class ComponentSelectionWithCurrent internal constructor(
   private val delegate: ComponentSelection,
   val currentVersion: String,
   /** The constraint the build declared for this module, null when no declaration named it. */
@@ -23,16 +23,6 @@ class ComponentSelectionWithCurrent(
     delegate: ComponentSelection,
     currentVersion: String,
   ) : this(delegate, currentVersion, null, emptyList())
-
-  /**
-   * Retains the arity the declared [VersionConstraint] arrived with, in case a release ships it
-   * before this change.
-   */
-  constructor(
-    delegate: ComponentSelection,
-    currentVersion: String,
-    versionConstraint: VersionConstraint?,
-  ) : this(delegate, currentVersion, versionConstraint, emptyList())
 
   /**
    * Whether the candidate lies within the bound the declaration stated, read the way dependency

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
@@ -1,0 +1,39 @@
+package com.github.benmanes.gradle.versions
+
+import com.github.benmanes.gradle.versions.updates.Coordinate
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
+import kotlin.jvm.JvmClassMappingKt
+import kotlin.reflect.KVisibility
+import spock.lang.Specification
+
+/**
+ * A constructor a release ships is published API forever, so an arity only this module calls must
+ * not reach a tag as public.
+ */
+final class ConstructorVisibilitySpec extends Specification {
+  def 'The selection wrapper has no three-argument constructor'() {
+    expect:
+    ComponentSelectionWithCurrent.declaredConstructors.every { it.parameterCount != 3 }
+  }
+
+  def 'The selection wrapper constructs internally, except at the arity v0.59.0 shipped'() {
+    given:
+    def constructors = JvmClassMappingKt.getKotlinClass(ComponentSelectionWithCurrent).constructors
+    def released = constructors.find { it.parameters.size() == 2 }
+    def constraintCarrying = constructors.findAll { it.parameters.size() > 2 }
+
+    expect:
+    released.visibility == KVisibility.PUBLIC
+    constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
+  }
+
+  def 'The constraint-carrying Coordinate constructors are internal'() {
+    given:
+    def constraintCarrying = JvmClassMappingKt.getKotlinClass(Coordinate).constructors
+      .findAll { it.parameters.size() > 4 }
+
+    expect:
+    constraintCarrying.size() == 2
+    constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -799,6 +799,53 @@ final class DeclaredVersionConstraintSpec extends Specification {
     !report().outdated.dependencies.any { it.name == 'guice' && it.version == '3.0' }
   }
 
+  // Gradle's own publisher writes `requires` beside `strictly`, so the strictly-only form only
+  // arrives from a platform published by other tooling; the fixture hand-authors the metadata.
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a platform constraint stating only a strict version reaches the rule'() {
+    given: 'a published platform whose module metadata states strictly with no requires'
+    writeBuildFile(
+      """
+        api platform('com.example:strict-platform:1.0')
+        api 'com.google.inject:guice'
+      """,
+      """
+        rejectVersionIf {
+          println "PROBE \${candidate.module} platformConstraints=" +
+            "\${platformVersionConstraints.collect { it.strictVersion }}"
+          return false
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'the strictly-only edge is harvested rather than dropped as stating nothing'
+    result.output.contains('PROBE guice platformConstraints=[2.0]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'a platform constraint stating only a strict version still bounds the module'() {
+    given: 'the platform pins guice purely with strictly, which resolution itself enforces'
+    writeBuildFile(
+      """
+        api platform('com.example:strict-platform:1.0')
+        api 'com.google.inject:guice'
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'the pinned module reports as current instead of being offered what Gradle refuses'
+    report().current.dependencies.any { it.name == 'guice' && it.version == '2.0' }
+    !report().outdated.dependencies*.name.contains('guice')
+  }
+
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
   def 'a direct version beside a platform keeps its floor'() {
     given: 'the build states its own version for guice, so the platform does not bound it'

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -234,6 +234,28 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().unresolved.dependencies.isEmpty()
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+  def 'a required range does not hold back a module a conflict pushed past it'() {
+    given: 'guice is declared as a range, and a transitive requires a version above that range'
+    writeBuildFile(
+      """
+        api 'com.google.inject:guice:[2.0, 3.0['
+        api 'com.example:guice-consumer:1.0'
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    run()
+
+    then: 'a required version is a floor resolution may rise above, a range included'
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.1'
+  }
+
   def 'a module with no declared bound is not held back'() {
     given: 'a plain declaration is a floor resolution may rise above, not a bound'
     writeBuildFile(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
@@ -214,6 +214,40 @@ final class PluginMarkerCatalogSpec extends Specification {
         'state differing version constraints; keeping the declared constraint')
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+  def 'a plain alias for one id blocks recovery from a rich one'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [plugins]
+        demoPlain = { id = "com.example.settings-demo", version = "1.0" }
+        demoBounded = { id = "com.example.settings-demo", version = { require = "1.0", reject = ["2.0"] } }
+      """)
+    buildFile(
+      'alias(libs.plugins.demoPlain) apply false',
+      """
+        rejectVersionIf {
+          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+            println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
+          }
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn('current', ['--info'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('PROBE rejects=[]')
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      'Multiple version catalog aliases for com.example.settings-demo:com.example.settings-demo.gradle.plugin ' +
+        'state differing version constraints; keeping the declared constraint')
+  }
+
   def 'two aliases for one id with identical constraints still recover'() {
     given:
     pluginManagementSettings()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
@@ -204,7 +204,7 @@ final class PluginMarkerCatalogSpec extends Specification {
     when:
     def result = runOn('current', ['--info'])
 
-    then:
+    then: 'no alias is credited, so nothing bounds the report and 2.0 is offered'
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains("PROBE strict=''")
     result.output.contains(
@@ -279,7 +279,7 @@ final class PluginMarkerCatalogSpec extends Specification {
       ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
   }
 
-  def 'a project dependency on the marker coordinate keeps its declared range as the bound'() {
+  def 'a project dependency on the marker coordinate recovers nothing from the catalog'() {
     given:
     catalog(
       """
@@ -317,12 +317,104 @@ final class PluginMarkerCatalogSpec extends Specification {
     when:
     def result = runOn('current')
 
+    then: 'the alias states a strictly the declaration never did, so 2.0 stays on offer'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+  }
+
+  def 'a project dependency at a plain version recovers nothing'() {
+    given:
+    catalog(
+      """
+        [plugins]
+        demo = { id = "com.example.settings-demo", version = { require = "1.0", reject = ["2.0"] } }
+      """)
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+              println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
+            }
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = runOn('current')
+
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
-    !result.output.contains(
-      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains('PROBE rejects=[]')
     result.output.contains(
-      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+  }
+
+  def 'a project dependency stating the alias range recovers nothing'() {
+    given:
+    catalog(
+      """
+        [versions]
+        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+        [plugins]
+        demo = { id = "com.example.settings-demo", version.ref = "demo" }
+      """)
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url = '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:[1.0, 2['
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+              println "PROBE strict='\${versionConstraint?.strictVersion}'" +
+                " prefer='\${versionConstraint?.preferredVersion}'"
+            }
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = runOn('current')
+
+    then: 'nothing is credited from the alias, so the strictly it states never applies'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains("PROBE strict='' prefer=''")
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
   }
 
   def 'a versionless declaration recovers nothing from a reject-only alias'() {
@@ -419,6 +511,42 @@ final class PluginMarkerCatalogSpec extends Specification {
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('PROBE rejects=[]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+  @Unroll
+  def 'an exact version from #declaration recovers nothing'() {
+    given:
+    pluginManagementSettings()
+    catalog(
+      """
+        [plugins]
+        demo = { id = "com.example.settings-demo", version = { require = "1.0", reject = ["2.0"] } }
+      """)
+    buildFile(
+      pluginsLine,
+      """
+        rejectVersionIf {
+          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
+            println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
+          }
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then: 'the flattened exact version could as well be stated inline, so no bound is credited'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('PROBE rejects=[]')
+    result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+
+    where:
+    declaration         | pluginsLine
+    'the plugins block' | "id 'com.example.settings-demo' version '1.0' apply false"
+    'the catalog alias' | 'alias(libs.plugins.demo) apply false'
   }
 
   def 'a plain string plugin version recovers nothing'() {

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/guice-consumer/1.0/guice-consumer-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/guice-consumer/1.0/guice-consumer-1.0.pom
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>guice-consumer</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <name>Example Guice Consumer</name>
+  <description>Requires a guice past the range a consumer is expected to declare for it.</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>3.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/guice-consumer/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/guice-consumer/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>guice-consumer</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260807000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/strict-platform/1.0/strict-platform-1.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/strict-platform/1.0/strict-platform-1.0.module
@@ -1,0 +1,45 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "strict-platform",
+    "version": "1.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.google.inject",
+          "module": "guice",
+          "version": {
+            "strictly": "2.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.google.inject",
+          "module": "guice",
+          "version": {
+            "strictly": "2.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/strict-platform/1.0/strict-platform-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/strict-platform/1.0/strict-platform-1.0.pom
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>strict-platform</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Example Strictly-Only Platform</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/strict-platform/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/strict-platform/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>strict-platform</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260806000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 moshi = { module = "com.squareup.moshi:moshi-kotlin", version = "1.12.0" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }


### PR DESCRIPTION
Testing the release snapshot against real builds turned up four defects, all of them in work this release has not shipped yet, so none of this changes released behavior.

The version catalog bound recovery credited an alias's constraint to declarations that never named it, which made the recommended `rejectVersionIf { !satisfiesDeclaredBound }` report a module as up to date while a newer version was published. It now runs only for a script classpath, and only when the declared version states a range. I couldn't find anything Gradle records that separates a catalog version from one written inline, so an alias flattening to an exact version is given up rather than guessed at.

The rest are smaller: a platform constraint stating `strictly` with no `requires` beside it was dropped and then ignored, three constraint-carrying constructors added since v0.59.0 were public with no caller outside this module, and the stability pattern the README recommends read Guava's `-jre` and `-android` releases as pre-releases.
