### PR TITLE
Name the platform projects that import an external platform, and reach the builds that hid one

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,8 @@ a version for every module it declares reaches no further than the platform
 project itself. The walk stops at the first published platform: a
 BOM that BOM imports states the BOM's version choice rather than the build's, and
 a BOM a library brings along as resolution metadata is not one the build
-imported, so neither is reported.
+imported, so neither is reported. The imported row names the platform project
+it was imported through, by build tree path.
 
 <details open>
 <summary>Kotlin</summary>

--- a/README.md
+++ b/README.md
@@ -610,8 +610,8 @@ a version for every module it declares reaches no further than the platform
 project itself. The walk stops at the first published platform: a
 BOM that BOM imports states the BOM's version choice rather than the build's, and
 a BOM a library brings along as resolution metadata is not one the build
-imported, so neither is reported. The imported row names the platform project
-it was imported through, by build tree path.
+imported, so neither is reported. The BOM's entry names every platform project
+that imports it, by build tree path.
 
 <details open>
 <summary>Kotlin</summary>

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -62,6 +62,12 @@ private fun configurationsLabel(names: List<String>): String {
 /** Returns the line describing where the dependency's version came from, or null for a declared one. */
 internal fun sourceLabel(dependency: Dependency): String? {
   val projects = dependency.projects
+  val platforms = dependency.platformProjects?.takeIf { it.isNotEmpty() }
+  if (platforms != null) {
+    val noun = if (platforms.size == 1) "platform" else "platforms"
+    val imported = "imported by the $noun ${projectsLabel(platforms)}"
+    return if (projects == null) imported else "$imported in ${projectsLabel(projects)}"
+  }
   val names = dependency.configurations?.takeIf { it.isNotEmpty() }
   if (dependency.contributed != true) {
     // A configuration is named only when the dependency was declared directly against a resolvable

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -59,7 +59,13 @@ private fun configurationsLabel(names: List<String>): String {
   return "the $listed $noun"
 }
 
-/** Returns the line describing where the dependency's version came from, or null for a declared one. */
+/**
+ * Returns the line describing where the dependency's version came from, or null for a declared one.
+ *
+ * A row is handed at most one attribution, decided where the statuses are assembled rather than by
+ * the order of the branches below: a declaration outranks the platform mark, which outranks the
+ * plugin's, ranking them by how directly the build can edit the version reported.
+ */
 internal fun sourceLabel(dependency: Dependency): String? {
   val projects = dependency.projects
   val platforms = dependency.platformProjects?.takeIf { it.isNotEmpty() }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -62,9 +62,10 @@ private fun configurationsLabel(names: List<String>): String {
 /**
  * Returns the line describing where the dependency's version came from, or null for a declared one.
  *
- * A row is handed at most one attribution, decided where the statuses are assembled rather than by
- * the order of the branches below: a declaration outranks the platform mark, which outranks the
- * plugin's, ranking them by how directly the build can edit the version reported.
+ * A row is handed at most one attribution, ranked by how directly the build can edit the version
+ * reported: a declaration outranks the platform mark, which outranks the plugin's. Which of the
+ * first two a row carries is decided where the statuses are assembled, so the branch order below
+ * settles only what the mark displaces, which is the configurations a declaration named.
  */
 internal fun sourceLabel(dependency: Dependency): String? {
   val projects = dependency.projects

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
@@ -237,6 +237,13 @@ class XmlReporter(
         appendTextChild(document, element, "configuration", configuration)
       }
     }
+    dependency.platformProjects?.let { platformProjects ->
+      val element = document.createElement("platformProjects")
+      dependencyElement.appendChild(element)
+      for (platformProject in platformProjects) {
+        appendTextChild(document, element, "platformProject", platformProject)
+      }
+    }
     return dependencyElement
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
@@ -26,6 +26,8 @@ open class Dependency
      * contributed it into when [contributed] is true.
      */
     @AbsentWhenNull open val configurations: List<String>? = null,
+    /** The platform projects the build imports this dependency through, by build tree path. */
+    @AbsentWhenNull open val platformProjects: List<String>? = null,
   ) : Comparable<Dependency> {
     override fun compareTo(other: Dependency): Int {
       return compareValuesBy(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
@@ -12,4 +12,5 @@ data class DependencyLatest
     @AbsentWhenNull override val projects: List<String>? = null,
     @AbsentWhenNull override val contributed: Boolean? = null,
     @AbsentWhenNull override val configurations: List<String>? = null,
+    @AbsentWhenNull override val platformProjects: List<String>? = null,
   ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
@@ -12,4 +12,5 @@ data class DependencyOutdated
     @AbsentWhenNull override val projects: List<String>? = null,
     @AbsentWhenNull override val contributed: Boolean? = null,
     @AbsentWhenNull override val configurations: List<String>? = null,
+    @AbsentWhenNull override val platformProjects: List<String>? = null,
   ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
@@ -12,4 +12,5 @@ data class DependencyUnresolved
     @AbsentWhenNull override val projects: List<String>? = null,
     @AbsentWhenNull override val contributed: Boolean? = null,
     @AbsentWhenNull override val configurations: List<String>? = null,
+    @AbsentWhenNull override val platformProjects: List<String>? = null,
   ) : Dependency()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -49,6 +49,13 @@ class Coordinate(
   var platformVersionConstraints: List<VersionConstraint> = emptyList()
     private set
 
+  /**
+   * The build tree paths of the platform projects the build imports this module through, empty
+   * otherwise.
+   */
+  var platformProjects: List<String> = emptyList()
+    private set
+
   val key: Key
     get() = Key(groupId, artifactId)
 
@@ -81,6 +88,18 @@ class Coordinate(
       } catch (e: LinkageError) {
         emptyList()
       }
+  }
+
+  internal constructor(
+    groupId: String?,
+    artifactId: String?,
+    version: String?,
+    userReason: String?,
+    versionConstraint: VersionConstraint?,
+    platformVersionConstraints: List<VersionConstraint>,
+    platformProjects: List<String>,
+  ) : this(groupId, artifactId, version, userReason, versionConstraint, platformVersionConstraints) {
+    this.platformProjects = platformProjects
   }
 
   override fun toString(): String {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -85,6 +85,7 @@ class DependencyStatus {
       info,
       contributed,
       configurations,
+      platformProjects = coordinate.platformProjects,
     )
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -49,6 +49,7 @@ import java.util.TreeSet
  * @property configurationsByCoordinate The configurations a plugin contributed each marked coordinate into.
  * @property skipped The configurations whose dependencies could not be inspected because applying the
  * resolutionStrategy to them failed.
+ * @property platformProjectsByCoordinate The platform projects the build imports each coordinate through.
  *
  */
 class DependencyUpdatesReporter(
@@ -73,6 +74,7 @@ class DependencyUpdatesReporter(
   val contributedCoordinates: Set<Coordinate> = emptySet(),
   val configurationsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
   val skipped: List<SkippedConfiguration> = emptyList(),
+  val platformProjectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
 ) {
   @Deprecated("Use the constructor that includes the skipped configurations.")
   constructor(
@@ -272,6 +274,7 @@ class DependencyUpdatesReporter(
       projects = projectsByCoordinate[coordinate],
       contributed = contributedFlag(coordinate),
       configurations = configurationsByCoordinate[coordinate],
+      platformProjects = platformProjectsByCoordinate[coordinate],
     )
   }
 
@@ -289,6 +292,7 @@ class DependencyUpdatesReporter(
       projects = projectsByCoordinate[coordinate],
       contributed = contributedFlag(coordinate),
       configurations = configurationsByCoordinate[coordinate],
+      platformProjects = platformProjectsByCoordinate[coordinate],
     )
   }
 
@@ -314,6 +318,7 @@ class DependencyUpdatesReporter(
       reason = info.failureText,
       contributed = contributedFlag(declared),
       configurations = configurationsByCoordinate[declared],
+      platformProjects = platformProjectsByCoordinate[declared],
     )
   }
 
@@ -338,6 +343,7 @@ class DependencyUpdatesReporter(
       projects = projectsByCoordinate[coordinate],
       contributed = contributedFlag(coordinate),
       configurations = configurationsByCoordinate[coordinate],
+      platformProjects = platformProjectsByCoordinate[coordinate],
     )
   }
 
@@ -419,6 +425,7 @@ fun reporterFor(
   val projectsByCoordinate = divergentProjects(statuses)
   val contributedCoordinates = contributedCoordinates(statuses, logger)
   val configurationsByCoordinate = namedConfigurations(statuses, contributedCoordinates)
+  val platformProjectsByCoordinate = platformProjectsByCoordinate(statuses)
   val unresolved = statuses.mapNotNullTo(mutableSetOf()) { it.unresolved }
   val projectUrls =
     statuses
@@ -444,7 +451,7 @@ fun reporterFor(
     reportfileName, currentVersions, latestVersions, upToDateVersions, downgradeVersions,
     upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
     gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate, contributedCoordinates,
-    configurationsByCoordinate, skipped,
+    configurationsByCoordinate, skipped, platformProjectsByCoordinate,
   )
 }
 
@@ -492,6 +499,13 @@ private fun namedConfigurations(
         }
     }.mapValues { (_, group) -> group.flatMap { it.configurations }.distinct().sorted() }
     .filterValues { it.isNotEmpty() }
+
+/** Returns the platform projects each coordinate was imported through, unioned across projects. */
+private fun platformProjectsByCoordinate(statuses: List<PartialStatus>): Map<Coordinate, List<String>> =
+  statuses
+    .filter { it.platformProjects.isNotEmpty() }
+    .groupBy { it.coordinate }
+    .mapValues { (_, group) -> group.flatMap { it.platformProjects }.distinct().sorted() }
 
 /** Returns the projects behind each version of a key whose declared versions diverge. */
 private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, List<String>> {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -425,7 +425,7 @@ fun reporterFor(
   val projectsByCoordinate = divergentProjects(statuses)
   val contributedCoordinates = contributedCoordinates(statuses, logger)
   val configurationsByCoordinate = namedConfigurations(statuses, contributedCoordinates)
-  val platformProjectsByCoordinate = platformProjectsByCoordinate(statuses)
+  val platformProjectsByCoordinate = platformProjectsByCoordinate(statuses, logger)
   val unresolved = statuses.mapNotNullTo(mutableSetOf()) { it.unresolved }
   val projectUrls =
     statuses
@@ -500,12 +500,33 @@ private fun namedConfigurations(
     }.mapValues { (_, group) -> group.flatMap { it.configurations }.distinct().sorted() }
     .filterValues { it.isNotEmpty() }
 
-/** Returns the platform projects each coordinate was imported through, unioned across projects. */
-private fun platformProjectsByCoordinate(statuses: List<PartialStatus>): Map<Coordinate, List<String>> =
+/**
+ * Returns the platform projects each coordinate was imported through, unioned across projects.
+ * Withheld when a project outside that importer set declares the coordinate, since a declaration
+ * anywhere else is the row to edit and the mark would point somewhere else. A declaring project
+ * that is itself one of the named importers is not a disagreement: the mark already points at it.
+ */
+private fun platformProjectsByCoordinate(
+  statuses: List<PartialStatus>,
+  logger: Logger,
+): Map<Coordinate, List<String>> =
   statuses
-    .filter { it.platformProjects.isNotEmpty() }
     .groupBy { it.coordinate }
-    .mapValues { (_, group) -> group.flatMap { it.platformProjects }.distinct().sorted() }
+    .filterValues { group -> group.any { it.platformProjects.isNotEmpty() } }
+    .filter { (coordinate, group) ->
+      val importers = group.flatMap { it.platformProjects }.toSet()
+      val declared =
+        group.any {
+          it.platformProjects.isEmpty() && !it.contributed && it.projectPath !in importers
+        }
+      if (declared) {
+        logger.info(
+          "A project outside ${coordinate.groupId}:${coordinate.artifactId}'s platform importers " +
+            "declares it, so the platform mark is withheld",
+        )
+      }
+      !declared
+    }.mapValues { (_, group) -> group.flatMap { it.platformProjects }.distinct().sorted() }
 
 /** Returns the projects behind each version of a key whose declared versions diverge. */
 private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, List<String>> {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -512,21 +512,25 @@ private fun platformProjectsByCoordinate(
 ): Map<Coordinate, List<String>> =
   statuses
     .groupBy { it.coordinate }
-    .filterValues { group -> group.any { it.platformProjects.isNotEmpty() } }
-    .filter { (coordinate, group) ->
+    .mapNotNull { (coordinate, group) ->
       val importers = group.flatMap { it.platformProjects }.toSet()
-      val declared =
-        group.any {
+      if (importers.isEmpty()) {
+        return@mapNotNull null
+      }
+      val declaringStatuses =
+        group.filter {
           it.platformProjects.isEmpty() && !it.contributed && it.projectPath !in importers
         }
-      if (declared) {
+      if (declaringStatuses.isNotEmpty()) {
+        val declaringPaths = declaringStatuses.mapNotNull { it.projectPath }.distinct().sorted()
         logger.info(
           "A project outside ${coordinate.groupId}:${coordinate.artifactId}'s platform importers " +
-            "declares it, so the platform mark is withheld",
+            "declares it, so the platform mark is withheld: ${declaringPaths.joinToString(", ")}",
         )
+        return@mapNotNull null
       }
-      !declared
-    }.mapValues { (_, group) -> group.flatMap { it.platformProjects }.distinct().sorted() }
+      coordinate to importers.toList().sorted()
+    }.toMap()
 
 /** Returns the projects behind each version of a key whose declared versions diverge. */
 private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, List<String>> {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -20,6 +20,12 @@ data class PartialStatus
     val configurations: List<String> = emptyList(),
     /** The observing project's build tree path, stamped by the accumulator rather than serialized. */
     @Transient val projectPath: String? = null,
+    /**
+     * The build tree paths of the platform projects the build imports this module through. Trails
+     * the transient projectPath rather than preceding it, since inserting a parameter before it
+     * would replace the shipped arities that end there.
+     */
+    val platformProjects: List<String> = emptyList(),
   ) {
     val coordinate: Coordinate
       get() = Coordinate(group, name, declaredVersion, userReason)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -32,6 +32,27 @@ data class PartialStatus
 
     val latestCoordinate: Coordinate
       get() = Coordinate(group, name, latestVersion, userReason)
+
+    /**
+     * Keeps the `copy` a release shipped callable, which the generated one no longer is now that
+     * the imported platform projects moved it past ten parameters.
+     */
+    fun copy(
+      group: String = this.group,
+      name: String = this.name,
+      declaredVersion: String = this.declaredVersion,
+      userReason: String? = this.userReason,
+      latestVersion: String = this.latestVersion,
+      projectUrl: String? = this.projectUrl,
+      unresolved: UnresolvedInfo? = this.unresolved,
+      contributed: Boolean = this.contributed,
+      configurations: List<String> = this.configurations,
+      projectPath: String? = this.projectPath,
+    ): PartialStatus =
+      copy(
+        group, name, declaredVersion, userReason, latestVersion, projectUrl, unresolved, contributed,
+        configurations, projectPath, platformProjects,
+      )
   }
 
 /** A resolution failure, as a value that survives the project boundary. */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -468,10 +468,10 @@ class Resolver(
     coordinates.keys.retainAll(declared.keys + contributed.map { it.key } + substitutions.values)
 
     val platformSources = if (checkConstraints) getPlatformSources(root, declared.keys) else emptyList()
-    val harvestedKeys = hashSetOf<Coordinate.Key>()
+    val platformSourceKeys = hashSetOf<Coordinate.Key>()
     for (source in platformSources) {
       if (coordinates.putIfAbsent(source.key, source) == null) {
-        harvestedKeys.add(source.key)
+        platformSourceKeys.add(source.key)
       }
     }
 
@@ -479,7 +479,7 @@ class Resolver(
     // listener) is missing from the snapshot taken before any configuration was first resolved, and
     // is not a substitution target, which traces to a real declaration.
     val contributedKeys =
-      coordinates.keys - declaredBeforeActions - substitutions.values.toSet() - harvestedKeys
+      coordinates.keys - declaredBeforeActions - substitutions.values.toSet() - platformSourceKeys
 
     // A plugin that adds its private classpath eagerly, at apply time, is indistinguishable from a
     // declaration by the time the snapshot above is taken, so what it leaves behind is named instead:
@@ -507,49 +507,75 @@ class Resolver(
    *
    * Such a platform's constraints bound this build's versionless modules while the substituted
    * project hides the coordinate to edit, so each one is reported as an entry of its own. Only a
-   * chain of platform variants that stays in project components until the harvested module
+   * chain of platform variants that stays in project components until the imported module
    * qualifies: a platform that an external platform imports is that platform's version choice
    * rather than the build's, and one a library drags in is a resolution input, so the walk stops at
    * the first external component either way. A platform the build declares itself already has a
    * report entry and is skipped. The constraint the platform project's declaration states rides
-   * along, so a stated bound holds the harvested row like any declared one.
+   * along, so a stated bound holds an imported row like any declared one. Each qualifying edge's
+   * dequeued source project, when it is one, is recorded as the coordinate's importer, by build
+   * tree path.
    */
   private fun getPlatformSources(
     root: ResolvedComponentResult,
     declaredKeys: Set<Coordinate.Key>,
   ): List<Coordinate> {
-    val sources = mutableListOf<Coordinate>()
+    val sources = linkedMapOf<Coordinate.Key, Coordinate>()
+    val importers = hashMapOf<Coordinate.Key, MutableSet<String>>()
     val seen = hashSetOf(root.id)
     val pending = ArrayDeque(listOf(root))
     while (pending.isNotEmpty()) {
-      for (dependency in pending.removeFirst().dependencies) {
+      val node = pending.removeFirst()
+      val importer = (node.id.takeIf { it != root.id } as? ProjectComponentIdentifier)?.buildTreePath
+      for (dependency in node.dependencies) {
         if (dependency !is ResolvedDependencyResult || dependency.isConstraint) {
           continue
         }
         val selected = dependency.selected
-        if (!seen.add(selected.id) || selected.variants.none { isPlatform(it) }) {
+        val firstVisit = seen.add(selected.id)
+        // The edge's own variant, rather than the component's set, since a module published with
+        // only a pom offers both a library and a platform variant and a build can consume each.
+        if (!isPlatform(dependency.resolvedVariant)) {
           continue
         }
         if (selected.id is ProjectComponentIdentifier) {
-          pending.add(selected)
+          if (firstVisit) {
+            pending.add(selected)
+          }
         } else {
           val moduleVersion = selected.moduleVersion ?: continue
           val requested = dependency.requested as? ModuleComponentSelector
-          val coordinate =
+          val key = Coordinate.Key(moduleVersion.group, moduleVersion.name)
+          if (key in declaredKeys) {
+            continue
+          }
+          sources.putIfAbsent(
+            key,
             Coordinate(
               moduleVersion.group,
               moduleVersion.name,
               moduleVersion.version,
               userReason = null,
               versionConstraint = requested?.versionConstraint,
-            )
-          if (coordinate.key !in declaredKeys) {
-            sources.add(coordinate)
+            ),
+          )
+          if (importer != null) {
+            importers.getOrPut(key) { sortedSetOf() }.add(importer)
           }
         }
       }
     }
-    return sources
+    return sources.map { (key, coordinate) ->
+      Coordinate(
+        coordinate.groupId,
+        coordinate.artifactId,
+        coordinate.version,
+        coordinate.userReason,
+        coordinate.versionConstraint,
+        coordinate.platformVersionConstraints,
+        importers[key]?.toList().orEmpty(),
+      )
+    }
   }
 
   /**

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -467,7 +467,7 @@ class Resolver(
     // Ignore undeclared (hidden) dependencies that appear when resolving a configuration
     coordinates.keys.retainAll(declared.keys + contributed.map { it.key } + substitutions.values)
 
-    val platformSources = if (checkConstraints) getPlatformSources(root, declared.keys) else emptyList()
+    val platformSources = if (checkConstraints) getPlatformSources(configuration, declared.keys) else emptyList()
     val platformSourceKeys = hashSetOf<Coordinate.Key>()
     for (source in platformSources) {
       if (coordinates.putIfAbsent(source.key, source) == null) {
@@ -504,6 +504,33 @@ class Resolver(
   /**
    * Returns the external platforms the build consumes through its own platform projects, such as a
    * BOM that an included build's platform imports and this build reaches by project substitution.
+   *
+   * Resolved from a dedicated copy holding only the configuration's platform-category
+   * declarations, always transitive, so a platform reached only through a project dependency (which
+   * carries no version for the main copy's own #231 flag to key off) is still found, without
+   * perturbing the main copy's resolution.
+   */
+  private fun getPlatformSources(
+    configuration: Configuration,
+    declaredKeys: Set<Coordinate.Key>,
+  ): List<Coordinate> {
+    val platformDependencies =
+      configuration.allDependencies.filterIsInstance<ModuleDependency>().filter { isPlatform(it) }
+    if (platformDependencies.isEmpty()) {
+      return emptyList()
+    }
+    val copy = configuration.copyRecursive().setTransitive(true)
+    // https://github.com/ben-manes/gradle-versions-plugin/issues/781
+    copy.resolutionStrategy.deactivateDependencyLocking()
+    disableAutoTargetJvm(copy)
+    copy.dependencies.clear()
+    copy.dependencies.addAll(platformDependencies)
+    return getPlatformSources(copy.incoming.resolutionResult.root, declaredKeys)
+  }
+
+  /**
+   * Returns the external platforms found by walking the given root, such as a BOM that an included
+   * build's platform imports and this build reaches by project substitution.
    *
    * Such a platform's constraints bound this build's versionless modules while the substituted
    * project hides the coordinate to edit, so each one is reported as an entry of its own. Only a
@@ -855,6 +882,17 @@ class Resolver(
       val category =
         variant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name
           ?: variant.attributes.getAttribute(DESUGARED_CATEGORY)
+      return (category == Category.REGULAR_PLATFORM) || (category == Category.ENFORCED_PLATFORM)
+    }
+
+    /**
+     * Whether the dependency declares a platform. A local project dependency carries the typed
+     * [Category] attribute while one desugared by other tooling is a string, so both forms are read.
+     */
+    private fun isPlatform(dependency: ModuleDependency): Boolean {
+      val category =
+        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name
+          ?: dependency.attributes.getAttribute(DESUGARED_CATEGORY)
       return (category == Category.REGULAR_PLATFORM) || (category == Category.ENFORCED_PLATFORM)
     }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -514,7 +514,8 @@ class Resolver(
    * report entry and is skipped. The constraint the platform project's declaration states rides
    * along, so a stated bound holds an imported row like any declared one. Each qualifying edge's
    * dequeued source project, when it is one, is recorded as the coordinate's importer, by build
-   * tree path.
+   * tree path. Every importer of a coordinate is recorded, while the bound is the one the first
+   * qualifying edge stated, so a row that names several projects states the bound of one of them.
    */
   private fun getPlatformSources(
     root: ResolvedComponentResult,
@@ -532,14 +533,15 @@ class Resolver(
           continue
         }
         val selected = dependency.selected
-        val firstVisit = seen.add(selected.id)
         // The edge's own variant, rather than the component's set, since a module published with
         // only a pom offers both a library and a platform variant and a build can consume each.
+        // Marking a component seen only once past this gate keeps an edge that resolved a library
+        // variant from barring the platform edge that reaches the same project later.
         if (!isPlatform(dependency.resolvedVariant)) {
           continue
         }
         if (selected.id is ProjectComponentIdentifier) {
-          if (firstVisit) {
+          if (seen.add(selected.id)) {
             pending.add(selected)
           }
         } else {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -53,6 +53,12 @@ class Resolver(
 ) {
   private var projectUrls = ConcurrentHashMap<ModuleVersionIdentifier, ProjectUrl>()
 
+  // The platform declarations whose scan threw, so a configuration inheriting the same ones does
+  // not repeat a resolution already known to fail. Only a failure is shared: what a scan finds
+  // depends on the resolving configuration's own attributes, constraints and resolution strategy,
+  // while skipping one costs an attribution at most.
+  private val failedPlatformScans = hashSetOf<Set<ModuleDependency>>()
+
   // Gradle flattens a version-catalog plugin alias to a bare required range on the marker
   // dependency it synthesizes for the buildscript classpath, dropping strictly/prefer/reject.
   // https://github.com/ben-manes/gradle-versions-plugin/issues/755
@@ -399,9 +405,10 @@ class Resolver(
     // An empty configuration is still resolved below, so that a listener contributing to it has
     // run by the time the declared set is read again. That resolution costs nothing. One holding
     // only project or file dependencies is skipped, as resolving it would not, unless it imports
-    // a platform: scan first, and keep the cheap exit when the scan has nothing to say.
+    // a platform: scan first, and keep the cheap exit when the scan has nothing to say. This path
+    // resolved nothing at all before, so the scan is its first resolution rather than a second one.
     if (declared.isEmpty() && configuration.allDependencies.isNotEmpty()) {
-      val platformSources = if (checkConstraints) getPlatformSources(configuration, emptySet()) else emptyList()
+      val platformSources = if (checkConstraints) getPlatformSources(configuration, declared.keys) else emptyList()
       if (platformSources.isEmpty()) {
         return CurrentCoordinates(emptyMap(), emptyMap(), emptySet())
       }
@@ -517,7 +524,8 @@ class Resolver(
    * Resolved from a dedicated copy holding only the configuration's platform-category
    * declarations, always transitive, so a platform reached only through a project dependency (which
    * carries no version for the main copy's own #231 flag to key off) is still found, without
-   * perturbing the main copy's resolution.
+   * perturbing the main copy's resolution. That copy is a second resolution of every configuration
+   * declaring a platform, so a build's own beforeResolve hook runs once more than it did.
    */
   private fun getPlatformSources(
     configuration: Configuration,
@@ -525,16 +533,36 @@ class Resolver(
   ): List<Coordinate> {
     val platformDependencies =
       configuration.allDependencies.filterIsInstance<ModuleDependency>().filter { isPlatform(it) }
-    if (platformDependencies.isEmpty()) {
+    if (platformDependencies.isEmpty() || platformDependencies.toSet() in failedPlatformScans) {
       return emptyList()
     }
+    return try {
+      getPlatformSources(resolvePlatformRoot(configuration, platformDependencies), declaredKeys)
+    } catch (e: Exception) {
+      // The scan is an extra resolution the report can do without: it is always transitive and
+      // carries the build's own resolution strategy, so a build with failOnVersionConflict() can
+      // throw here even though the main, non-transitive copy resolved fine. Losing one
+      // attribution beats losing every row of the configuration.
+      failedPlatformScans.add(platformDependencies.toSet())
+      project.logger.info("Failed to resolve the platforms declared by ${configuration.name}", e)
+      emptyList()
+    }
+  }
+
+  /** Returns the root of resolving the configuration's platform declarations, always transitive. */
+  private fun resolvePlatformRoot(
+    configuration: Configuration,
+    platformDependencies: List<ModuleDependency>,
+  ): ResolvedComponentResult {
     val copy = configuration.copyRecursive().setTransitive(true)
     // https://github.com/ben-manes/gradle-versions-plugin/issues/781
     copy.resolutionStrategy.deactivateDependencyLocking()
     disableAutoTargetJvm(copy)
     copy.dependencies.clear()
-    copy.dependencies.addAll(platformDependencies)
-    return getPlatformSources(copy.incoming.resolutionResult.root, declaredKeys)
+    // Copied rather than shared, as copyRecursive does for the set cleared above: a withDependencies
+    // action carried onto this copy would otherwise mutate the build's own declarations.
+    copy.dependencies.addAll(platformDependencies.map { it.copy() })
+    return copy.incoming.resolutionResult.root
   }
 
   /**
@@ -603,7 +631,10 @@ class Resolver(
         }
       }
     }
+    // Rebuilt only where an importer was recorded, since the constraint a rebuild carries over is
+    // copied again on the way through and an unattributed coordinate is already what it needs to be.
     return sources.map { (key, coordinate) ->
+      val importedBy = importers[key] ?: return@map coordinate
       Coordinate(
         coordinate.groupId,
         coordinate.artifactId,
@@ -611,7 +642,7 @@ class Resolver(
         coordinate.userReason,
         coordinate.versionConstraint,
         coordinate.platformVersionConstraints,
-        importers[key]?.toList().orEmpty(),
+        importedBy.toList(),
       )
     }
   }
@@ -883,6 +914,10 @@ class Resolver(
     private val ABSOLUTE_URL = Regex("""^[a-zA-Z][a-zA-Z0-9+.-]*://""")
     private val DESUGARED_CATEGORY = Attribute.of(Category.CATEGORY_ATTRIBUTE.name, String::class.java)
 
+    /** Whether the category names a regular or enforced platform. */
+    private fun isPlatformCategory(category: String?): Boolean =
+      (category == Category.REGULAR_PLATFORM) || (category == Category.ENFORCED_PLATFORM)
+
     /**
      * Whether the variant is a platform's. A local project's variant carries the typed [Category]
      * attribute while a published module's is desugared to a string, so both forms are read.
@@ -891,19 +926,17 @@ class Resolver(
       val category =
         variant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name
           ?: variant.attributes.getAttribute(DESUGARED_CATEGORY)
-      return (category == Category.REGULAR_PLATFORM) || (category == Category.ENFORCED_PLATFORM)
+      return isPlatformCategory(category)
     }
 
     /**
-     * Whether the dependency declares a platform. A local project dependency carries the typed
-     * [Category] attribute while one desugared by other tooling is a string, so both forms are read.
+     * Whether the dependency declares a platform. A declaration created by `platform(...)` or
+     * `enforcedPlatform(...)` always carries the typed [Category] attribute; the desugared string
+     * form appears only on published module metadata, which the resolved-variant overload above
+     * reads instead.
      */
-    private fun isPlatform(dependency: ModuleDependency): Boolean {
-      val category =
-        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name
-          ?: dependency.attributes.getAttribute(DESUGARED_CATEGORY)
-      return (category == Category.REGULAR_PLATFORM) || (category == Category.ENFORCED_PLATFORM)
-    }
+    private fun isPlatform(dependency: ModuleDependency): Boolean =
+      isPlatformCategory(dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name)
 
     private fun getUrlFromPom(file: File): String? {
       val pom = XmlSlurper(false, false).parse(file)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -398,9 +398,18 @@ class Resolver(
         }
     // An empty configuration is still resolved below, so that a listener contributing to it has
     // run by the time the declared set is read again. That resolution costs nothing. One holding
-    // only project or file dependencies is skipped, as resolving it would not.
+    // only project or file dependencies is skipped, as resolving it would not, unless it imports
+    // a platform: scan first, and keep the cheap exit when the scan has nothing to say.
     if (declared.isEmpty() && configuration.allDependencies.isNotEmpty()) {
-      return CurrentCoordinates(emptyMap(), emptyMap(), emptySet())
+      val platformSources = if (checkConstraints) getPlatformSources(configuration, emptySet()) else emptyList()
+      if (platformSources.isEmpty()) {
+        return CurrentCoordinates(emptyMap(), emptyMap(), emptySet())
+      }
+      return CurrentCoordinates(
+        platformSources.associateBy { it.key },
+        emptyMap(),
+        platformSources = platformSources,
+      )
     }
 
     // https://github.com/ben-manes/gradle-versions-plugin/issues/231

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -755,6 +755,63 @@ final class CompositeBuildSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Reports the platform imported by the only dependency the build declares'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        include 'app', 'platform-a'
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('platform-a')
+    testProjectDir.newFile('platform-a/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation platform(project(':platform-a'))
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '-DoutputFormatter=json', '--no-parallel')
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    def boms = jsonReport.outdated.dependencies.findAll { it.name == 'external-bom' }
+    boms.size() == 1
+    boms[0].platformProjects == [':platform-a']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
   def 'Skips the platform scan when the imported platform cannot be resolved'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 import groovy.json.JsonSlurper
+import groovy.xml.XmlParser
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -478,6 +479,7 @@ final class CompositeBuildSpec extends Specification {
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    result.output.contains('imported by the platform :platforms')
     // A platform that only a library's metadata drags in is not one the build imported.
     !result.output.contains('com.example:dragged-bom')
   }
@@ -611,6 +613,146 @@ final class CompositeBuildSpec extends Specification {
     // (issue #231), so the platform project's edges are absent and its import is out of the walk's
     // reach. Widening that boundary trades the declared current version for the resolved one.
     !result.output.contains('com.example:external-bom')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Names the importing platform in the file reports'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:platforms:1.0')
+          implementation 'com.google.inject:guice'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    includedBuild(
+      'platforms',
+      """
+        plugins {
+          id 'java-platform'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+
+        javaPlatform {
+          allowDependencies()
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates', '-DoutputFormatter=json,xml')
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def xmlReport = new XmlParser()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.xml'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    def bom = jsonReport.outdated.dependencies.find { it.name == 'external-bom' }
+    bom.platformProjects == [':platforms']
+    def guice = jsonReport.outdated.dependencies.find { it.name == 'guice' }
+    !guice.containsKey('platformProjects')
+    def bomElement = xmlReport.outdated.dependencies.outdatedDependency.find {
+      it.name.text() == 'external-bom'
+    }
+    bomElement.platformProjects.platformProject*.text() == [':platforms']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Aggregates the importers of a platform that two projects import'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        include 'app', 'lib', 'platform-a', 'platform-b'
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    ['platform-a', 'platform-b'].each { name ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          javaPlatform {
+            allowDependencies()
+          }
+          dependencies {
+            api platform('com.example:external-bom:1.0')
+          }
+        """.stripIndent()
+    }
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation platform(project(':platform-b'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '-DoutputFormatter=json', '--no-parallel')
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    def boms = jsonReport.outdated.dependencies.findAll { it.name == 'external-bom' }
+    boms.size() == 1
+    boms[0].platformProjects == [':platform-a', ':platform-b']
   }
 
   def 'Reuses the configuration cache across runs of a composite build'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -812,6 +812,63 @@ final class CompositeBuildSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Reports the platform an enforcedPlatform declaration imports'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        include 'app', 'platform-a'
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('platform-a')
+    testProjectDir.newFile('platform-a/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation enforcedPlatform(project(':platform-a'))
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '-DoutputFormatter=json', '--no-parallel')
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    def boms = jsonReport.outdated.dependencies.findAll { it.name == 'external-bom' }
+    boms.size() == 1
+    boms[0].platformProjects == [':platform-a']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
   def 'Skips the platform scan when the imported platform cannot be resolved'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
@@ -869,6 +926,9 @@ final class CompositeBuildSpec extends Specification {
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
     !result.output.contains('missing-bom')
+    // Disabling the platform scan entirely would also satisfy the absence above, so pin that the
+    // configuration's other dependency still made it into the report.
+    result.output.contains('com.google.inject:guice')
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -872,6 +872,137 @@ final class CompositeBuildSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Withholds the platform mark when another project declares the imported platform'() {
+    given:
+    testProjectDir.newFile('settings.gradle') <<
+      """
+        include 'app', 'lib', 'platform-b'
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('platform-b')
+    testProjectDir.newFile('platform-b/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation platform(project(':platform-b'))
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates', '-DoutputFormatter=json', '--info', '--no-parallel')
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    def boms = jsonReport.outdated.dependencies.findAll { it.name == 'external-bom' }
+    boms.size() == 1
+    !boms[0].containsKey('platformProjects')
+    !result.output.contains('imported by the platform')
+    result.output.contains(
+      "A project outside com.example:external-bom's platform importers declares it, " +
+        'so the platform mark is withheld')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Names the platform importer by its build-tree path when the report runs in an included build'() {
+    given: 'the composite runs the aggregating task from inside the included build, not the root'
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') << ''
+    testProjectDir.newFolder('child')
+    testProjectDir.newFile('child/settings.gradle') <<
+      """
+        rootProject.name = 'child'
+        include 'app', 'platform-a'
+      """.stripIndent()
+    testProjectDir.newFile('child/build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'io.github.ben-manes.versions'
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('child/platform-a')
+    testProjectDir.newFile('child/platform-a/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('child/app')
+    testProjectDir.newFile('child/app/build.gradle') <<
+      """
+        apply plugin: 'java-library'
+        dependencies {
+          implementation platform(project(':platform-a'))
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(':child:dependencyUpdates')
+
+    then: 'the importer is named by its path in the build tree, not platform-a\'s path within child'
+    result.task(':child:dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    result.output.contains('imported by the platform :child:platform-a\n')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
   def 'Merges an imported platform with the version a library elsewhere drags in'() {
     given: 'a library drags a newer version of the same bom the platform states'
     testProjectDir.newFile('settings.gradle') << "include 'platform-a'"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -552,7 +552,8 @@ final class CompositeBuildSpec extends Specification {
     !result.output.contains('com.example:external-bom [1.0 -> 2.0]')
   }
 
-  def 'Reaches no imported platform when every declared module is versioned'() {
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Reports the imported platform when every declared module is versioned'() {
     given:
     testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
     testProjectDir.newFile('build.gradle') <<
@@ -608,11 +609,9 @@ final class CompositeBuildSpec extends Specification {
 
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    result.output.contains('imported by the platform :platforms\n')
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
-    // A build whose declarations all carry versions resolves the current copy non-transitively
-    // (issue #231), so the platform project's edges are absent and its import is out of the walk's
-    // reach. Widening that boundary trades the declared current version for the resolved one.
-    !result.output.contains('com.example:external-bom')
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
@@ -753,6 +752,120 @@ final class CompositeBuildSpec extends Specification {
     def boms = jsonReport.outdated.dependencies.findAll { it.name == 'external-bom' }
     boms.size() == 1
     boms[0].platformProjects == [':platform-a', ':platform-b']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Skips the platform scan when the imported platform cannot be resolved'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'platforms'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:platforms:1.0')
+          implementation 'com.google.inject:guice'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    includedBuild(
+      'platforms',
+      """
+        plugins {
+          id 'java-platform'
+        }
+
+        group = 'com.example'
+        version = '1.0'
+
+        javaPlatform {
+          allowDependencies()
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api platform('com.example:missing-bom:9.9')
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains('missing-bom')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Merges an imported platform with the version a library elsewhere drags in'() {
+    given: 'a library drags a newer version of the same bom the platform states'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation 'com.example:external-bom-consumer:1.0'
+          implementation 'com.google.inject:guice'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('platform-a')
+    testProjectDir.newFile('platform-a/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then: 'one merged row names the platform-stated version and the update the drag cannot hide'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    result.output.contains('imported by the platform :platform-a\n')
+    !result.output.contains('com.example:external-bom:2.0')
   }
 
   def 'Reuses the configuration cache across runs of a composite build'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -479,7 +479,7 @@ final class CompositeBuildSpec extends Specification {
     then:
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('com.example:external-bom [1.0 -> 2.0]')
-    result.output.contains('imported by the platform :platforms')
+    result.output.contains('imported by the platform :platforms\n')
     // A platform that only a library's metadata drags in is not one the build imported.
     !result.output.contains('com.example:dragged-bom')
   }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -542,4 +542,196 @@ final class ConstraintsSpec extends Specification {
     !result.output.contains('log4j-core')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Names the platform project that imports an external platform'() {
+    given: 'a chain of same-build platform projects, only the last of which imports the BOM'
+    testProjectDir.newFile('settings.gradle') << "include 'app-platform', 'test-platform'\n"
+    testProjectDir.newFolder('app-platform')
+    testProjectDir.newFile('app-platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        dependencies {
+          api platform(project(':test-platform'))
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('test-platform')
+    testProjectDir.newFile('test-platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':app-platform'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the direct importer is named, not the first hop of the chain'
+    result.output.contains('imported by the platform :test-platform\n')
+    !result.output.contains('the platform :app-platform')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Names every platform project that imports the same external platform'() {
+    given: 'two platform projects, each importing the same external bom'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b'\n"
+    ['platform-a', 'platform-b'].each { name ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          javaPlatform {
+            allowDependencies()
+          }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            api platform('com.example:external-bom:1.0')
+          }
+        """.stripIndent()
+    }
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation platform(project(':platform-b'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then:
+    result.output.contains('imported by the platforms :platform-a, :platform-b\n')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Leaves out a platform project that consumes the module as a library'() {
+    given: 'one platform project importing a pom module as a platform and another as a library'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b', 'platform-c'\n"
+    ['platform-a': "api 'com.google.guava:guava:15.0'",
+     'platform-b': "api platform('com.google.guava:guava:15.0')",
+     'platform-c': "api platform('com.example:external-bom:1.0')"].each { name, declaration ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          javaPlatform {
+            allowDependencies()
+          }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            $declaration
+          }
+        """.stripIndent()
+    }
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation platform(project(':platform-b'))
+          implementation platform(project(':platform-c'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'only the project whose own edge resolved the platform variant is named'
+    result.output.contains('imported by the platform :platform-b\n')
+    !result.output.contains('imported by the platform :platform-a')
+    !result.output.contains('imported by the platforms')
+    result.output.contains('imported by the platform :platform-c\n')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -795,4 +795,69 @@ final class ConstraintsSpec extends Specification {
     result.output.contains('imported by the platform :platform-c\n')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Does not skip the configuration when the platform scan throws under failOnVersionConflict'() {
+    given: 'two platform projects import the same bom at different versions, conflicting transitively'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b'\n"
+    ['platform-a': '1.0', 'platform-b': '2.0'].each { name, version ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          javaPlatform {
+            allowDependencies()
+          }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            api platform('com.example:external-bom:$version')
+          }
+        """.stripIndent()
+    }
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.all {
+          resolutionStrategy.failOnVersionConflict()
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation platform(project(':platform-b'))
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates', '--info')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the platform scan throwing does not sink the whole configuration'
+    result.output.contains('Failed to resolve the platforms declared by')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !result.output.contains('Skipping configuration')
+  }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -732,7 +732,7 @@ final class ConstraintsSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
-  def 'Leaves out a platform project that consumes the module as a library'() {
+  def 'Withholds the mark of a module a platform project declares as a library'() {
     given: 'one platform project importing a pom module as a platform and another as a library'
     testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b', 'platform-c'\n"
     ['platform-a': "api 'com.google.guava:guava:15.0'",
@@ -788,8 +788,8 @@ final class ConstraintsSpec extends Specification {
       .withPluginClasspath()
       .build()
 
-    then: 'only the project whose own edge resolved the platform variant is named'
-    result.output.contains('imported by the platform :platform-b\n')
+    then: 'platform-a declares guava as a library, outranking the mark platform-b would otherwise carry'
+    !result.output.contains('imported by the platform :platform-b')
     !result.output.contains('imported by the platform :platform-a')
     !result.output.contains('imported by the platforms')
     result.output.contains('imported by the platform :platform-c\n')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -671,6 +671,67 @@ final class ConstraintsSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'Names every importer of an external platform they bound differently'() {
+    given: 'two platform projects importing the same bom, one of them stating a preference'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b'\n"
+    ['platform-a': "api platform('com.example:external-bom:1.0')",
+     'platform-b': "api(platform('com.example:external-bom')) { version { prefer '1.0' } }"].each { name, declaration ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          javaPlatform {
+            allowDependencies()
+          }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            $declaration
+          }
+        """.stripIndent()
+    }
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation platform(project(':platform-b'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the differing bound costs neither project its place in the attribution'
+    result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    result.output.contains('imported by the platforms :platform-a, :platform-b\n')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
   def 'Leaves out a platform project that consumes the module as a library'() {
     given: 'one platform project importing a pom module as a platform and another as a library'
     testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b', 'platform-c'\n"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
@@ -37,7 +37,7 @@ final class ConstructorVisibilitySpec extends Specification {
       .findAll { it.parameters.size() > 4 }
 
     expect:
-    constraintCarrying.size() == 2
+    constraintCarrying.size() == 3
     constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -842,7 +842,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     when:
     def result = run()
 
-    then: 'the strictly-only edge is harvested rather than dropped as stating nothing'
+    then: 'the strictly-only edge is kept rather than dropped as stating nothing'
     result.output.contains('PROBE guice platformConstraints=[2.0]')
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -97,6 +97,37 @@ final class PartialResultSpec extends Specification {
     decoded.statuses[0].unresolved.userReason == null
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'The platform projects survive the round trip'() {
+    given:
+    def status = new PartialStatus('com.example', 'external-bom', '1.0', null, '1.0', null, null,
+      false, [], ':app', [':platforms'])
+    def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [status], [])
+
+    when:
+    def json = result.toJson()
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    json.contains('"platformProjects":[":platforms"]')
+    decoded.statuses[0].platformProjects == [':platforms']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1070')
+  def 'A partial without the platform projects key reads as none'() {
+    given:
+    def json = '''
+      {"formatVersion":1,"projectPath":":","statuses":[{"group":"com.google.guava",
+      "name":"guava","declaredVersion":"1.0","latestVersion":"1.0"}],"buildscriptStatuses":[]}
+      '''.stripIndent()
+
+    when:
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    decoded.statuses[0].platformProjects == []
+  }
+
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
   def 'A partial without the skipped key reads as none skipped'() {
     given:

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom-consumer/1.0/external-bom-consumer-1.0.module
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom-consumer/1.0/external-bom-consumer-1.0.module
@@ -1,0 +1,57 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "external-bom-consumer",
+    "version": "1.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "external-bom",
+          "version": {
+            "requires": "2.0"
+          },
+          "attributes": {
+            "org.gradle.category": "platform"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "com.example",
+          "module": "external-bom",
+          "version": {
+            "requires": "2.0"
+          },
+          "attributes": {
+            "org.gradle.category": "platform"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom-consumer/1.0/external-bom-consumer-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/external-bom-consumer/1.0/external-bom-consumer-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>external-bom-consumer</artifactId>
+  <version>1.0</version>
+  <name>Example Library Dragging a Newer External Platform</name>
+</project>


### PR DESCRIPTION
This PR names the platform projects an external platform was imported through. #1071 reports the external platform a build consumes through its own platform projects, but the row named only the BOM that moved. Before:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

After:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
     imported by the platform :platforms
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

Two shortcuts in the resolution the plugin walked also hid a build's platform projects from it entirely. A build whose declarations all carry versions resolves that copy non-transitively, since #231 asked for it, so the platform projects expose no edges and nothing is reported at all. Before:

```
The following dependencies have later milestone versions:
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

After:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
     imported by the platform :platforms
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

And a configuration whose only entry is a platform project returns before resolving at all, so its import went unattributed. Before:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
```

After:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
     imported by the platform :platform-a
```

The plugin now reads a copy holding only the configuration's platform declarations, resolved transitively, so #231's copy and the declared versions it reports are untouched. A configuration declaring no platform resolves nothing extra. One that declares a platform resolves a second time, so a `beforeResolve` hook on it runs once more than it did. The plugin also tests the variant each edge resolved rather than whether the selected component has a platform variant, so a platform project that consumes a module as an ordinary library is no longer named as importing it.

Reporting more of these rows reaches a coordinate the build both declares and imports through a platform. It now reports the declaration, since that is the version the build can edit. Below, `:platform-a` declares guava as an ordinary library while `:platform-b` imports it as a platform, so guava is left unnamed and only the BOM `:platform-c` imports is attributed. Before:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
 - com.google.guava:guava [15.0 -> 16.0-rc1]
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

After:

```
The following dependencies have later milestone versions:
 - com.example:external-bom [1.0 -> 2.0]
     imported by the platform :platform-c
 - com.google.guava:guava [15.0 -> 16.0-rc1]
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

This finishes the attribution #1071 started, for #1070.

