### PR TITLE
Report the configurations skipped when a `resolutionStrategy` throws (fixes #1073)

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,12 @@ upgrade line goes with it. A bound naming a version that was never published
 does that, so a `strictly "1.2.3"` pointing at nothing reports as a resolution
 failure rather than as up to date.
 
+A `resolutionStrategy` that throws while the plugin applies it to a
+configuration, rather than while Gradle resolves the graph, skips that
+configuration instead: its dependencies are absent from every section, the
+skipped configuration is listed in the report's `skipped` section along with
+the failure, and the console is warned about it. The build still succeeds.
+
 Narrowing the candidate set can also surface metadata that the unbounded query
 stepped over, with the same result. And a module whose only declaration is a
 constraint reports that constraint as its current version, so `currentVersion`
@@ -1351,6 +1357,16 @@ Alternatively, the report may be output to a structured file.
    "reason": "update check disabled",
    "version": ""
   }
+ },
+ "skipped": {
+  "count": 1,
+  "configurations": [
+   {
+    "project": ":",
+    "name": "compileClasspath",
+    "reason": "org.gradle.api.InvalidUserCodeException: Could not add a component selection rule for module 'com.google.guava'."
+   }
+  ]
  }
 }
 ```
@@ -1500,6 +1516,16 @@ Searched in the following locations:
             </unresolvedDependency>
         </dependencies>
     </unresolved>
+    <skipped>
+        <count>1</count>
+        <configurations>
+            <skippedConfiguration>
+                <project>:</project>
+                <name>compileClasspath</name>
+                <reason>org.gradle.api.InvalidUserCodeException: Could not add a component selection rule for module 'com.google.guava'.</reason>
+            </skippedConfiguration>
+        </configurations>
+    </skipped>
     <gradle>
         <enabled>true</enabled>
         <running>

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
@@ -56,6 +56,7 @@ class HtmlReporter(
       writeUndeclared(printStream, result)
       writeUnresolved(printStream, result)
     }
+    writeSkipped(printStream, result)
     writeGradleUpdates(printStream, result)
     printStream.println("</body>")
   }
@@ -146,6 +147,25 @@ class HtmlReporter(
         .println("<p>Failed to determine the latest version for the following dependencies:<p>")
       printStream.println("<table class=\"warningInfo\">")
       for (it in getUnresolvedRows(result)) {
+        printStream.println(it)
+      }
+      printStream.println("</table>")
+      printStream.println("<br>")
+    }
+  }
+
+  private fun writeSkipped(
+    printStream: OutputStream,
+    result: Result,
+  ) {
+    val skipped = result.skipped.configurations
+    if (skipped.isNotEmpty()) {
+      printStream.println("<h2>Skipped configurations</h2>")
+      printStream.println(
+        "<p>Failed to inspect the dependencies of the following configurations:<p>",
+      )
+      printStream.println("<table class=\"warningInfo\">")
+      for (it in getSkippedRows(result)) {
         printStream.println(it)
       }
       printStream.println("</table>")
@@ -443,6 +463,32 @@ class HtmlReporter(
       }
       return rows
     }
+
+    private fun getSkippedRows(result: Result): List<String> {
+      val rows = mutableListOf<String>()
+      rows.add(
+        "<tr class=\"header\"><th colspan=\"3\"><b>Skipped configurations<span>(Click to collapse)</span></b></th></tr>",
+      )
+      rows.add(
+        "<tr><td><b>Project</b></td><td><b>Configuration</b></td><td><b>Reason</b></td></tr>",
+      )
+      for ((reason, group) in result.skipped.configurations.groupBy { it.reason }) {
+        val projects = group.joinToString("<br>") { escapeHtml(it.project) }
+        val names = group.joinToString("<br>") { escapeHtml(it.name) }
+        val rowString =
+          String.format(
+            "<tr><td>%s</td><td>%s</td><td>%s</td></tr>",
+            projects,
+            names,
+            escapeHtml(reason),
+          )
+        rows.add(rowString)
+      }
+      return rows
+    }
+
+    /** Escapes text placed into an HTML element, which a resolution exception's message is not. */
+    private fun escapeHtml(text: String): String = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
     private fun getGradleUrl(): String {
       return "<p>For information about Gradle releases click <a target=\"_blank\" href=\"https://gradle.org/releases/\">here</a>.</p>"

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -50,6 +50,7 @@ class PlainTextReporter
         writeUnresolved(printStream, result)
       }
 
+      writeSkipped(printStream, result)
       writeGradleUpdates(printStream, result)
     }
 
@@ -170,6 +171,26 @@ class PlainTextReporter
           }
           dependency.projectUrl?.let {
             printStream.println("     $it")
+          }
+        }
+      }
+    }
+
+    private fun writeSkipped(
+      printStream: OutputStream,
+      result: Result,
+    ) {
+      val skipped = result.skipped.configurations
+      if (skipped.isNotEmpty()) {
+        val hint = if (isInfoEnabled) "" else " (use --info for details)"
+        printStream.println()
+        printStream.println(
+          "Failed to inspect the dependencies of the following configurations$hint:",
+        )
+        for ((reason, group) in skipped.groupBy { it.reason }) {
+          printStream.println(" - " + reason.lineSequence().first())
+          for (configuration in group) {
+            printStream.println("     '${configuration.name}' in ${projectsLabel(listOf(configuration.project))}")
           }
         }
       }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
@@ -49,6 +49,7 @@ class XmlReporter(
     writeExceededSection(result, document, response)
     writeUndeclaredSection(result, document, response)
     writeUnresolvedSection(result, document, response)
+    writeSkippedSection(result, document, response)
     writeGradle(result, document, response)
 
     val transformerFactory = TransformerFactory.newInstance()
@@ -154,6 +155,26 @@ class XmlReporter(
     for (dependency in result.unresolved.dependencies) {
       val element = writeDependency(document, dependencies, "unresolvedDependency", dependency)
       appendTextChild(document, element, "reason", dependency.reason)
+    }
+  }
+
+  private fun writeSkippedSection(
+    result: Result,
+    document: Document,
+    response: Element,
+  ) {
+    val skipped = document.createElement("skipped")
+    response.appendChild(skipped)
+    appendTextChild(document, skipped, "count", result.skipped.count)
+
+    val configurations = document.createElement("configurations")
+    skipped.appendChild(configurations)
+    for (configuration in result.skipped.configurations) {
+      val element = document.createElement("skippedConfiguration")
+      configurations.appendChild(element)
+      appendTextChild(document, element, "project", configuration.project)
+      appendTextChild(document, element, "name", configuration.name)
+      appendTextChild(document, element, "reason", configuration.reason)
     }
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Result.kt
@@ -14,13 +14,17 @@ import com.github.benmanes.gradle.versions.updates.gradle.GradleUpdateResults
  * @property undeclared The dependencies whose versions were not declared.
  * @property unresolved The unresolvable dependencies.
  * @property gradle Gradle release channels and respective update availability.
+ * @property skipped The configurations whose dependencies could not be inspected, which [count] does not include.
  */
-class Result(
-  val count: Int,
-  val current: DependenciesGroup<Dependency>,
-  val outdated: DependenciesGroup<DependencyOutdated>,
-  val exceeded: DependenciesGroup<DependencyLatest>,
-  val undeclared: DependenciesGroup<Dependency>,
-  val unresolved: DependenciesGroup<DependencyUnresolved>,
-  val gradle: GradleUpdateResults,
-)
+class Result
+  @JvmOverloads
+  constructor(
+    val count: Int,
+    val current: DependenciesGroup<Dependency>,
+    val outdated: DependenciesGroup<DependencyOutdated>,
+    val exceeded: DependenciesGroup<DependencyLatest>,
+    val undeclared: DependenciesGroup<Dependency>,
+    val unresolved: DependenciesGroup<DependencyUnresolved>,
+    val gradle: GradleUpdateResults,
+    val skipped: SkippedConfigurationsGroup = SkippedConfigurationsGroup(0),
+  )

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/SkippedConfiguration.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/SkippedConfiguration.kt
@@ -1,0 +1,25 @@
+package com.github.benmanes.gradle.versions.reporter.result
+
+/** A configuration whose dependencies could not be inspected because applying the resolutionStrategy to it failed. */
+data class SkippedConfiguration(
+  val project: String,
+  val name: String,
+  val reason: String,
+) : Comparable<SkippedConfiguration> {
+  override fun compareTo(other: SkippedConfiguration): Int {
+    return compareValuesBy(this, other, { it.project }, { it.name }, { it.reason })
+  }
+}
+
+/**
+ * A group of skipped configurations.
+ *
+ * @property count The number of skipped configurations in this group.
+ * @property configurations The skipped configurations that belong to this group, kept as a list
+ * rather than a set so that two projects skipping an identically named configuration for the same
+ * reason both survive rather than collapsing into one.
+ */
+data class SkippedConfigurationsGroup(
+  val count: Int,
+  val configurations: List<SkippedConfiguration> = emptyList(),
+)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -1,6 +1,7 @@
 package com.github.benmanes.gradle.versions.updates
 
 import com.github.benmanes.gradle.versions.claims
+import com.github.benmanes.gradle.versions.reporter.projectsLabel
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -29,6 +30,9 @@ private const val ELEMENTS_CONFIGURATION = "dependencyUpdatesElements"
 private const val AGGREGATION_CONFIGURATION = "dependencyUpdatesAggregation"
 private const val PARAMETERS_SERVICE = "dependencyUpdatesParameters"
 private const val VERIFICATION_TYPE = "dependency-updates"
+
+/** The number of causes joined into a skipped configuration's reason, matching DependencyStatus. */
+private const val MAX_FAILURE_CAUSES = 20
 
 /** The filter applied when a task leaves the configurations unrestricted. */
 internal val ALL_CONFIGURATIONS = Spec<Configuration> { true }
@@ -392,9 +396,8 @@ private fun registerProducer(
             (ownConfigurations + settingsConfigurations)
               .filter { it.isCanBeResolved }
 
-          PartialResult(
-            PartialResult.FORMAT_VERSION,
-            project.path,
+          val skipped = mutableListOf<SkippedInfo>()
+          val statuses =
             statusesOf(
               project,
               configurations,
@@ -403,7 +406,9 @@ private fun registerProducer(
               filledByPlugin,
               nameDeclaringConfiguration = true,
               scriptClasspaths = false,
-            ),
+              skipped,
+            )
+          val buildscriptStatuses =
             statusesOf(
               project,
               buildscriptConfigurations,
@@ -418,7 +423,18 @@ private fun registerProducer(
               // The plugins block deposits its flattened markers only on these classpaths, so
               // only they recover a catalog plugin constraint.
               scriptClasspaths = true,
-            ),
+              skipped,
+            )
+          // Warned once the whole project's configurations and script classpaths are known, as the
+          // two calls above share this list and a configuration skipped by each would otherwise be
+          // warned about twice.
+          warnSkipped(project, skipped)
+          PartialResult(
+            PartialResult.FORMAT_VERSION,
+            project.path,
+            statuses,
+            buildscriptStatuses,
+            skipped,
           ).toJson()
         },
       )
@@ -487,6 +503,7 @@ private fun statusesOf(
   filledByPlugin: Set<String>,
   nameDeclaringConfiguration: Boolean,
   scriptClasspaths: Boolean,
+  skipped: MutableList<SkippedInfo>,
 ): List<PartialStatus> {
   if (configurations.isEmpty()) {
     return emptyList()
@@ -510,8 +527,31 @@ private fun statusesOf(
           status.configurations.any { parameters.filterDeclaredConfigurations.isSatisfiedBy(it) }
       }.map { it.toPartialStatus() }
     } catch (e: Exception) {
+      val reason =
+        generateSequence(e as Throwable) { it.cause }.take(MAX_FAILURE_CAUSES).joinToString("; ") { it.toString() }
+      // The default-visible warning is grouped and emitted once the project's whole set of skipped
+      // configurations is known, so only the stack trace is logged here.
       project.logger.info("Skipping configuration ${project.path}:${configuration.name}", e)
+      skipped.add(SkippedInfo(configuration.name, reason))
       emptyList()
     }
+  }
+}
+
+/**
+ * Warns once per distinct reason among the project's skipped configurations, naming the
+ * configurations it dropped, rather than once per configuration: a build with many configurations
+ * sharing one failing resolutionStrategy would otherwise flood the log with one line each.
+ */
+private fun warnSkipped(
+  project: Project,
+  skipped: List<SkippedInfo>,
+) {
+  for ((reason, group) in skipped.groupBy { it.reason }) {
+    val noun = if (group.size == 1) "configuration" else "configurations"
+    val names = group.joinToString(", ") { "'${it.name}'" }
+    project.logger.warn(
+      "Skipping $noun $names in ${projectsLabel(listOf(project.path))}: " + reason.lineSequence().first(),
+    )
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -11,6 +11,8 @@ import com.github.benmanes.gradle.versions.reporter.result.DependencyLatest
 import com.github.benmanes.gradle.versions.reporter.result.DependencyOutdated
 import com.github.benmanes.gradle.versions.reporter.result.DependencyUnresolved
 import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.github.benmanes.gradle.versions.reporter.result.SkippedConfiguration
+import com.github.benmanes.gradle.versions.reporter.result.SkippedConfigurationsGroup
 import com.github.benmanes.gradle.versions.reporter.result.VersionAvailable
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel
 import com.github.benmanes.gradle.versions.updates.gradle.GradleUpdateChecker
@@ -45,6 +47,8 @@ import java.util.TreeSet
  * @property projectsByCoordinate The projects behind each version of a coordinate whose versions diverge.
  * @property contributedCoordinates The coordinates that only lazy actions contributed, no project declaring them.
  * @property configurationsByCoordinate The configurations a plugin contributed each marked coordinate into.
+ * @property skipped The configurations whose dependencies could not be inspected because applying the
+ * resolutionStrategy to them failed.
  *
  */
 class DependencyUpdatesReporter(
@@ -68,7 +72,38 @@ class DependencyUpdatesReporter(
   val projectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
   val contributedCoordinates: Set<Coordinate> = emptySet(),
   val configurationsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
+  val skipped: List<SkippedConfiguration> = emptyList(),
 ) {
+  @Deprecated("Use the constructor that includes the skipped configurations.")
+  constructor(
+    projectPath: String,
+    logger: Logger,
+    revision: String,
+    outputFormatterArgument: OutputFormatterArgument,
+    outputDirectory: File,
+    reportfileName: String?,
+    currentVersions: Map<Map<String, String>, Coordinate>,
+    latestVersions: Map<Map<String, String>, Coordinate>,
+    upToDateVersions: Map<Map<String, String>, Coordinate>,
+    downgradeVersions: Map<Map<String, String>, Coordinate>,
+    upgradeVersions: Map<Map<String, String>, Coordinate>,
+    undeclared: Set<Coordinate>,
+    unresolved: Set<UnresolvedInfo>,
+    projectUrls: Map<Map<String, String>, String>,
+    gradleUpdateChecker: GradleUpdateChecker,
+    gradleReleaseChannel: String,
+    latestByCurrent: Map<Coordinate, Coordinate> = emptyMap(),
+    projectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
+    contributedCoordinates: Set<Coordinate> = emptySet(),
+    configurationsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
+  ) : this(
+    projectPath, logger, revision, outputFormatterArgument, outputDirectory, reportfileName,
+    currentVersions, latestVersions, upToDateVersions, downgradeVersions, upgradeVersions,
+    undeclared, unresolved, projectUrls, gradleUpdateChecker, gradleReleaseChannel,
+    latestByCurrent, projectsByCoordinate, contributedCoordinates, configurationsByCoordinate,
+    emptyList(),
+  )
+
   @Synchronized
   fun write() {
     if (outputFormatterArgument !is OutputFormatterArgument.CustomAction && logger.isLifecycleEnabled) {
@@ -131,6 +166,7 @@ class DependencyUpdatesReporter(
     val sortedExceeded = buildExceededGroup()
     val sortedUndeclared = buildUndeclaredGroup()
     val sortedUnresolved = buildUnresolvedGroup()
+    val sortedSkipped = skipped.sorted()
 
     val count =
       sortedCurrent.size +
@@ -147,6 +183,7 @@ class DependencyUpdatesReporter(
       undeclaredGroup = buildDependenciesGroup(sortedUndeclared),
       unresolvedGroup = buildDependenciesGroup(sortedUnresolved),
       gradleUpdateResults = buildGradleUpdateResults(),
+      skippedGroup = SkippedConfigurationsGroup(sortedSkipped.size, sortedSkipped),
     )
   }
 
@@ -320,6 +357,7 @@ class DependencyUpdatesReporter(
       undeclaredGroup: DependenciesGroup<Dependency>,
       unresolvedGroup: DependenciesGroup<DependencyUnresolved>,
       gradleUpdateResults: GradleUpdateResults,
+      skippedGroup: SkippedConfigurationsGroup,
     ): Result {
       return Result(
         count = count,
@@ -329,6 +367,7 @@ class DependencyUpdatesReporter(
         undeclared = undeclaredGroup,
         unresolved = unresolvedGroup,
         gradle = gradleUpdateResults,
+        skipped = skippedGroup,
       )
     }
 
@@ -362,6 +401,7 @@ class DependencyUpdatesReporter(
 
 /** Returns a reporter for the merged statuses of one or more projects. */
 @Suppress("LongParameterList")
+@JvmOverloads
 fun reporterFor(
   statuses: List<PartialStatus>,
   projectPath: String,
@@ -373,6 +413,7 @@ fun reporterFor(
   checkForGradleUpdate: Boolean,
   gradleVersionsApiBaseUrl: String,
   gradleReleaseChannel: String,
+  skipped: List<SkippedConfiguration> = emptyList(),
 ): DependencyUpdatesReporter {
   val versions = VersionMapping(logger, statuses)
   val projectsByCoordinate = divergentProjects(statuses)
@@ -403,7 +444,7 @@ fun reporterFor(
     reportfileName, currentVersions, latestVersions, upToDateVersions, downgradeVersions,
     upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
     gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate, contributedCoordinates,
-    configurationsByCoordinate,
+    configurationsByCoordinate, skipped,
   )
 }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -2,6 +2,7 @@ package com.github.benmanes.gradle.versions.updates
 
 import com.github.benmanes.gradle.versions.reporter.Reporter
 import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.github.benmanes.gradle.versions.reporter.result.SkippedConfiguration
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentFilter
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
@@ -265,10 +266,13 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
             partial.buildscriptStatuses.map { it.copy(projectPath = partial.projectPath) }
           },
         )
+    val skipped =
+      partials
+        .flatMap { partial -> partial.skipped.map { SkippedConfiguration(partial.projectPath, it.name, it.reason) } }
 
     reporterFor(
       statuses, projectPath, logger, revision, outputFormatter(), outputDirectory(), reportfileName,
-      checkForGradleUpdate, gradleVersionsApiBaseUrl, gradleReleaseChannel,
+      checkForGradleUpdate, gradleVersionsApiBaseUrl, gradleReleaseChannel, skipped,
     ).write()
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -59,6 +59,17 @@ data class PartialResult
   ) {
     fun toJson(): String = adapter.toJson(this)
 
+    /**
+     * Keeps the `copy` a release shipped callable, which the generated one no longer is now that
+     * the skipped configurations moved it to five parameters.
+     */
+    fun copy(
+      formatVersion: Int = this.formatVersion,
+      projectPath: String = this.projectPath,
+      statuses: List<PartialStatus> = this.statuses,
+      buildscriptStatuses: List<PartialStatus> = this.buildscriptStatuses,
+    ): PartialResult = copy(formatVersion, projectPath, statuses, buildscriptStatuses, skipped)
+
     companion object {
       /**
        * Bumped when the shape changes incompatibly; a field with a compatible default reads from an

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -41,39 +41,48 @@ data class UnresolvedInfo
     val userReason: String? = null,
   )
 
+/** A configuration skipped when its inspection failed, as a value that survives the project boundary. */
+data class SkippedInfo(
+  val name: String,
+  val reason: String,
+)
+
 /** The statuses one project observed, as written by its producer task. */
-data class PartialResult(
-  val formatVersion: Int,
-  val projectPath: String,
-  val statuses: List<PartialStatus>,
-  val buildscriptStatuses: List<PartialStatus>,
-) {
-  fun toJson(): String = adapter.toJson(this)
+data class PartialResult
+  @JvmOverloads
+  constructor(
+    val formatVersion: Int,
+    val projectPath: String,
+    val statuses: List<PartialStatus>,
+    val buildscriptStatuses: List<PartialStatus>,
+    val skipped: List<SkippedInfo> = emptyList(),
+  ) {
+    fun toJson(): String = adapter.toJson(this)
 
-  companion object {
-    /**
-     * Bumped when the shape changes incompatibly; a field with a compatible default reads from an
-     * older partial as that default.
-     */
-    const val FORMAT_VERSION: Int = 1
+    companion object {
+      /**
+       * Bumped when the shape changes incompatibly; a field with a compatible default reads from an
+       * older partial as that default.
+       */
+      const val FORMAT_VERSION: Int = 1
 
-    private val adapter =
-      Moshi.Builder()
-        .addLast(KotlinJsonAdapterFactory())
-        .build()
-        .adapter(PartialResult::class.java)
-        .serializeNulls()
+      private val adapter =
+        Moshi.Builder()
+          .addLast(KotlinJsonAdapterFactory())
+          .build()
+          .adapter(PartialResult::class.java)
+          .serializeNulls()
 
-    @JvmStatic
-    fun fromJson(json: String): PartialResult {
-      val result = requireNotNull(adapter.fromJson(json)) { "Empty partial result" }
-      require(result.formatVersion == FORMAT_VERSION) {
-        "Unsupported partial result format ${result.formatVersion}, expected $FORMAT_VERSION; re-run the build"
+      @JvmStatic
+      fun fromJson(json: String): PartialResult {
+        val result = requireNotNull(adapter.fromJson(json)) { "Empty partial result" }
+        require(result.formatVersion == FORMAT_VERSION) {
+          "Unsupported partial result format ${result.formatVersion}, expected $FORMAT_VERSION; re-run the build"
+        }
+        return result
       }
-      return result
     }
   }
-}
 
 /**
  * Merges statuses observed across projects, keeping one entry per coordinate key unless a

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
@@ -2,6 +2,7 @@ package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -102,6 +103,11 @@ final class AggregationConfigurationCacheSpec extends Specification {
 
   private def run(List<String> arguments) {
     return runner(arguments).build()
+  }
+
+  private def report() {
+    return new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
   }
 
   @Unroll
@@ -288,6 +294,41 @@ final class AggregationConfigurationCacheSpec extends Specification {
     store.output.contains('https://code.google.com/p/google-guice/')
     hit.output.contains('Reusing configuration cache')
     hit.output.contains('https://code.google.com/p/google-guice/')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Reports the skipped configurations on the store and on the cache hit'() {
+    given:
+    // The measured #801 trigger: a withModule id missing its ':name' half.
+    configure(
+      '''
+        resolutionStrategy {
+          componentSelection { rules ->
+            rules.withModule('com.google.guava') { }
+          }
+        }
+      ''')
+
+    when:
+    def store = run(ARGUMENTS + ['-DoutputFormatter=plain,json'])
+    def stored = report()
+
+    then:
+    store.task(':dependencyUpdates').outcome == SUCCESS
+    store.output.contains('Skipping configuration')
+    store.output.contains('Failed to inspect the dependencies of the following configurations')
+    stored.skipped.count > 0
+    stored.skipped.configurations*.name.contains('compileClasspath')
+
+    when:
+    def hit = run(ARGUMENTS + ['-DoutputFormatter=plain,json'])
+
+    then:
+    hit.output.contains('Reusing configuration cache')
+    // A hit does not re-evaluate the producers, so the warning they log while resolving does not
+    // re-emit, while the report the task writes from the replayed results is unchanged.
+    hit.output.contains('Failed to inspect the dependencies of the following configurations')
+    report() == stored
   }
 
   def 'Invalidates the cache when a dependency publishes a new version'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -2,6 +2,7 @@ package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -684,5 +685,98 @@ final class CompositeBuildSpec extends Specification {
 
     where:
     gradleVersion << ['9.0.0', '9.6.1']
+  }
+
+  // The measured #801 trigger: a withModule id missing its ':name' half.
+  private static String throwingStrategy() {
+    return '''
+      dependencyUpdates.resolutionStrategy {
+        componentSelection { rules ->
+          rules.withModule('com.google.guava') { }
+        }
+      }
+      '''.stripIndent()
+  }
+
+  // Gradle 9 requires JVM 17.
+  @Requires({ jvm.java17Compatible })
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Surfaces the skipped configurations of both builds on Gradle 9'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+
+        ${throwingStrategy()}
+      """.stripIndent()
+    includedBuild(
+      'child',
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.guava:guava:15.0'
+        }
+
+        ${throwingStrategy()}
+      """.stripIndent(),
+    )
+
+    when:
+    def result = GradleRunner.create()
+      .withGradleVersion('9.6.1')
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates', ':child:dependencyUpdates',
+        '-DoutputFormatter=plain,json')
+      .withPluginClasspath()
+      .build()
+    def including = report('')
+    def included = report('child/')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.task(':child:dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Failed to inspect the dependencies of the following configurations')
+
+    // Each build reports on its own projects. Both name their root ':', so the counts are what
+    // distinguish an owned entry from one collected out of the other build's report.
+    [including, included].every { it.skipped.count > 0 }
+    [including, included].every { it.skipped.configurations*.name.contains('compileClasspath') }
+    [including, included].every { it.skipped.configurations*.name.unique().size() == it.skipped.count }
+    including.skipped.count + included.skipped.count == 13
+    including.skipped.configurations.every { it.project == ':' }
+    included.skipped.configurations.every { it.project == ':' }
+  }
+
+  private def report(String path) {
+    return new JsonSlurper()
+      .parse(new File(testProjectDir.root, "${path}build/dependencyUpdates/report.json"))
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
@@ -1,9 +1,13 @@
 package com.github.benmanes.gradle.versions
 
+import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.updates.Coordinate
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesReporter
+import com.github.benmanes.gradle.versions.updates.PartialResult
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import kotlin.jvm.JvmClassMappingKt
 import kotlin.reflect.KVisibility
+import spock.lang.Issue
 import spock.lang.Specification
 
 /**
@@ -35,5 +39,13 @@ final class ConstructorVisibilitySpec extends Specification {
     expect:
     constraintCarrying.size() == 2
     constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'The arities gaining the skipped configurations widened are still callable'() {
+    expect:
+    Result.declaredConstructors.any { it.parameterCount == 7 }
+    DependencyUpdatesReporter.declaredConstructors.any { it.parameterCount == 20 }
+    PartialResult.declaredMethods.any { it.name == 'copy' && it.parameterCount == 4 }
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -2,6 +2,7 @@ package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -204,6 +205,38 @@ final class IsolatedProjectsAggregationSpec extends Specification {
     // the plugin is applied.
     !result.output.contains('com.google.guava:guava')
     result.output.contains('The dependency updates report is missing :lib')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Names the project of a skipped configuration with isolated projects'() {
+    given:
+    // The measured #801 trigger: a withModule id missing its ':name' half.
+    new File(testProjectDir.root, 'app/build.gradle') <<
+      '''
+        dependencyUpdates.resolutionStrategy {
+          componentSelection { rules ->
+            rules.withModule('com.google.guava') { }
+          }
+        }
+      '''.stripIndent()
+
+    when:
+    def result = run(['-DoutputFormatter=plain,json'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Isolated Projects is an incubating feature.')
+    // Only the project whose strategy throws loses its dependencies, so the other still reports.
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+    !result.output.contains('com.google.inject:guice [')
+
+    // Each project resolves in isolation and the aggregate names it from the partial result it
+    // published, rather than from the project it was read into.
+    def json = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    json.skipped.count > 0
+    json.skipped.configurations.every { it.project == ':app' }
+    json.skipped.configurations*.name.contains('compileClasspath')
   }
 
   def 'Omits a project that has no build script from the warning'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
@@ -331,6 +331,12 @@ final class OutputFormatterSpec extends Specification {
             ],
             "count": 1
         },
+        "skipped": {
+            "configurations": [
+
+            ],
+            "count": 0
+        },
         "count": 2
     }
       """.stripIndent())
@@ -420,6 +426,10 @@ final class OutputFormatterSpec extends Specification {
         <count>0</count>
         <dependencies/>
       </unresolved>
+      <skipped>
+        <count>0</count>
+        <configurations/>
+      </skipped>
       <gradle>
         <enabled>false</enabled>
         <running>

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions
 import com.github.benmanes.gradle.versions.updates.PartialResult
 import com.github.benmanes.gradle.versions.updates.PartialResultKt
 import com.github.benmanes.gradle.versions.updates.PartialStatus
+import com.github.benmanes.gradle.versions.updates.SkippedInfo
 import com.github.benmanes.gradle.versions.updates.UnresolvedInfo
 import spock.lang.Issue
 import spock.lang.Specification
@@ -94,6 +95,35 @@ final class PartialResultSpec extends Specification {
     then:
     decoded.statuses[0].unresolved.declaredVersion == 'none'
     decoded.statuses[0].unresolved.userReason == null
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'A partial without the skipped key reads as none skipped'() {
+    given:
+    def json = '''
+      {"formatVersion":1,"projectPath":":","statuses":[],"buildscriptStatuses":[]}
+      '''.stripIndent()
+
+    when:
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    decoded.skipped == []
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Skipped configurations survive the round trip'() {
+    given:
+    def skipped = new SkippedInfo('compileClasspath', 'org.gradle.api.InvalidUserCodeException: boom')
+    def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [], [], [skipped])
+
+    when:
+    def json = result.toJson()
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    decoded == result
+    json.contains('org.gradle.api.InvalidUserCodeException: boom')
   }
 
   def 'Rejects an unknown format version'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -2,6 +2,7 @@ package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -432,6 +433,36 @@ final class SettingsPluginAggregationSpec extends Specification {
     // Served in the artifact's place before this was left out of variant selection, rather than
     // failing, so the consumer took the statuses onto its classpath and carried on.
     !new File(testProjectDir.root, 'app/build/late/partial.json').exists()
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Surfaces every projects skipped configurations when applied from settings'() {
+    given:
+    createBuild([])
+    settingsApplying(true)
+    // The measured #801 trigger: a withModule id missing its ':name' half. Declared on the root
+    // task, which is the only one the settings application registers, so it reaches the producer of
+    // every project rather than only the one it was written in.
+    new File(testProjectDir.root, 'build.gradle') <<
+      '''
+        dependencyUpdates.resolutionStrategy {
+          componentSelection { rules ->
+            rules.withModule('com.google.guava') { }
+          }
+        }
+      '''.stripIndent()
+
+    when:
+    def result = run(ISOLATED + ['-DoutputFormatter=plain,json'])
+    def json = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('Isolated Projects is an incubating feature.')
+    result.output.contains('Failed to inspect the dependencies of the following configurations')
+    json.skipped.configurations*.project.toUnique().toSorted() == [':', ':app', ':lib']
+    json.skipped.configurations*.name.contains('compileClasspath')
   }
 
   def 'Applies once when a project also applies the plugin itself'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SkippedConfigurationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SkippedConfigurationSpec.groovy
@@ -81,10 +81,16 @@ final class SkippedConfigurationSpec extends Specification {
     entry != null
     entry.project == ':'
     entry.reason.contains('Could not add a component selection rule')
+    entry.reason.contains('Cannot convert the provided notation')
+
+    def report = new File(testProjectDir.root, 'build/dependencyUpdates/report.txt').text
+    report.contains("'compileClasspath' in root project")
 
     def xml = new File(testProjectDir.root, 'build/dependencyUpdates/report.xml').text
     xml.contains('<skipped>')
     xml.contains('<skippedConfiguration>')
+    xml.contains('<project>:</project>')
+    xml.contains('<name>compileClasspath</name>')
 
     def html = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
     html.contains('Skipped configurations')
@@ -329,5 +335,102 @@ final class SkippedConfigurationSpec extends Specification {
     def json = new JsonSlurper().parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
     json.skipped.count == 6
     json.skipped.configurations.every { it.project == ':app' }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Configurations skipped for distinct reasons get a heading and a warning each'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+
+        def attempts = new java.util.concurrent.atomic.AtomicInteger()
+        dependencyUpdates.resolutionStrategy {
+          throw new IllegalStateException('boom ' + attempts.incrementAndGet() + '\\nswallowed detail')
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    def json = new JsonSlurper().parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    json.skipped.count > 1
+    json.skipped.configurations*.reason.unique().size() == json.skipped.count
+    json.skipped.configurations*.name == json.skipped.configurations*.name.toSorted()
+
+    def report = new File(testProjectDir.root, 'build/dependencyUpdates/report.txt').text
+    def section = report.substring(report.indexOf('Failed to inspect the dependencies'))
+    section.readLines().count { it.startsWith(' - ') } == json.skipped.count
+    !report.contains('swallowed detail')
+
+    result.output.readLines().count { it.contains('Skipping configuration') } == json.skipped.count
+    !result.output.contains('swallowed detail')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'The HTML report keeps a project beside the configuration it skipped'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app', 'lib'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+
+        subprojects {
+          apply plugin: 'java'
+          apply plugin: 'io.github.ben-manes.versions'
+
+          repositories {
+            maven { url '${mavenRepoUrl}' }
+          }
+
+          dependencies {
+            implementation 'com.google.inject:guice:2.0'
+          }
+
+          dependencyUpdates.resolutionStrategy {
+            throw new IllegalStateException('boom')
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run([':dependencyUpdates', '-DoutputFormatter=html', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    def html = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+    def rows = (html.substring(html.indexOf('<h2>Skipped configurations</h2>')) =~
+      /<tr><td>(.*?)<\/td><td>(.*?)<\/td><td>(.*?)<\/td><\/tr>/)
+      .collect { [it[1], it[2]] }
+      .findAll { !it[0].startsWith('<b>') }
+
+    rows.every { it[0].split('<br>').length == it[1].split('<br>').length }
+    rows.any { it[0].split('<br>').length > 2 }
+    rows.any { it[0].contains(':app') && it[0].contains(':lib') }
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SkippedConfigurationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SkippedConfigurationSpec.groovy
@@ -254,4 +254,80 @@ final class SkippedConfigurationSpec extends Specification {
     !result.output.contains('::classpath')
     result.output.contains('root project')
   }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'A project inside a composite build whose configurations are skipped is annotated beside the surviving entries'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        includeBuild('child') {
+          dependencySubstitution {
+            substitute module('com.example:swapped') using project(':')
+          }
+        }
+        include 'app', 'lib'
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          api 'com.example:swapped:1.0'
+          api 'com.google.inject:guice:2.0'
+        }
+
+        ${throwingStrategy()}
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('child')
+    testProjectDir.newFile('child/settings.gradle') << "rootProject.name = 'child'"
+    testProjectDir.newFile('child/build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+      """.stripIndent()
+
+    when:
+    def result = run([':dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+
+    def json = new JsonSlurper().parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    json.skipped.count == 6
+    json.skipped.configurations.every { it.project == ':app' }
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SkippedConfigurationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SkippedConfigurationSpec.groovy
@@ -1,0 +1,257 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for surfacing configurations that were skipped because applying the build's
+ * resolutionStrategy to them threw.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+final class SkippedConfigurationSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private def run(List<String> arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  // The measured #801 trigger: a withModule id missing its ':name' half.
+  private static String throwingStrategy() {
+    return '''
+      dependencyUpdates.resolutionStrategy {
+        componentSelection { rules ->
+          rules.withModule('com.google.guava') { }
+        }
+      }
+      '''.stripIndent()
+  }
+
+  def 'A resolution strategy that throws surfaces every skipped configuration'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+
+        ${throwingStrategy()}
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=plain,json,xml,html', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('No dependencies found.')
+    result.output.contains('Failed to inspect the dependencies of the following configurations')
+    result.output.contains("'compileClasspath'")
+    result.output.contains('Skipping configuration')
+
+    def json = new JsonSlurper().parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    json.skipped.count > 0
+    def entry = json.skipped.configurations.find { it.name == 'compileClasspath' }
+    entry != null
+    entry.project == ':'
+    entry.reason.contains('Could not add a component selection rule')
+
+    def xml = new File(testProjectDir.root, 'build/dependencyUpdates/report.xml').text
+    xml.contains('<skipped>')
+    xml.contains('<skippedConfiguration>')
+
+    def html = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+    html.contains('Skipped configurations')
+  }
+
+  // A resolution failure's message is an exception toString() chain, arbitrary text that Gradle
+  // itself routinely fills with generics like "List<String>", so the HTML report must escape it
+  // rather than interpolate it raw into a <td>.
+  def 'The HTML report escapes a skipped configuration reason'() {
+    given:
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+
+        dependencyUpdates.resolutionStrategy {
+          throw new IllegalStateException(
+            'cannot convert to List<String> & <b>bold</b> <script>alert(1)</script>')
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=html', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    def html = new File(testProjectDir.root, 'build/dependencyUpdates/report.html').text
+    !html.contains('<script>alert(1)</script>')
+    !html.contains('List<String>')
+    !html.contains('<b>bold</b>')
+    html.contains('&lt;script&gt;alert(1)&lt;/script&gt;')
+    html.contains('List&lt;String&gt;')
+    html.contains('&lt;b&gt;bold&lt;/b&gt;')
+  }
+
+  def 'A project whose configurations are skipped is annotated beside the surviving entries'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'app', 'lib'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+
+        ${throwingStrategy()}
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        apply plugin: 'java'
+
+        repositories {
+          maven { url '${mavenRepoUrl}' }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run([':dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    def json = new JsonSlurper().parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def guice = json.outdated.dependencies.find { it.name == 'guice' }
+    guice != null
+    guice.version == '3.0'
+
+    json.skipped.configurations.every { it.project == ':app' }
+    json.skipped.count > 0
+
+    result.output.contains('guice [3.0 ->')
+    result.output.contains('Failed to inspect the dependencies of the following configurations')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
+  def 'Two configurations skipped for the same reason both survive into the report'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven { url '${mavenRepoUrl}' }
+          }
+
+          dependencies {
+            classpath 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions.settings'
+        }
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven { url '${mavenRepoUrl}' }
+          }
+
+          dependencies {
+            classpath 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        dependencyUpdates {
+          checkForGradleUpdate = false
+        }
+
+        ${throwingStrategy()}
+      """.stripIndent()
+
+    when:
+    def result = run(['dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    def json = new JsonSlurper().parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def classpathEntries = json.skipped.configurations.findAll { it.name == 'classpath' && it.project == ':' }
+    classpathEntries.size() == 2
+    json.skipped.count == 2
+
+    // The root project's own path renders as "root project", not the "::classpath" of a naive
+    // "$project.path:$configuration.name" concatenation.
+    !result.output.contains('::classpath')
+    result.output.contains('root project')
+  }
+}


### PR DESCRIPTION
A `resolutionStrategy` that throws while the plugin applies it to a configuration drops that configuration's dependencies from the report at info level, so the output stays plausible while understating how far behind the build is. This records each skipped configuration and surfaces it as a new `skipped` section on `Result`, printed by all four reporters, plus one warning per project per distinct reason. The catch stays, since #507's reason for it holds.

Before, on the issue's reproducer, where `:app` is on guice 2.0 and `:lib` on 3.0 and only `:app`'s strategy throws:

```
The following dependencies have later milestone versions:
 - com.google.inject:guice [3.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

After:

```
The following dependencies have later milestone versions:
 - com.google.inject:guice [3.0 -> 3.1]
     https://code.google.com/p/google-guice/

Failed to inspect the dependencies of the following configurations (use --info for details):
 - org.gradle.api.InvalidUserCodeException: Could not add a component selection rule for module 'com.google.guava'.; org.gradle.internal.typeconversion.UnsupportedNotationException: Cannot convert the provided notation to an object of type ModuleIdentifier: com.google.guava.
     'annotationProcessor' in :app
     'compileClasspath' in :app
     'runtimeClasspath' in :app
     'testAnnotationProcessor' in :app
     'testCompileClasspath' in :app
     'testRuntimeClasspath' in :app
```

The console also gets one line it did not have before:

```
Skipping configurations 'annotationProcessor', 'compileClasspath', 'runtimeClasspath', 'testAnnotationProcessor', 'testCompileClasspath', 'testRuntimeClasspath' in :app: org.gradle.api.InvalidUserCodeException: Could not add a component selection rule for module 'com.google.guava'.; org.gradle.internal.typeconversion.UnsupportedNotationException: Cannot convert the provided notation to an object of type ModuleIdentifier: com.google.guava.
```

`PartialResult.skipped` defaults to an empty list, so `FORMAT_VERSION` stays 1 and an older partial still reads. `Result` and `DependencyUpdatesReporter` keep their released constructors.

A custom `outputFormatter` reading `count`, `outdated` or `unresolved` is still told nothing, since the signal is only in the new key. Giving `unresolved` a meaning it does not have seemed worse.

An existing issue I uncovered testing this: an entry names its project by `project.path`, so an included build aggregated by its coordinates reports its skips as `root project` next to the including build's own. The existing sections carry the same path. I'm also looking into a fix for the project naming, which would cover the existing sections too.

Fixes #1073
