### PR TITLE
Add `filterDeclaredConfigurations` to leave out entries by the name they show (fixes #1068)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ instead:
 ```
 
 A configuration the build declares against directly, such as a tool
-configuration of its own, is named the same way. Use
-[`filterConfigurations`](#configuration-filter) to leave a configuration out of
-the report entirely.
+configuration of its own, is named the same way. The [configuration
+filter](#configuration-filter) leaves a configuration out of the report, though
+the name an entry shows is not always one to reject.
 
 Gradle updates are checked for on the `current`, `release-candidate` and
 `nightly` release channels. The plain-text report displays Gradle updates as a
@@ -368,11 +368,11 @@ tasks.named("dependencyUpdates").configure {
 
 </details>
 
-Because each entry names the configuration it was declared against (see [The
-`dependencyUpdates` task](#the-dependencyupdates-task)), a build can leave
-out the configurations a plugin fills for its own tooling, the ones holding a
-version the build never chose. The Kotlin Gradle Plugin adds six; at KGP
-2.4.10 they are:
+The filter is offered a project's resolvable configurations, and a dependency
+leaves the report once every one of them that reaches it is rejected. That is
+how a build leaves out the configurations a plugin fills for its own tooling,
+the ones holding a version the build never chose. The Kotlin Gradle Plugin adds
+six; at KGP 2.4.10 they are:
 
 <details open>
 <summary>Kotlin</summary>
@@ -479,6 +479,19 @@ These names belong to the plugins at the versions above, not to Gradle, and
 they change between plugin releases. Take the set from your own report
 rather than from this page, and keep the matches exact wherever a plugin's
 configurations share a prefix with ones the build fills itself.
+
+The name an entry shows is the configuration its dependency was declared
+against (see [The `dependencyUpdates` task](#the-dependencyupdates-task)),
+which is not always one to reject. A plugin that declares into a configuration
+it cannot resolve is reported under a name the filter is never offered, and
+rejecting a configuration that another one extends leaves the dependency
+reachable through that other one. Reject the resolvable configurations that
+reach it instead. `gradle resolvableConfigurations` reports what each of them
+extends, though only directly, so a chain takes more than one step to follow. A
+dependency contributed into a shared configuration such as `implementation` is
+reachable only through classpaths that carry the build's own dependencies, so
+rejecting those costs the rest of the report. Neither the buildscript nor the
+settings classpath is offered to the filter.
 
 ##### Constraints
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
     - [A recommended configuration](#a-recommended-configuration)
     - [What the report checks](#what-the-report-checks)
       - [Configuration filter](#configuration-filter)
+        - [`filterConfigurations`](#filterconfigurations)
+        - [`filterDeclaredConfigurations`](#filterdeclaredconfigurations)
+        - [Choosing between them](#choosing-between-them)
       - [Constraints](#constraints)
     - [Which versions it offers](#which-versions-it-offers)
       - [Revisions](#revisions)
@@ -232,9 +235,9 @@ instead:
 ```
 
 A configuration the build declares against directly, such as a tool
-configuration of its own, is named the same way. The [configuration
-filter](#configuration-filter) leaves a configuration out of the report, though
-the name an entry shows is not always one to reject.
+configuration of its own, is named the same way. Reject the name an entry
+shows with [`filterDeclaredConfigurations`](#filterdeclaredconfigurations) to
+leave it out of the report.
 
 Gradle updates are checked for on the `current`, `release-candidate` and
 `nightly` release channels. The plain-text report displays Gradle updates as a
@@ -328,6 +331,10 @@ tasks.named("dependencyUpdates").configure {
 Each piece stands alone: drop any line whose behavior the build does not
 want, and the rest keep working.
 
+The [configuration filters](#configuration-filter) are absent only because
+their arguments are build-specific: the names to reject come off your own
+report.
+
 In Kotlin the `isNonStable` extension replaces a helper of that name the build
 already has. A top-level `fun isNonStable(version: String)` compiles to the same
 JVM signature, so keeping both fails the build with a platform declaration
@@ -337,8 +344,17 @@ clash.
 
 ##### Configuration filter
 
-You can change which dependency configurations the plugin checks for updates
-like this:
+Two properties leave things out of the report. `filterConfigurations`
+decides which configurations the task checks: a rejected configuration is
+never resolved, and nothing reachable only through it is reported.
+`filterDeclaredConfigurations` decides which entries the report keeps once
+the checks have run: it matches the configuration name printed on the entry
+itself.
+
+###### `filterConfigurations`
+
+The task checks every resolvable configuration of every project. A build
+that only acts on its main classpaths can restrict the check to them:
 
 <details open>
 <summary>Kotlin</summary>
@@ -368,11 +384,13 @@ tasks.named("dependencyUpdates").configure {
 
 </details>
 
-The filter is offered a project's resolvable configurations, and a dependency
-leaves the report once every one of them that reaches it is rejected. That is
-how a build leaves out the configurations a plugin fills for its own tooling,
-the ones holding a version the build never chose. The Kotlin Gradle Plugin adds
-six; at KGP 2.4.10 they are:
+A dependency leaves the report once every configuration that reaches it is
+rejected, and everything reachable only through a rejected configuration
+leaves with it—rejecting `compileClasspath` removes the build's own
+dependencies too. Reach for this filter when a whole configuration is noise:
+a skipped configuration also costs no version lookups, which suits the
+classpaths a plugin fills for its own tooling, holding versions the build
+never chose. The Kotlin Gradle Plugin adds six; at KGP 2.4.10 they are:
 
 <details open>
 <summary>Kotlin</summary>
@@ -480,18 +498,62 @@ they change between plugin releases. Take the set from your own report
 rather than from this page, and keep the matches exact wherever a plugin's
 configurations share a prefix with ones the build fills itself.
 
-The name an entry shows is the configuration its dependency was declared
-against (see [The `dependencyUpdates` task](#the-dependencyupdates-task)),
-which is not always one to reject. A plugin that declares into a configuration
-it cannot resolve is reported under a name the filter is never offered, and
-rejecting a configuration that another one extends leaves the dependency
-reachable through that other one. Reject the resolvable configurations that
-reach it instead. `gradle resolvableConfigurations` reports what each of them
-extends, though only directly, so a chain takes more than one step to follow. A
-dependency contributed into a shared configuration such as `implementation` is
-reachable only through classpaths that carry the build's own dependencies, so
-rejecting those costs the rest of the report. Neither the buildscript nor the
-settings classpath is offered to the filter.
+###### `filterDeclaredConfigurations`
+
+Start from the report line. Rejecting the name an entry shows removes the
+entry:
+
+```text
+ - org.jacoco:org.jacoco.ant [0.8.11 -> 0.8.13]
+     contributed by a plugin into the 'jacocoAnt' configuration
+```
+
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  filterDeclaredConfigurations = Spec<String> { it != "jacocoAnt" }
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+tasks.named("dependencyUpdates").configure {
+  filterDeclaredConfigurations { it != "jacocoAnt" }
+}
+```
+
+</details>
+
+It matches exactly the name the entry prints, from a "contributed by a
+plugin into" line or a "declared in" one—a tool configuration the build
+declares against directly is rejectable the same way. An entry leaves the
+report when every name it shows is rejected, and an entry that names no
+configuration is never affected: dependencies declared through
+`implementation` and its siblings carry no name, so no rejection reaches
+them, and where such a declaration also backs a named entry, rejection
+removes the attribution line, never the dependency.
+
+###### Choosing between them
+
+Both filters silence a tooling configuration like the KGP and AGP sets
+above; prefer `filterConfigurations` there, since it also skips the lookups.
+They part ways when the name an entry shows is not one the task checks (see
+[The `dependencyUpdates` task](#the-dependencyupdates-task)): a declarable
+configuration read through a resolvable classpath that extends it, and
+`implementation` holding a plugin's contribution, both show names
+`filterConfigurations` is never offered. `filterDeclaredConfigurations`
+matches the name shown, with no side effect on what is checked. Buildscript
+and settings classpath entries ordinarily name no configuration, so neither
+property affects them; one a plugin contributes is named `classpath` and can
+be rejected like any other entry.
 
 ##### Constraints
 
@@ -1600,7 +1662,8 @@ task by that name now fails with a duplicate-task error—rename yours.
 
 Each project takes the settings that control resolution (`revision`,
 `rejectVersionIf` or a full `resolutionStrategy`, `filterConfigurations`,
-`checkConstraints`, and `checkBuildEnvironmentConstraints`) from the nearest
+`filterDeclaredConfigurations`, `checkConstraints`, and
+`checkBuildEnvironmentConstraints`) from the nearest
 project up the hierarchy whose task set them. Configuring the root project's
 task therefore covers every project, unless a subproject configures its own (see
 [Task properties](#task-properties)).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
         - [`filterConfigurations`](#filterconfigurations)
         - [`filterDeclaredConfigurations`](#filterdeclaredconfigurations)
         - [Choosing between them](#choosing-between-them)
+        - [Kotlin Gradle Plugin](#kotlin-gradle-plugin)
+        - [Android Gradle Plugin](#android-gradle-plugin)
       - [Constraints](#constraints)
     - [Which versions it offers](#which-versions-it-offers)
       - [Revisions](#revisions)
@@ -390,113 +392,9 @@ leaves with it—rejecting `compileClasspath` removes the build's own
 dependencies too. Reach for this filter when a whole configuration is noise:
 a skipped configuration also costs no version lookups, which suits the
 classpaths a plugin fills for its own tooling, holding versions the build
-never chose. The Kotlin Gradle Plugin adds six; at KGP 2.4.10 they are:
-
-<details open>
-<summary>Kotlin</summary>
-
-```kotlin
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
-val kgpInternal = setOf(
-  "kotlinCompilerClasspath",
-  "kotlinBuildToolsApiClasspath",
-  "kotlinAbiValidationCompatClasspath",
-  "kotlinKlibCommonizerClasspath",
-  "kotlinCompilerPluginClasspathMain",
-  "kotlinCompilerPluginClasspathTest",
-)
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-  filterConfigurations = Spec<Configuration> { it.name !in kgpInternal }
-}
-```
-
-</details>
-
-<details>
-<summary>Groovy</summary>
-
-```groovy
-def kgpInternal = [
-  "kotlinCompilerClasspath",
-  "kotlinBuildToolsApiClasspath",
-  "kotlinAbiValidationCompatClasspath",
-  "kotlinKlibCommonizerClasspath",
-  "kotlinCompilerPluginClasspathMain",
-  "kotlinCompilerPluginClasspathTest",
-]
-
-tasks.named("dependencyUpdates").configure {
-  filterConfigurations {
-    !kgpInternal.contains(it.name)
-  }
-}
-```
-
-</details>
-
-The unsuffixed `kotlinCompilerPluginClasspath` is left in on purpose: it
-holds the compiler plugins the build itself declares, and only the `Main`-
-and `Test`-suffixed siblings belong to the plugin. That is why the filter
-names configurations exactly instead of dropping everything that starts with
-`kotlin`.
-
-The Android Gradle Plugin fills a set of its own. At AGP 9.3.1, which builds
-in its Kotlin support rather than applying a separate Kotlin plugin, that is
-`androidLintTool`, two of the Kotlin classpaths above, and a
-`unified-test-platform-*` family thirteen configurations wide. The family is
-the one place a prefix fits: its membership shifts between AGP releases and
-no configuration a build fills itself uses the prefix. (The per-variant
-`kotlinCompilerPluginClasspathDebug` and friends never appear in the report
-by name, since a dependency is attributed to the configuration it was
-declared against, so they need no entry.)
-
-<details open>
-<summary>Kotlin</summary>
-
-```kotlin
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
-val agpInternal = setOf(
-  "androidLintTool",
-  "kotlinBuildToolsApiClasspath",
-  "kotlinCompilerClasspath",
-)
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-  filterConfigurations = Spec<Configuration> {
-    it.name !in agpInternal && !it.name.startsWith("unified-test-platform-")
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Groovy</summary>
-
-```groovy
-def agpInternal = [
-  "androidLintTool",
-  "kotlinBuildToolsApiClasspath",
-  "kotlinCompilerClasspath",
-]
-
-tasks.named("dependencyUpdates").configure {
-  filterConfigurations {
-    !agpInternal.contains(it.name) &&
-      !it.name.startsWith("unified-test-platform-")
-  }
-}
-```
-
-</details>
-
-These names belong to the plugins at the versions above, not to Gradle, and
-they change between plugin releases. Take the set from your own report
-rather than from this page, and keep the matches exact wherever a plugin's
-configurations share a prefix with ones the build fills itself.
+never chose. The [Kotlin Gradle Plugin](#kotlin-gradle-plugin) and
+[Android Gradle Plugin](#android-gradle-plugin) sections below give ready
+sets.
 
 ###### `filterDeclaredConfigurations`
 
@@ -544,7 +442,7 @@ removes the attribution line, never the dependency.
 ###### Choosing between them
 
 Both filters silence a tooling configuration like the KGP and AGP sets
-above; prefer `filterConfigurations` there, since it also skips the lookups.
+below; prefer `filterConfigurations` there, since it also skips the lookups.
 They part ways when the name an entry shows is not one the task checks (see
 [The `dependencyUpdates` task](#the-dependencyupdates-task)): a declarable
 configuration read through a resolvable classpath that extends it, and
@@ -554,6 +452,126 @@ matches the name shown, with no side effect on what is checked. Buildscript
 and settings classpath entries ordinarily name no configuration, so neither
 property affects them; one a plugin contributes is named `classpath` and can
 be rejected like any other entry.
+
+###### Kotlin Gradle Plugin
+
+The Kotlin Gradle Plugin fills four fixed classpaths for its own tooling,
+plus one `kotlinCompilerPluginClasspath<SourceSet>` per source set—a [JVM
+test suite](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html)
+adds one too—so a list of names goes stale as the build grows. Match the
+family by prefix; at KGP 2.4.10:
+
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+fun isKgpInternal(configurationName: String): Boolean {
+  val kgpInternalConfigurations = setOf(
+    "kotlinCompilerClasspath",
+    "kotlinBuildToolsApiClasspath",
+    "kotlinAbiValidationCompatClasspath",
+    "kotlinKlibCommonizerClasspath",
+  )
+  return configurationName in kgpInternalConfigurations ||
+    (configurationName.startsWith("kotlinCompilerPluginClasspath") &&
+      configurationName != "kotlinCompilerPluginClasspath")
+}
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  filterConfigurations = Spec<Configuration> { !isKgpInternal(it.name) }
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+def isKgpInternal = { String configurationName ->
+  def kgpInternalConfigurations = [
+    "kotlinCompilerClasspath",
+    "kotlinBuildToolsApiClasspath",
+    "kotlinAbiValidationCompatClasspath",
+    "kotlinKlibCommonizerClasspath",
+  ]
+  return kgpInternalConfigurations.contains(configurationName) ||
+    (configurationName.startsWith("kotlinCompilerPluginClasspath") &&
+      configurationName != "kotlinCompilerPluginClasspath")
+}
+
+tasks.named("dependencyUpdates").configure {
+  filterConfigurations { !isKgpInternal(it.name) }
+}
+```
+
+</details>
+
+The prefix stops short of the unsuffixed `kotlinCompilerPluginClasspath`,
+which keeps reporting, and stays narrower than dropping everything that
+starts with `kotlin`. A compiler plugin the build itself declares resolves
+through these same suffixed classpaths and is filtered with them. Its Gradle
+plugin's marker still reports, so a version shared between the two stays
+visible, but a compiler plugin versioned apart from its Gradle plugin leaves
+the report with no replacement—keep the classpath that carries it if you
+declare one.
+
+###### Android Gradle Plugin
+
+The Android Gradle Plugin fills a set of its own. At AGP 9.3.1, which builds
+in its Kotlin support rather than applying a separate Kotlin plugin, that is
+`androidLintTool`, two of the Kotlin classpaths above, and a
+`unified-test-platform-*` family thirteen configurations wide. The family
+takes a prefix too: its membership shifts between AGP releases and no
+configuration a build fills itself uses it.
+
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+val agpInternal = setOf(
+  "androidLintTool",
+  "kotlinBuildToolsApiClasspath",
+  "kotlinCompilerClasspath",
+)
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+  filterConfigurations = Spec<Configuration> {
+    it.name !in agpInternal && !it.name.startsWith("unified-test-platform-")
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+def agpInternal = [
+  "androidLintTool",
+  "kotlinBuildToolsApiClasspath",
+  "kotlinCompilerClasspath",
+]
+
+tasks.named("dependencyUpdates").configure {
+  filterConfigurations {
+    !agpInternal.contains(it.name) &&
+      !it.name.startsWith("unified-test-platform-")
+  }
+}
+```
+
+</details>
+
+These names belong to the plugins at the versions above, not to Gradle, and
+they change between plugin releases. Take the set from your own report
+rather than from this page, and keep the matches exact wherever a plugin's
+configurations share a prefix with ones the build fills itself.
 
 ##### Constraints
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -33,6 +33,9 @@ private const val VERIFICATION_TYPE = "dependency-updates"
 /** The filter applied when a task leaves the configurations unrestricted. */
 internal val ALL_CONFIGURATIONS = Spec<Configuration> { true }
 
+/** The filter applied when a task leaves the declared configurations unrestricted. */
+internal val ALL_DECLARED_CONFIGURATIONS = Spec<String> { true }
+
 /** Returns whether isolated projects is enabled, which forbids configuring the other projects. */
 internal fun isIsolatedProjectsEnabled(project: Project): Boolean =
   runCatching {
@@ -45,6 +48,9 @@ internal class DependencyUpdatesParameters {
 
   @Transient
   var filterConfigurations: Spec<Configuration>? = null
+
+  @Transient
+  var filterDeclaredConfigurations: Spec<String>? = null
 
   @Transient
   var resolutionStrategy: Action<in ResolutionStrategyWithCurrent>? = null
@@ -113,6 +119,8 @@ internal abstract class DependencyUpdatesParametersService :
           ?: chain.firstNotNullOfOrNull { it.revision } ?: "milestone",
       filterConfigurations =
         chain.firstNotNullOfOrNull { it.filterConfigurations } ?: ALL_CONFIGURATIONS,
+      filterDeclaredConfigurations =
+        chain.firstNotNullOfOrNull { it.filterDeclaredConfigurations } ?: ALL_DECLARED_CONFIGURATIONS,
       resolutionStrategy = chain.firstOrNull { it.resolutionStrategySet }?.resolutionStrategy,
       checkConstraints = chain.firstNotNullOfOrNull { it.checkConstraints } ?: false,
       checkBuildEnvironmentConstraints =
@@ -125,6 +133,7 @@ internal abstract class DependencyUpdatesParametersService :
 internal class ResolvedParameters(
   val revision: String,
   val filterConfigurations: Spec<Configuration>,
+  val filterDeclaredConfigurations: Spec<String>,
   val resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
   val checkConstraints: Boolean,
   val checkBuildEnvironmentConstraints: Boolean,
@@ -494,6 +503,11 @@ private fun statusesOf(
       // configurations whose every dependency a plugin contributed.
       resolver.resolve(configuration, parameters.revision, nameDeclaringConfiguration, scriptClasspaths) {
         declaredKeys.getValue(configuration) - keysOf(configuration, filledByPlugin)
+      }.filter { status ->
+        // A status that names no configuration, as an ordinary declaration's does, is kept
+        // whatever the filter rejects.
+        status.configurations.isEmpty() ||
+          status.configurations.any { parameters.filterDeclaredConfigurations.isSatisfiedBy(it) }
       }.map { it.toPartialStatus() }
     } catch (e: Exception) {
       project.logger.info("Skipping configuration ${project.path}:${configuration.name}", e)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -131,6 +131,13 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
       parameters.filterConfigurations = value
     }
 
+  @get:Internal
+  var filterDeclaredConfigurations: Spec<String>
+    get() = parameters.filterDeclaredConfigurations ?: ALL_DECLARED_CONFIGURATIONS
+    set(value) {
+      parameters.filterDeclaredConfigurations = value
+    }
+
   @get:Input
   var checkBuildEnvironmentConstraints: Boolean
     get() = parameters.checkBuildEnvironmentConstraints ?: false

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
@@ -124,7 +124,7 @@ final class AggregationConfigurationCacheSpec extends Specification {
 
     where:
     hook << ['rejectVersionIf', 'resolutionStrategy', 'filterConfigurations', 'checkConstraints',
-             'revision']
+             'revision', 'filterDeclaredConfigurations']
     settings << [
       '''
         rejectVersionIf {
@@ -149,6 +149,16 @@ final class AggregationConfigurationCacheSpec extends Specification {
       ''',
       'checkConstraints = true',
       "revision = 'release'",
+      '''
+        project.configurations.create('pluginClasspath') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+        project.dependencies.add('pluginClasspath', 'org.apache.logging.log4j:log4j-core:2.16.0')
+        filterDeclaredConfigurations {
+          it != 'pluginClasspath'
+        }
+      ''',
     ]
     present << [
       ['com.google.inject:guice [2.0 -> 3.0]'],
@@ -159,6 +169,7 @@ final class AggregationConfigurationCacheSpec extends Specification {
       // task's own settings would announce the default level and offer no version at all.
       ['The following dependencies have later release versions:',
        'com.google.inject:guice [2.0 -> 3.1]'],
+      ['com.google.inject:guice [2.0 -> 3.1]'],
     ]
     absent << [
       ['com.google.inject:guice [2.0 -> 3.1]'],
@@ -166,6 +177,7 @@ final class AggregationConfigurationCacheSpec extends Specification {
       ['com.google.guava:guava'],
       [],
       ['The following dependencies have later milestone versions:'],
+      ['org.apache.logging.log4j:log4j-core'],
     ]
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConfigurationFilterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConfigurationFilterSpec.groovy
@@ -1,0 +1,155 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+/**
+ * A specification for the configuration filter, pinning the names the report shows against the
+ * configurations the filter is offered.
+ */
+final class ConfigurationFilterSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  /**
+   * A 'toolBucket' that cannot be resolved, filled by {@code defaultDependencies} and reached
+   * through the resolvable 'toolClasspath' that extends it, as a declare/resolve plugin pairs them.
+   */
+  private static String bucketConfigurations(String taskBody = '') {
+    """
+      configurations.create('toolBucket') {
+        canBeResolved = false
+        canBeConsumed = false
+      }
+      configurations.create('toolClasspath') {
+        canBeResolved = true
+        canBeConsumed = false
+        extendsFrom configurations.toolBucket
+      }
+      configurations.toolBucket.defaultDependencies { deps ->
+        deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+      }
+
+      dependencyUpdates {
+        $taskBody
+      }
+    """.stripIndent()
+  }
+
+  private void writeBuild(String projectBody) {
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        $projectBody
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Names a configuration a plugin filled but cannot resolve'() {
+    given:
+    writeBuild(bucketConfigurations())
+
+    when:
+    def result = run(['dependencyUpdates'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}" +
+      "     contributed by a plugin into the 'toolBucket' configuration")
+  }
+
+  def 'Keeps the entry when filterConfigurations rejects the configuration it names'() {
+    given:
+    writeBuild(bucketConfigurations("filterConfigurations { it.name != 'toolBucket' }"))
+
+    when:
+    def result = run(['dependencyUpdates'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}" +
+      "     contributed by a plugin into the 'toolBucket' configuration")
+  }
+
+  def 'Leaves out the entry when filterConfigurations rejects the configuration that resolves it'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        ${bucketConfigurations("filterConfigurations { it.name != 'toolClasspath' }")}
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.google.guava:guava')
+    // The rejection removes the entry rather than emptying the report.
+    result.output.contains('com.google.inject:guice')
+  }
+
+  def 'Keeps the entry when another resolvable configuration still reaches it'() {
+    given:
+    writeBuild(
+      """
+        configurations.create('helper')
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+          extendsFrom configurations.helper
+        }
+        configurations.helper.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+
+        dependencyUpdates {
+          filterConfigurations { it.name != 'helper' }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}" +
+      "     contributed by a plugin into the 'helper' configuration")
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConfigurationFilterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConfigurationFilterSpec.groovy
@@ -2,14 +2,16 @@ package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 /**
- * A specification for the configuration filter, pinning the names the report shows against the
- * configurations the filter is offered.
+ * A specification for the configuration filters: {@code filterConfigurations} over the
+ * configurations the task checks, and {@code filterDeclaredConfigurations} over the names a
+ * report entry shows.
  */
 final class ConfigurationFilterSpec extends Specification {
   @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -23,7 +25,9 @@ final class ConfigurationFilterSpec extends Specification {
    * A 'toolBucket' that cannot be resolved, filled by {@code defaultDependencies} and reached
    * through the resolvable 'toolClasspath' that extends it, as a declare/resolve plugin pairs them.
    */
-  private static String bucketConfigurations(String taskBody = '') {
+  private static String bucketConfigurations(
+    String taskBody = '',
+    String coordinate = 'com.google.guava:guava:15.0') {
     """
       configurations.create('toolBucket') {
         canBeResolved = false
@@ -35,7 +39,7 @@ final class ConfigurationFilterSpec extends Specification {
         extendsFrom configurations.toolBucket
       }
       configurations.toolBucket.defaultDependencies { deps ->
-        deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        deps.add(project.dependencies.create('$coordinate'))
       }
 
       dependencyUpdates {
@@ -151,5 +155,345 @@ final class ConfigurationFilterSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains(" - com.google.guava:guava [15.0 -> 16.0-rc1]${nl}" +
       "     contributed by a plugin into the 'helper' configuration")
+  }
+
+  def 'Leaves out an entry when the filter rejects the name it shows'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        ${bucketConfigurations("filterDeclaredConfigurations { it != 'toolBucket' }")}
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.google.guava:guava')
+    // The survivor proves the drop is per-entry, not an emptied report.
+    result.output.contains('com.google.inject:guice')
+  }
+
+  def 'Leaves out an entry declared directly against a resolvable configuration'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          tool 'com.google.guava:guava:15.0'
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        dependencyUpdates {
+          filterDeclaredConfigurations { it != 'tool' }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.google.guava:guava')
+    result.output.contains('com.google.inject:guice')
+  }
+
+  def 'Keeps every entry the build declares itself when the filter rejects everything'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        dependencyUpdates {
+          filterDeclaredConfigurations { false }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // Rejecting every configuration silences only attributed entries, never a plain declaration.
+    result.output.contains('com.google.inject:guice')
+  }
+
+  def 'Keeps an entry when the filter accepts one of the names it shows'() {
+    given:
+    writeBuild(
+      """
+        configurations.create('bucketA') {
+          canBeResolved = false
+          canBeConsumed = false
+        }
+        configurations.create('bucketB') {
+          canBeResolved = false
+          canBeConsumed = false
+        }
+        configurations.create('toolClasspath') {
+          canBeResolved = true
+          canBeConsumed = false
+          extendsFrom configurations.bucketA, configurations.bucketB
+        }
+        configurations.bucketA.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+        configurations.bucketB.defaultDependencies { deps ->
+          deps.add(project.dependencies.create('com.google.guava:guava:15.0'))
+        }
+
+        dependencyUpdates {
+          filterDeclaredConfigurations { it != 'bucketA' }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.guava:guava')
+  }
+
+  def 'Leaves out a contributed constraint without touching the declared dependencies'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        def listener = new org.gradle.api.artifacts.DependencyResolutionListener() {
+          void beforeResolve(ResolvableDependencies dependencies) {
+            project.dependencies.constraints.add(
+              'implementation', 'com.google.guava:guava:15.0')
+            gradle.removeListener(this)
+          }
+
+          void afterResolve(ResolvableDependencies dependencies) { }
+        }
+        gradle.addListener(listener)
+
+        dependencyUpdates {
+          checkConstraints = true
+          filterDeclaredConfigurations { it != 'implementation' }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.google.guava:guava')
+    result.output.contains('com.google.inject:guice')
+  }
+
+  def 'Leaves out an unresolved entry when the filter rejects the name it shows'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.1'
+        }
+
+        ${bucketConfigurations(
+          "filterDeclaredConfigurations { it != 'toolBucket' }",
+          'com.github.ben-manes:unresolvable:1.0')}
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=json'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // The drop covers every report section, the unresolved one included.
+    jsonReport.unresolved.dependencies.isEmpty()
+    jsonReport.current.dependencies*.name == ['guice']
+  }
+
+  def 'Keeps an entry a plain declaration also backs'() {
+    given:
+    writeBuild(
+      """
+        apply plugin: 'java'
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          tool 'com.google.guava:guava:15.0'
+          implementation 'com.google.guava:guava:15.0'
+        }
+
+        dependencyUpdates {
+          filterDeclaredConfigurations { it != 'tool' }
+        }
+      """.stripIndent())
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // Rejecting every name the entry shows removes the attribution, never the declared dependency.
+    result.output.contains(' - com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains("declared in the 'tool' configuration")
+  }
+
+  def 'Leaves out a buildscript entry when the filter rejects the name it shows'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            mavenCentral()
+          }
+          dependencies {
+            classpath 'com.google.code.findbugs:jsr305:3.0.1'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        def listener = new org.gradle.api.artifacts.DependencyResolutionListener() {
+          void beforeResolve(ResolvableDependencies dependencies) {
+            if (dependencies.name.startsWith('classpath')) {
+              project.buildscript.dependencies.add('classpath', 'com.google.inject:guice:3.0')
+              gradle.removeListener(this)
+            }
+          }
+
+          void afterResolve(ResolvableDependencies dependencies) { }
+        }
+        gradle.addListener(listener)
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+          filterDeclaredConfigurations { it != 'classpath' }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    // A contributed buildscript entry names 'classpath' and is rejected like any other entry.
+    !result.output.contains('com.google.inject:guice')
+    // The plainly declared classpath dependency is unnamed and stays.
+    result.output.contains(' - com.google.code.findbugs:jsr305 [3.0.1 -> ')
+  }
+
+  def 'the README recipe compiles and applies under the Kotlin DSL'() {
+    given:
+    testProjectDir.newFile('build.gradle.kts') <<
+      """
+        import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+        plugins {
+          `java-library`
+          id("io.github.ben-manes.versions")
+        }
+
+        repositories {
+          maven(url = "${mavenRepoUrl}")
+        }
+
+        dependencies {
+          implementation("com.google.inject:guice:3.1")
+        }
+
+        val tool = configurations.create("tool") {
+          isCanBeResolved = true
+          isCanBeConsumed = false
+        }
+        tool.defaultDependencies {
+          add(project.dependencies.create("com.google.guava:guava:15.0"))
+        }
+
+        tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+          checkForGradleUpdate = false
+          filterDeclaredConfigurations = Spec<String> { it != "tool" }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.google.guava:guava')
+    result.output.contains('com.google.inject:guice')
+  }
+
+  def 'Honors the filter declared in the root project'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+          filterDeclaredConfigurations { it != 'toolBucket' }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'io.github.ben-manes.versions'
+
+        ${bucketConfigurations('checkForGradleUpdate = false')}
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('com.google.guava:guava')
   }
 }


### PR DESCRIPTION
Fixes #1068.

This PR adds `filterDeclaredConfigurations`, which leaves entries out of the report by the configuration name the entry shows. The existing `filterConfigurations` decides which configurations the task checks, so a name it is never offered—a declarable bucket read through a resolvable classpath, or `implementation` holding a plugin's contribution—cannot be rejected with it, and rejecting the classpaths that reach such an entry removes the build's own dependencies with it. The new property matches the shown name once the checks have run: an entry leaves the report when every configuration it names is rejected, and an entry that names none is never affected. The README's Configuration filter section now explains both properties and when each applies, with the Kotlin and Android guidance in sections of their own. The Kotlin example also moves to a prefix match, since its six-name set missed the `kotlinCompilerPluginClasspath` a JVM test suite adds.

With 0.60.0, `filterConfigurations { it.name != 'toolBucket' }` leaves this entry in place, since the filter is only ever offered the resolvable `toolClasspath` that extends the bucket:

```text
The following dependencies have later milestone versions:
 - com.google.code.findbugs:jsr305 [3.0.1 -> 3.0.2]
     http://findbugs.sourceforge.net/
     contributed by a plugin into the 'toolBucket' configuration
 - org.apache.commons:commons-lang3 [3.12.0 -> 3.20.0]
     https://commons.apache.org/proper/commons-lang/
```

With this PR, `filterDeclaredConfigurations { it != 'toolBucket' }` removes it and touches nothing else:

```text
The following dependencies have later milestone versions:
 - io.github.ben-manes.versions:io.github.ben-manes.versions.gradle.plugin [0.60.0-r49-SNAPSHOT -> 0.60.0]
 - org.apache.commons:commons-lang3 [3.12.0 -> 3.20.0]
     https://commons.apache.org/proper/commons-lang/
```
