### PR TITLE
Prepare the 0.60.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ tasks.named("dependencyUpdates").configure {
   versions](#filtering-unstable-versions)).
 - `!satisfiesDeclaredBound` rejects a candidate outside a `strictly` or
   `reject` bound the build declares, or outside the version a consumed
-  platform requires (see [Respecting declared
+  platform states (see [Respecting declared
   bounds](#respecting-declared-bounds)).
 
 Each piece stands alone: drop any line whose behavior the build does not
@@ -790,7 +790,7 @@ range included, and a `prefer` version only breaks a tie, so a plain
 `implementation("group:name:1.2.3")` is not held back by this rule.
 
 A module declared with no version of its own is additionally bound by the
-version a consumed platform requires for it, since the build cannot take that
+version a consumed platform states for it, since the build cannot take that
 upgrade without also bumping the platform. Given a platform BOM that pins
 `log4j-core` to `2.16.0`:
 
@@ -846,7 +846,7 @@ The bound is deliberately narrow:
   hierarchy keeps the floor semantics above; a platform never tightens a
   version declared directly.
 - A platform that states a range admits in-range upgrades, the same as a
-  declared range.
+  declared `strictly` range.
 - A platform that states only a `prefer` version does not bound, the same as
   a declared `prefer`.
 - When more than one consumed platform bounds the same module, a candidate

--- a/README.md
+++ b/README.md
@@ -1917,18 +1917,32 @@ and *Note*s are things worth knowing that need no action.
 
 v0.60.0 names the configuration a dependency was declared directly against, so a
 plugin that fills a classpath of its own when it is applied no longer reads as
-the build declaring the dependency, and states the reason a dependency
-constraint was declared with:
+the build declaring the dependency, states the reason a dependency constraint
+was declared with, and lets a component selection rule hold the report to the
+bound the build declared:
 
 > [!IMPORTANT]
 > - An entry can now carry an attribution line where it carried none, naming the
 >   configuration the dependency was declared against. A tool that parses the plain
 >   text report line by line has to skip it, as it already does for the other
->   attribution lines (see [Report format](#report-format)).
+>   attribution lines (see [Report format](#report-format)). The JSON and XML
+>   reports carry the same names in `configurations`, which until now held only
+>   what a plugin contributed, so a tool reading that field has to read
+>   `contributed` alongside it to tell the two apart.
 > - An entry for a dependency constraint declared with `because` now carries that
 >   reason, where only a dependency's reason appeared before. It prints on the same
 >   line as a dependency's reason does, so a tool that already handles one handles
 >   both.
+
+> [!TIP]
+> - A component selection rule can hold the report to what the build declared,
+>   with `rejectVersionIf { !satisfiesDeclaredBound }`. A module bounded by a
+>   `strictly` or by a platform the build consumes is then held to that bound,
+>   so the report offers only versions the build can actually take (see
+>   [Respecting declared bounds](#respecting-declared-bounds)).
+> - A Kotlin DSL build script that worked around the Gradle 9 overload ambiguity
+>   by naming `Action<ComponentSelectionWithCurrent>` can go back to the untyped
+>   `all { }` and `withModule(id) { }` forms.
 
 ### v0.58.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ben-manes
-VERSION_NAME=0.59.0
+VERSION_NAME=0.60.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps the version for the v0.60.0 release. It also adds the migration notes for #1059 and #1060, which let a component selection rule hold the report to the bound the build declared, and corrects three README sentences that say a platform's required version bounds a module, where #1065 accepts a platform stating only `strictly`.

Draft release notes below. Let me know if there's anything more you want included in this release.

---

* Accept an untyped Kotlin DSL lambda in the component selection rules, which Gradle 9 binds to the rule source overload instead, leaving `candidate`, `currentVersion` and `reject` unresolved (#941, #1058)
* Name the configuration a dependency was declared directly against, so a plugin that fills a classpath of its own when it is applied no longer reads as the build declaring the dependency (#1055, #1056)
* Report the reason a dependency constraint was declared with, where only a dependency's reason reached the report before, and the version constraint a declaration stated as `versionConstraint`, so a component selection rule can hold the report to the bound the build declared rather than restating it (#1059)
* Bound a module the build declares without a version of its own by the version constraints the platforms it consumes state for it, so a rule that respects declared bounds stops offering a version the platform does not allow (#402, #755, #1060)
* Recover a plugin marker's declared bound from the version catalog when the alias states a range, which Gradle flattens to a bare required version on the buildscript classpath (#755, #1061)
* Document a recommended configuration and group the task properties by what they control (#1062)
* Test and document Gradle 9.7.0 as the current release (#1064)
* Say what the `configurations` field of the JSON and XML reports holds, now that it also names a configuration the build declared against directly (#1055, #1063)
* Regenerate the HTML report screenshot (#1054)
* Accept Guava's `-jre` and `-android` releases in the documented `isNonStable` filter, which the pattern the README recommended treated as unstable (#1065)

> [!IMPORTANT]
> * An entry can now carry an attribution line where it carried none, naming the configuration the dependency was declared against. A tool that parses the plain text report line by line has to skip it, as it already does for the other attribution lines. The JSON and XML reports carry the same names in `configurations`, which until now held only what a plugin contributed, so a tool reading that field has to read `contributed` alongside it to tell the two apart.
> * An entry for a dependency constraint declared with `because` now carries that reason, where only a dependency's reason appeared before. It prints on the same line as a dependency's reason does, so a tool that already handles one handles both.
>
> See [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#v0590).

> [!TIP]
> * A component selection rule can hold the report to what the build declared, with `rejectVersionIf { !satisfiesDeclaredBound }`. A module bounded by a `strictly` or by a platform the build consumes is then held to that bound, so the report offers only versions the build can actually take (see [Respecting declared bounds](https://github.com/ben-manes/gradle-versions-plugin#respecting-declared-bounds)).
> * A Kotlin DSL build script that worked around the Gradle 9 overload ambiguity by naming `Action<ComponentSelectionWithCurrent>` can go back to the untyped `all { }` and `withModule(id) { }` forms.
> * A build that copied the README's `isNonStable` filter has a pattern that treats Guava's `-jre` and `-android` releases as unstable and drops every Guava upgrade from the report. Widen the copy to `^[0-9,.v-]+(-r|-jre|-android)?$`.
