### PR TITLE
Release from the deploy workflow, from building the tag to publishing the release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      # A rebase merge produces a commit no pull request check ran on, so the tag can
+      # carry a tree the build workflow has never seen. Build it here, where a failure
+      # still stops the publication.
+      - name: Run build with caching enabled
+        run: ./gradlew clean build -s
+
       - name: Publish
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,18 @@
 name: deploy
 
 on:
-  release:
-    types: [ created ]
   workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout Project
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.release.tag_name }}
 
       - name: Verify Release Version
         run: |
@@ -45,3 +44,23 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: ./gradlew publishPlugins -s
+
+      - name: Verify Portal Publication
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for _ in $(seq 30); do
+            if curl -sf https://plugins.gradle.org/m2/io/github/ben-manes/gradle-versions-plugin/maven-metadata.xml \
+                 | grep -qF "<version>${VERSION}</version>"; then
+              echo "The portal serves ${VERSION}"
+              exit 0
+            fi
+            sleep 20
+          done
+          echo "::error::The portal is not serving ${VERSION}. The release is left as a draft."
+          exit 1
+
+      # Last, because it notifies watchers and a release cannot be un-notified.
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,11 @@ How a pull request lands:
 
 For maintainers. Releases are published to the [Gradle Plugin
 Portal](https://plugins.gradle.org/plugin/io.github.ben-manes.versions) by the
-[deploy workflow](.github/workflows/deploy.yml), which builds the release tag
-and then runs `publishPlugins` against it. It runs when a release is created,
-and on manual dispatch.
+[deploy workflow](.github/workflows/deploy.yml). Dispatching it at a tag is the
+whole release: it builds that tag, runs `publishPlugins` against it, waits for
+the portal to serve the new version, and only then publishes the drafted
+release. Each step gates the one after it, so a failure stops short of
+notifying watchers.
 
 Prerequisites:
 
@@ -94,10 +96,10 @@ not.
 
 Always create the GitHub release as a draft:
 
-- Creating it published runs the workflow and notifies watchers in the same
-  moment, before anything has confirmed the portal accepted the artifacts.
-- A release cannot be un-notified.
-- A draft neither runs the workflow nor notifies, so the portal goes first.
+- A release cannot be un-notified, so nothing may notify watchers until the
+  portal has accepted the artifacts.
+- A draft does not notify, and the workflow publishes it once the portal
+  serves the version.
 
 1. Set `VERSION_NAME` in `gradle.properties` to the release version and merge
    it to `master` as `Prepare the vX.Y.Z release`.
@@ -153,41 +155,28 @@ Always create the GitHub release as a draft:
    > The `dependencyUpdates` task now reticulates splines. See [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#vXYZ).
    ```
 
-4. Publish to the portal by dispatching the workflow at the tag:
+4. Release by dispatching the workflow at the tag, then watch the run:
 
    ```bash
    gh workflow run deploy.yml --ref vX.Y.Z
+   gh run watch --exit-status
    ```
 
    - `--ref` has to name the tag: a manual run checks out the dispatched ref.
+   - `gh run watch` picks from the runs in progress, so give the dispatch a few
+     seconds to register. It exits non-zero when the run fails.
    - The workflow refuses a ref whose `VERSION_NAME` does not match the tag,
      so a dispatch that forgets `--ref` fails instead of publishing `master`.
-   - It builds the tag before publishing, which is where the release gets its
-     test run. The bump lands by rebase, so the pull request's checks ran on a
-     commit the tag does not carry, and a docs-only commit merged after them
-     triggers no build workflow at all. A failure here leaves the portal
-     untouched: fix `master`, move the tag, and dispatch again.
-
-5. Confirm the portal serves the new version:
-
-   ```bash
-   curl -sf https://plugins.gradle.org/m2/io/github/ben-manes/gradle-versions-plugin/maven-metadata.xml \
-     | grep -qF '<version>X.Y.Z</version>' && echo "published" || echo "not published"
-   ```
-
-   - The portal takes a few minutes after the workflow succeeds. "not
-     published" covers an unreachable portal too; either way, wait and run it
-     again.
-
-6. Publish the release:
-
-   ```bash
-   gh release edit vX.Y.Z --draft=false --latest
-   ```
-
-   - This notifies watchers, which is why it comes last.
-   - Publishing the draft does not run the workflow again; its trigger is
-     `created`, which the flip from draft to published does not fire.
+   - It builds the tag, which is where the release gets its test run. The bump
+     lands by rebase, so the pull request's checks ran on a commit the tag does
+     not carry, and a commit touching only `README.md` or `CONTRIBUTING.md`
+     merged after them triggers no build workflow at all. A failure here leaves
+     the portal untouched: fix `master`, move the tag, and dispatch again.
+   - It waits up to ten minutes for the portal to serve the version, since the
+     portal takes a few minutes to index what `publishPlugins` uploaded.
+   - It publishes the release last, which is what notifies watchers. A run that
+     fails before then leaves the release a draft, so dispatch again once the
+     cause is fixed.
 
 ### Releasing a new plugin id
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,9 @@ How a pull request lands:
 
 For maintainers. Releases are published to the [Gradle Plugin
 Portal](https://plugins.gradle.org/plugin/io.github.ben-manes.versions) by the
-[deploy workflow](.github/workflows/deploy.yml), which runs `publishPlugins`
-against the release tag. It runs when a release is created, and on manual
-dispatch.
+[deploy workflow](.github/workflows/deploy.yml), which builds the release tag
+and then runs `publishPlugins` against it. It runs when a release is created,
+and on manual dispatch.
 
 Prerequisites:
 
@@ -162,6 +162,11 @@ Always create the GitHub release as a draft:
    - `--ref` has to name the tag: a manual run checks out the dispatched ref.
    - The workflow refuses a ref whose `VERSION_NAME` does not match the tag,
      so a dispatch that forgets `--ref` fails instead of publishing `master`.
+   - It builds the tag before publishing, which is where the release gets its
+     test run. The bump lands by rebase, so the pull request's checks ran on a
+     commit the tag does not carry, and a docs-only commit merged after them
+     triggers no build workflow at all. A failure here leaves the portal
+     untouched: fix `master`, move the tag, and dispatch again.
 
 5. Confirm the portal serves the new version:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,9 +104,12 @@ Always create the GitHub release as a draft:
 1. Set `VERSION_NAME` in `gradle.properties` to the release version and merge
    it to `master` as `Prepare the vX.Y.Z release`.
 
-   - Keep the bump alone in its own pull request, so it can be rebased rather
-     than squashed and the version lands in the commit subject rather than in
-     a pull request number.
+   - Keep the bump alone in its own pull request, and to a single commit, so
+     rebasing is the obvious way to merge it. A rebase lands the subject
+     verbatim; the squash button appends the pull request number to it.
+   - Squash locally and force-push if the branch gained commits along the way.
+     Nothing reads the subject, so a squashed bump still releases, but the
+     version reads better without a pull request number beside it.
    - Anything else the release needs, migration notes above all, belongs to
      the pull request whose change called for it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,13 @@ Always create the GitHub release as a draft:
    - It publishes the release last, which is what notifies watchers. A run that
      fails before then leaves the release a draft, so dispatch again once the
      cause is fixed.
+   - Dispatch again only while the portal is still not serving the version. The
+     portal refuses a version it already has, so a run that failed after the
+     upload succeeded cannot be repeated. Publish the release by hand instead:
+
+     ```bash
+     gh release edit vX.Y.Z --draft=false --latest
+     ```
 
 ### Releasing a new plugin id
 


### PR DESCRIPTION
This PR moves the whole release into the deploy workflow. It builds the tag before publishing, waits for the portal to serve the new version, then publishes the drafted release, so a failure anywhere stops short of notifying watchers. The build is the piece that was missing: the version bump lands by rebase, so the pull request's checks ran on a commit the tag does not carry.

It also drops the `release: created` trigger, since creating a published release notifies watchers before anything has confirmed the upload. No release since v0.54.0 has published through it.
