### PR TITLE
Report the platforms a build imports through its own platform projects (fixes #1070)

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,19 @@ version the platform supplies is reported and offered updates as usual. Only a
 module the consumer never declares is absent, and the platform project's own
 report covers those.
 
+The platform a platform project imports is reported here, though. A build whose
+platform project declares `api(platform("group:artifact:version"))` reaches that
+BOM's constraints without naming the BOM anywhere the report covers, and an
+included build's platform hides it further, since that build is reported
+separately (see [Composite builds](#composite-builds)). With `checkConstraints`
+the BOM gets an entry of its own beside the versionless declarations it
+supplies, so the coordinate to bump is one the report names. A build that states
+a version for every module it declares reaches no further than the platform
+project itself. The walk stops at the first published platform: a
+BOM that BOM imports states the BOM's version choice rather than the build's, and
+a BOM a library brings along as resolution metadata is not one the build
+imported, so neither is reported.
+
 <details open>
 <summary>Kotlin</summary>
 
@@ -924,11 +937,11 @@ The following dependencies have later milestone versions:
 ```
 
 The platform keeps its own report line, so the upgrade that is actually
-available, bumping the BOM, still shows. That line is there only when the
-report covers the project declaring the platform. A build that centralizes its
-platforms in an included build holds the modules with nothing naming the BOM to
-bump, since an included build is reported separately (see [Composite
-builds](#composite-builds)). A bound the build states on the platform itself
+available, bumping the BOM, still shows. A build that centralizes its platforms
+in a platform project of its own, an included build's included, states the BOM
+where this report does not cover it; `checkConstraints` reports that BOM here
+anyway, so the coordinate to bump is named either way (see
+[Constraints](#constraints)). A bound the build states on the platform itself
 holds that line too: a BOM whose own version says `strictly "[2.0, 3.0["`,
 inline or through a version catalog, reports the newest version inside that
 range and never the major beyond it.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
@@ -181,6 +182,10 @@ class Resolver(
       }
     }
 
+    for (source in current.platformSources) {
+      latest.add(createPlatformQueryDependency(source))
+    }
+
     val copy = configuration.copyRecursive().setTransitive(false)
 
     // https://github.com/ben-manes/gradle-versions-plugin/issues/592
@@ -280,6 +285,20 @@ class Resolver(
       addAttributes(latest, dependency)
     }
     return latest
+  }
+
+  /** Returns a platform dependency used for querying the latest version of a consumed platform. */
+  private fun createPlatformQueryDependency(coordinate: Coordinate): Dependency {
+    val dependency =
+      project.dependencies.create("${coordinate.groupId}:${coordinate.artifactId}:+") as ModuleDependency
+    dependency.isTransitive = false
+    dependency.attributes { attributes ->
+      attributes.attribute(
+        Category.CATEGORY_ATTRIBUTE,
+        project.objects.named(Category::class.java, Category.REGULAR_PLATFORM),
+      )
+    }
+    return dependency
   }
 
   /** Returns a variant of the provided dependency used for querying the latest version.  */
@@ -448,10 +467,19 @@ class Resolver(
     // Ignore undeclared (hidden) dependencies that appear when resolving a configuration
     coordinates.keys.retainAll(declared.keys + contributed.map { it.key } + substitutions.values)
 
+    val platformSources = if (checkConstraints) getPlatformSources(root, declared.keys) else emptyList()
+    val harvestedKeys = hashSetOf<Coordinate.Key>()
+    for (source in platformSources) {
+      if (coordinates.putIfAbsent(source.key, source) == null) {
+        harvestedKeys.add(source.key)
+      }
+    }
+
     // A key only reached via a lazy action (withDependencies/defaultDependencies, or a resolution
     // listener) is missing from the snapshot taken before any configuration was first resolved, and
     // is not a substitution target, which traces to a real declaration.
-    val contributedKeys = coordinates.keys - declaredBeforeActions - substitutions.values.toSet()
+    val contributedKeys =
+      coordinates.keys - declaredBeforeActions - substitutions.values.toSet() - harvestedKeys
 
     // A plugin that adds its private classpath eagerly, at apply time, is indistinguishable from a
     // declaration by the time the snapshot above is taken, so what it leaves behind is named instead:
@@ -469,7 +497,59 @@ class Resolver(
       substitutions,
       contributedKeys,
       configurationsOf(configuration, contributedKeys + declaringKeys),
+      platformSources,
     )
+  }
+
+  /**
+   * Returns the external platforms the build consumes through its own platform projects, such as a
+   * BOM that an included build's platform imports and this build reaches by project substitution.
+   *
+   * Such a platform's constraints bound this build's versionless modules while the substituted
+   * project hides the coordinate to edit, so each one is reported as an entry of its own. Only a
+   * chain of platform variants that stays in project components until the harvested module
+   * qualifies: a platform that an external platform imports is that platform's version choice
+   * rather than the build's, and one a library drags in is a resolution input, so the walk stops at
+   * the first external component either way. A platform the build declares itself already has a
+   * report entry and is skipped. The constraint the platform project's declaration states rides
+   * along, so a stated bound holds the harvested row like any declared one.
+   */
+  private fun getPlatformSources(
+    root: ResolvedComponentResult,
+    declaredKeys: Set<Coordinate.Key>,
+  ): List<Coordinate> {
+    val sources = mutableListOf<Coordinate>()
+    val seen = hashSetOf(root.id)
+    val pending = ArrayDeque(listOf(root))
+    while (pending.isNotEmpty()) {
+      for (dependency in pending.removeFirst().dependencies) {
+        if (dependency !is ResolvedDependencyResult || dependency.isConstraint) {
+          continue
+        }
+        val selected = dependency.selected
+        if (!seen.add(selected.id) || selected.variants.none { isPlatform(it) }) {
+          continue
+        }
+        if (selected.id is ProjectComponentIdentifier) {
+          pending.add(selected)
+        } else {
+          val moduleVersion = selected.moduleVersion ?: continue
+          val requested = dependency.requested as? ModuleComponentSelector
+          val coordinate =
+            Coordinate(
+              moduleVersion.group,
+              moduleVersion.name,
+              moduleVersion.version,
+              userReason = null,
+              versionConstraint = requested?.versionConstraint,
+            )
+          if (coordinate.key !in declaredKeys) {
+            sources.add(coordinate)
+          }
+        }
+      }
+    }
+    return sources
   }
 
   /**
@@ -731,6 +811,7 @@ class Resolver(
     val substitutions: Map<Coordinate.Key, Coordinate.Key>,
     val contributedKeys: Set<Coordinate.Key> = emptySet(),
     val contributedConfigurations: Map<Coordinate.Key, List<String>> = emptyMap(),
+    val platformSources: List<Coordinate> = emptyList(),
   )
 
   companion object {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -419,6 +419,199 @@ final class CompositeBuildSpec extends Specification {
     result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
   }
 
+  def 'Reports the platform that an included build platform imports'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:platforms:1.0')
+          implementation 'com.google.inject:guice'
+          implementation 'com.example:bom-consumer:1.0'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    includedBuild(
+      'platforms',
+      """
+        plugins {
+          id 'java-platform'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+
+        javaPlatform {
+          allowDependencies()
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    // A platform that only a library's metadata drags in is not one the build imported.
+    !result.output.contains('com.example:dragged-bom')
+  }
+
+  def 'Holds the reported platform to the bound the platform project states'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:platforms:1.0')
+          implementation 'com.google.inject:guice'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+          rejectVersionIf {
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
+    includedBuild(
+      'platforms',
+      """
+        plugins {
+          id 'java-platform'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+
+        javaPlatform {
+          allowDependencies()
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api(platform('com.example:external-bom')) {
+            version {
+              strictly '[1.0, 2.0['
+            }
+          }
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:external-bom:1.0')
+    // 2.0 exists, but the platform project's declaration excludes it and the bound rides along.
+    !result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+  }
+
+  def 'Reaches no imported platform when every declared module is versioned'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:platforms:1.0')
+          implementation 'com.google.inject:guice:2.0'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    includedBuild(
+      'platforms',
+      """
+        plugins {
+          id 'java-platform'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+
+        javaPlatform {
+          allowDependencies()
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    // A build whose declarations all carry versions resolves the current copy non-transitively
+    // (issue #231), so the platform project's edges are absent and its import is out of the walk's
+    // reach. Widening that boundary trades the declared current version for the resolved one.
+    !result.output.contains('com.example:external-bom')
+  }
+
   def 'Reuses the configuration cache across runs of a composite build'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/JavaLibrarySpec.groovy
@@ -48,4 +48,42 @@ final class JavaLibrarySpec extends Specification {
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  def "Report the declared version as current when a transitive edge requires a higher one"() {
+    given:
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+          api 'com.example:guice-consumer:1.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    // guice-consumer requires guice 3.0, and a transitive resolution would conflict-resolve to it
+    // and report a current version no declaration states. The copy resolves non-transitively when
+    // every declared module carries a version (issue #231), so the declared version stays current.
+    !result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
 }

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/bom-consumer/1.0/bom-consumer-1.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/bom-consumer/1.0/bom-consumer-1.0.module
@@ -1,0 +1,57 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "bom-consumer",
+    "version": "1.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "dragged-bom",
+          "version": {
+            "requires": "1.0"
+          },
+          "attributes": {
+            "org.gradle.category": "platform"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "dragged-bom",
+          "version": {
+            "requires": "1.0"
+          },
+          "attributes": {
+            "org.gradle.category": "platform"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/bom-consumer/1.0/bom-consumer-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/bom-consumer/1.0/bom-consumer-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>bom-consumer</artifactId>
+  <version>1.0</version>
+  <name>Example Library Importing a Platform</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/bom-consumer/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/bom-consumer/maven-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>bom-consumer</artifactId>
+  <versioning>
+    <latest>1.0</latest>
+    <release>1.0</release>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <lastUpdated>20260807000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/1.0/dragged-bom-1.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/1.0/dragged-bom-1.0.module
@@ -1,0 +1,45 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "dragged-bom",
+    "version": "1.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.example",
+          "module": "bom-consumer",
+          "version": {
+            "requires": "1.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.example",
+          "module": "bom-consumer",
+          "version": {
+            "requires": "1.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/1.0/dragged-bom-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/1.0/dragged-bom-1.0.pom
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>dragged-bom</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Example Library-Imported Platform</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/2.0/dragged-bom-2.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/2.0/dragged-bom-2.0.module
@@ -1,0 +1,45 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "dragged-bom",
+    "version": "2.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.example",
+          "module": "bom-consumer",
+          "version": {
+            "requires": "1.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.example",
+          "module": "bom-consumer",
+          "version": {
+            "requires": "1.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/2.0/dragged-bom-2.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/2.0/dragged-bom-2.0.pom
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>dragged-bom</artifactId>
+  <version>2.0</version>
+  <packaging>pom</packaging>
+  <name>Example Library-Imported Platform</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/dragged-bom/maven-metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>dragged-bom</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20260807000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/1.0/external-bom-1.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/1.0/external-bom-1.0.module
@@ -1,0 +1,45 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "external-bom",
+    "version": "1.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.google.inject",
+          "module": "guice",
+          "version": {
+            "requires": "2.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.google.inject",
+          "module": "guice",
+          "version": {
+            "requires": "2.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/1.0/external-bom-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/1.0/external-bom-1.0.pom
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>external-bom</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Example External Platform</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/2.0/external-bom-2.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/2.0/external-bom-2.0.module
@@ -1,0 +1,45 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "external-bom",
+    "version": "2.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.google.inject",
+          "module": "guice",
+          "version": {
+            "requires": "3.0"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "platform",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencyConstraints": [
+        {
+          "group": "com.google.inject",
+          "module": "guice",
+          "version": {
+            "requires": "3.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/2.0/external-bom-2.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/2.0/external-bom-2.0.pom
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>external-bom</artifactId>
+  <version>2.0</version>
+  <packaging>pom</packaging>
+  <name>Example External Platform</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom/maven-metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>external-bom</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20260807000000</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Fixes #1070

This PR reports a platform that one of the build's own platform projects imports, so a build centralizing its BOMs behind a `java-platform` has the coordinate to bump named in the report that holds the modules. The walk follows platform variants from the resolution root and descends only through project components, so a BOM that a library brings along as resolution metadata is not picked up. It rides `checkConstraints` and appears beside the versionless declarations the platform supplies. A `strictly` range the platform project states on the import holds the harvested entry.

Before, with `platforms/` as an included build declaring `api(platform("org.junit:junit-bom:6.1.2"))`:

```text
The following dependencies are using the latest milestone version:
 - com.example:test-platform:unspecified
 - org.junit.jupiter:junit-jupiter-api:6.1.2
```

After:

```text
The following dependencies are using the latest milestone version:
 - com.example:test-platform:unspecified
 - org.junit.jupiter:junit-jupiter-api:6.1.2

The following dependencies have later milestone versions:
 - org.junit:junit-bom [6.1.2 -> 6.1.3]
     https://junit.org/
```

