### PR TITLE
Sync the remaining isNonStable copies with the README recipe

### DIFF
--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -33,7 +33,7 @@ configurations {
 
 def isNonStable = { String version ->
   def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-  def regex = /^[0-9,.v-]+(-r)?$/
+  def regex = /^[0-9,.v-]+(-r|-jre|-android)?$/
   return !stableKeyword && !(version ==~ regex)
 }
 

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -32,7 +32,7 @@ configurations {
 
 fun String.isNonStable(): Boolean {
   val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { uppercase().contains(it) }
-  val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+  val regex = "^[0-9,.v-]+(-r|-jre|-android)?$".toRegex()
   val isStable = stableKeyword || regex.matches(this)
   return isStable.not()
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LazyDependencySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/LazyDependencySpec.groovy
@@ -66,7 +66,7 @@ final class LazyDependencySpec extends Specification {
 
         def isNonStable = { String version ->
           def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-          def regex = /^[0-9,.v-]+(-r)?\$/
+          def regex = /^[0-9,.v-]+(-r|-jre|-android)?\$/
           return !stableKeyword && !(version ==~ regex)
         }
 


### PR DESCRIPTION
This PR widens the `isNonStable` recipe in `LazyDependencySpec` and both example builds to the `-jre|-android` pattern #1065 put in the README.

Nothing failed against the narrow copies. None of the three declares a Guava-shaped version, which is why #1065 missed them.
