### PR TITLE
Name a report entry by the project's build tree path (fixes #1075)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1703,6 +1703,11 @@ The plain text and HTML reports name the first five projects and count the rest
 (`declared in :app, :lib, ... and 60 others`). The JSON and XML reports always
 carry the complete list, so use one of them when a tool needs every project.
 
+A project is named by the path it holds in the build tree, so a project of an
+included build reads as `:child:app` and that build's root as `:child`. Every
+build names its own root `:`, which would otherwise report the projects of two
+builds under one name.
+
 With the settings plugin applied (see [Applying the
 plugin](#applying-the-plugin)), the root project receives the
 `dependencyUpdates` task and every other project contributes to it. No project

--- a/README.md
+++ b/README.md
@@ -2051,6 +2051,29 @@ the section above it, and the topmost migrates to the current release.
 *Important*s are must-dos, *Tip*s are actions you should or may want to take,
 and *Note*s are things worth knowing that need no action.
 
+### v0.60.0
+
+v0.61.0 names a report entry by the project's path in the build tree, so the
+projects of an included build no longer share the `:` that every build answers
+for its own root:
+
+> [!IMPORTANT]
+> - A project of an included build is named by its build tree path, so an entry
+>   reads `declared in :child` where it read `declared in root project` (see
+>   [Multi-project builds](#multi-project-builds)). The JSON and XML reports
+>   carry the same paths in `projects`.
+> - A `buildSrc` build is named the same way when its task is run from the
+>   outer build, as `:buildSrc:dependencyUpdates`. Its report is headed
+>   `:buildSrc` rather than `:`, and its projects are named beneath that path.
+>   Running the task from inside `buildSrc` makes it the root of its own build
+>   tree, which still reads `:`.
+
+> [!NOTE]
+> A dependency that two builds of a composite declare at different versions is
+> now reported as divergent. The attribution naming the projects behind each
+> version was withheld while every entry carried the same project path, which
+> in a composite was always `:`.
+
 ### v0.59.0
 
 v0.60.0 names the configuration a dependency was declared directly against, so a

--- a/README.md
+++ b/README.md
@@ -2053,9 +2053,9 @@ and *Note*s are things worth knowing that need no action.
 
 ### v0.60.0
 
-v0.61.0 names a report entry by the project's path in the build tree, so the
-projects of an included build no longer share the `:` that every build answers
-for its own root:
+v0.61.0 names a project by its path in the build tree wherever the report shows
+one, so the projects of an included build no longer share the `:` that every
+build answers for its own root:
 
 > [!IMPORTANT]
 > - A project of an included build is named by its build tree path, so an entry

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -7,7 +7,7 @@ import java.io.PrintStream
 /**
  * A base result object reporter for the dependency updates results.
  *
- * @property projectPath The path of the project evaluated against.
+ * @property projectPath The build tree path of the project evaluated against.
  * @property revision The revision strategy evaluated with.
  * @property gradleReleaseChannel The gradle release channel to use for reporting.
  */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -551,7 +551,8 @@ private fun warnSkipped(
     val noun = if (group.size == 1) "configuration" else "configurations"
     val names = group.joinToString(", ") { "'${it.name}'" }
     project.logger.warn(
-      "Skipping $noun $names in ${projectsLabel(listOf(project.path))}: " + reason.lineSequence().first(),
+      "Skipping $noun $names in ${projectsLabel(listOf(project.buildTreePath))}: " +
+        reason.lineSequence().first(),
     )
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -203,11 +203,11 @@ internal fun registerAggregation(
   // project with no build script cannot apply the plugin there, so naming it in the completeness
   // warning would report what the user has no way to act on.
   val aggregatedPaths =
-    project.allprojects.filter { it.buildFile.exists() }.map { it.path }.toSet()
+    project.allprojects.filter { it.buildFile.exists() }.map { it.buildTreePath }.toSet()
 
   val partialsDirectory = project.layout.buildDirectory.dir("dependencyUpdates/partials")
   accumulator.configure { task ->
-    task.projectPath = project.path
+    task.projectPath = project.buildTreePath
     task.aggregatedProjectPaths = aggregatedPaths
     task.projectDirectory.set(project.layout.projectDirectory)
     task.partialResults.from(
@@ -431,7 +431,7 @@ private fun registerProducer(
           warnSkipped(project, skipped)
           PartialResult(
             PartialResult.FORMAT_VERSION,
-            project.path,
+            project.buildTreePath,
             statuses,
             buildscriptStatuses,
             skipped,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -26,7 +26,7 @@ import java.util.TreeSet
 /**
  * Sorts and writes the resolved dependency reports.
  *
- * @property projectPath The path of the project evaluated against.
+ * @property projectPath The build tree path of the project evaluated against.
  * @property logger The logger to report generated report files with.
  * @property revision The revision strategy evaluated with.
  * @property outputFormatterArgument The output formatter strategy evaluated with.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -172,11 +172,11 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   @get:PathSensitive(PathSensitivity.NONE)
   val partialResults: ConfigurableFileCollection = project.files()
 
-  /** Captured at configuration time; replaces `project.path` at execution. */
+  /** Captured at configuration time; replaces `project.buildTreePath` at execution. */
   @Internal
-  var projectPath: String = project.path
+  var projectPath: String = project.buildTreePath
 
-  /** The project paths expected to contribute partial results, wired by the plugin. */
+  /** The build tree paths expected to contribute partial results, wired by the plugin. */
   @Internal
   var aggregatedProjectPaths: Set<String> = emptySet()
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -18,7 +18,7 @@ data class PartialStatus
     val contributed: Boolean = false,
     /** The configurations a contributed dependency was declared against, empty when declared. */
     val configurations: List<String> = emptyList(),
-    /** The observing project, stamped by the accumulator rather than serialized. */
+    /** The observing project's build tree path, stamped by the accumulator rather than serialized. */
     @Transient val projectPath: String? = null,
   ) {
     val coordinate: Coordinate

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/BuildSrcAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/BuildSrcAggregationSpec.groovy
@@ -1,0 +1,134 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+final class BuildSrcAggregationSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String classpathString
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        'Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+    classpathString = pluginClasspathResource.readLines()
+      .collect { it.replace('\\', '\\\\') } // escape backslashes in Windows paths
+      .collect { "'$it'" }
+      .join(', ')
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+
+    testProjectDir.newFile('settings.gradle') << "rootProject.name = 'outer'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('buildSrc')
+    testProjectDir.newFile('buildSrc/build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          testImplementation 'com.google.guava:guava:15.0'
+          testImplementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+  }
+
+  private def run(String... arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Names a buildSrc build by its build tree path rather than the root project path'() {
+    when:
+    def result = run(':buildSrc:dependencyUpdates')
+
+    then:
+    // GradleRunner.build() throws unless every requested task succeeds, so reaching here already
+    // proves the task ran; TestKit does not surface a buildSrc task's outcome through result.task().
+    result.output.contains(':buildSrc Project Dependency Updates')
+    !result.output.contains('\n: Project Dependency Updates')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+  }
+
+  def 'Names the projects of a buildSrc build with subprojects by their build tree paths'() {
+    given:
+    testProjectDir.newFile('buildSrc/settings.gradle') << "include 'logic'"
+    testProjectDir.newFolder('buildSrc', 'logic')
+    testProjectDir.newFile('buildSrc/logic/build.gradle') <<
+      """
+        apply plugin: 'java'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          testImplementation 'com.google.inject:guice:2.2'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(':buildSrc:dependencyUpdates')
+
+    then:
+    // The root's label is a prefix of the subproject's, so it is matched to the end of its line.
+    result.output.contains('declared in :buildSrc\n')
+    result.output.contains('declared in :buildSrc:logic\n')
+    !result.output.contains('declared in root project')
+    !result.output.contains('The dependency updates report is missing')
+  }
+
+  def 'Excludes buildSrc from the outer build aggregated report'() {
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('com.google.guava:guava')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/BuildSrcAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/BuildSrcAggregationSpec.groovy
@@ -5,6 +5,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
 import spock.lang.Specification
 
 final class BuildSrcAggregationSpec extends Specification {
@@ -79,6 +80,7 @@ final class BuildSrcAggregationSpec extends Specification {
       .build()
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1075')
   def 'Names a buildSrc build by its build tree path rather than the root project path'() {
     when:
     def result = run(':buildSrc:dependencyUpdates')
@@ -91,6 +93,7 @@ final class BuildSrcAggregationSpec extends Specification {
     result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1075')
   def 'Names the projects of a buildSrc build with subprojects by their build tree paths'() {
     given:
     testProjectDir.newFile('buildSrc/settings.gradle') << "include 'logic'"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -773,6 +773,70 @@ final class CompositeBuildSpec extends Specification {
     including.skipped.count + included.skipped.count == 13
     including.skipped.configurations.every { it.project == ':' }
     included.skipped.configurations.every { it.project == ':child' }
+
+    // The warning accompanying the section names the same project the section does, rather than
+    // reporting both builds' roots under the one name each answers for itself.
+    result.output.contains('in :child:')
+    result.output.count('in root project:') == 1
+  }
+
+  def 'Names an included build that aggregates its own projects by its build tree path'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') << ''
+    testProjectDir.newFolder('child')
+    testProjectDir.newFile('child/settings.gradle') <<
+      """
+        rootProject.name = 'child'
+        include 'alpha', 'beta'
+      """.stripIndent()
+    testProjectDir.newFile('child/build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'io.github.ben-manes.versions'
+
+        allprojects {
+          apply plugin: 'java'
+
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('child', 'alpha')
+    testProjectDir.newFile('child/alpha/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('child', 'beta')
+    testProjectDir.newFile('child/beta/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(':child:dependencyUpdates')
+
+    then:
+    result.task(':child:dependencyUpdates').outcome == SUCCESS
+    result.output.contains(':child Project Dependency Updates')
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
+
+    // The projects the completeness check expects are named the way the partial results stamp
+    // them, so an included build that aggregates does not report its own projects as absent.
+    !result.output.contains('The dependency updates report is missing')
   }
 
   def 'Names the projects that declare a divergent version by their build tree paths'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -780,6 +780,7 @@ final class CompositeBuildSpec extends Specification {
     result.output.count('in root project:') == 1
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1075')
   def 'Names an included build that aggregates its own projects by its build tree path'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
@@ -839,6 +840,7 @@ final class CompositeBuildSpec extends Specification {
     !result.output.contains('The dependency updates report is missing')
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1075')
   def 'Names the projects that declare a divergent version by their build tree paths'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -765,14 +765,91 @@ final class CompositeBuildSpec extends Specification {
     result.task(':child:dependencyUpdates').outcome == SUCCESS
     result.output.contains('Failed to inspect the dependencies of the following configurations')
 
-    // Each build reports on its own projects. Both name their root ':', so the counts are what
-    // distinguish an owned entry from one collected out of the other build's report.
+    // Each build reports on its own projects, named by the path they hold in the build tree so
+    // that the included build's root is told apart from the including build's.
     [including, included].every { it.skipped.count > 0 }
     [including, included].every { it.skipped.configurations*.name.contains('compileClasspath') }
     [including, included].every { it.skipped.configurations*.name.unique().size() == it.skipped.count }
     including.skipped.count + included.skipped.count == 13
     including.skipped.configurations.every { it.project == ':' }
-    included.skipped.configurations.every { it.project == ':' }
+    included.skipped.configurations.every { it.project == ':child' }
+  }
+
+  def 'Names the projects that declare a divergent version by their build tree paths'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          dependencyUpdatesAggregation 'com.example:child:1.0'
+          tool 'com.example:jvm-library:2.0'
+        }
+      """.stripIndent()
+    includedBuild(
+      'child',
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'io.github.ben-manes.versions'
+
+        group = 'com.example'
+        version = '1.0'
+
+        configurations.maybeCreate('default')
+        afterEvaluate {
+          artifacts.add('default', file('child.jar'))
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          tool 'com.example:jvm-library:1.0'
+        }
+      """.stripIndent(),
+    )
+    testProjectDir.newFile('child/child.jar')
+
+    when:
+    def result = run('dependencyUpdates', '-DoutputFormatter=plain,json')
+    def json = report('')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    // Both roots answer ':' for their own build, which read as one project and withheld the
+    // divergence altogether rather than naming the two that disagree.
+    json.outdated.dependencies.find { it.name == 'jvm-library' }.projects == [':child']
+    json.current.dependencies.find { it.name == 'jvm-library' }.projects == [':']
+    result.output.contains("declared in the 'tool' configuration in root project")
+    result.output.contains("declared in the 'tool' configuration in :child")
   }
 
   private def report(String path) {


### PR DESCRIPTION
Fixes #1075.

This PR names a project by its build tree path wherever the report shows one. An entry names a project only where builds disagree on a version, and a composite used to hide that disagreement entirely, since both builds answered `:`.

Before:

```text
The following dependencies have later milestone versions:
 - org.apache.commons:commons-lang3 [3.11 -> 3.20.0]
     https://commons.apache.org/proper/commons-lang/
     declared in the 'tool' configuration
 - org.apache.commons:commons-lang3 [3.12.0 -> 3.20.0]
     https://commons.apache.org/proper/commons-lang/
     declared in the 'tool' configuration
```

After:

```text
The following dependencies have later milestone versions:
 - org.apache.commons:commons-lang3 [3.11 -> 3.20.0]
     https://commons.apache.org/proper/commons-lang/
     declared in the 'tool' configuration in :child
 - org.apache.commons:commons-lang3 [3.12.0 -> 3.20.0]
     https://commons.apache.org/proper/commons-lang/
     declared in the 'tool' configuration in root project
```

One consequence outside composites: a `buildSrc` build heads its report `:buildSrc` when its task is run from the outer build as `:buildSrc:dependencyUpdates`. Run from inside `buildSrc`, it is its own build tree root and still reads `:`.

