### PR TITLE
Name the platform behind a module's bound (fixes #1080)

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,19 @@ a BOM a library brings along as resolution metadata is not one the build
 imported, so neither is reported. The BOM's entry names every platform project
 that imports it, by build tree path.
 
+The platform behind a constrained module's version is included in that module's
+own entry either way, as `constrained by the platform :platform` for a platform
+project included in the build and `constrained by the platform group:artifact`
+for a BOM, whose own version appears on its own entry. A platform is only
+included when its constraint is the same version the entry shows: if something
+else in the build required a higher version and won out, changing the platform
+would not change that version. The coordinate to bump appears on the entry where
+the version is held (see
+[Respecting declared bounds](#respecting-declared-bounds)). This line does not
+depend on `checkConstraints`. The same names are present in the JSON and XML
+reports as `constrainedBy`, beside the `platformProjects` importers of a
+platform's own entry.
+
 <details open>
 <summary>Kotlin</summary>
 
@@ -933,10 +946,19 @@ instead:
 ```text
 The following dependencies are using the latest milestone version:
  - org.apache.logging.log4j:log4j-core:2.16.0
+     constrained by the platform org.apache.logging.log4j:log4j-bom
 
 The following dependencies have later milestone versions:
  - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.17.0]
 ```
+
+The platform behind the bound appears on an attribution line under the bounded
+entry, so the reason for the version shows up next to it. A platform project
+appears as its build tree path, `constrained by the platform :platform`, and a
+BOM as its group and module; where several platforms bound the module, all of
+them follow `constrained by the platforms`. A constraint written as a range is
+left out, since a range alone is not enough to tell which version was
+selected.
 
 The platform keeps its own report line, so the upgrade that is actually
 available, bumping the BOM, still shows. A build that centralizes its platforms

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/AbstractReporter.kt
@@ -62,10 +62,12 @@ private fun configurationsLabel(names: List<String>): String {
 /**
  * Returns the line describing where the dependency's version came from, or null for a declared one.
  *
- * A row is handed at most one attribution, ranked by how directly the build can edit the version
- * reported: a declaration outranks the platform mark, which outranks the plugin's. Which of the
- * first two a row carries is decided where the statuses are assembled, so the branch order below
- * settles only what the mark displaces, which is the configurations a declaration named.
+ * A row gets at most one attribution line, and the order below picks which, nearest cause first:
+ * the platform a row was imported through comes before the platform that constrains it, then a
+ * declaration, then the plugin that contributed it. Only a module declared without a version can be
+ * constrained by a platform, so a declaration displaced by that line would point at a spot in the
+ * build script with no version in it. Which line a row qualifies for is decided where the statuses
+ * are assembled; the order below settles only which one wins.
  */
 internal fun sourceLabel(dependency: Dependency): String? {
   val projects = dependency.projects
@@ -74,6 +76,12 @@ internal fun sourceLabel(dependency: Dependency): String? {
     val noun = if (platforms.size == 1) "platform" else "platforms"
     val imported = "imported by the $noun ${projectsLabel(platforms)}"
     return if (projects == null) imported else "$imported in ${projectsLabel(projects)}"
+  }
+  val bounding = dependency.constrainedBy?.takeIf { it.isNotEmpty() }
+  if (bounding != null) {
+    val noun = if (bounding.size == 1) "platform" else "platforms"
+    val constrained = "constrained by the $noun ${projectsLabel(bounding)}"
+    return if (projects == null) constrained else "$constrained in ${projectsLabel(projects)}"
   }
   val names = dependency.configurations?.takeIf { it.isNotEmpty() }
   if (dependency.contributed != true) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
@@ -244,6 +244,13 @@ class XmlReporter(
         appendTextChild(document, element, "platformProject", platformProject)
       }
     }
+    dependency.constrainedBy?.let { constrainedBy ->
+      val element = document.createElement("constrainedBy")
+      dependencyElement.appendChild(element)
+      for (constraint in constrainedBy) {
+        appendTextChild(document, element, "constraint", constraint)
+      }
+    }
     return dependencyElement
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
@@ -28,6 +28,11 @@ open class Dependency
     @AbsentWhenNull open val configurations: List<String>? = null,
     /** The platform projects the build imports this dependency through, by build tree path. */
     @AbsentWhenNull open val platformProjects: List<String>? = null,
+    /**
+     * The platforms that constrain this dependency's version, a project one by its build tree path
+     * and an external one by its module coordinate.
+     */
+    @AbsentWhenNull open val constrainedBy: List<String>? = null,
   ) : Comparable<Dependency> {
     override fun compareTo(other: Dependency): Int {
       return compareValuesBy(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
@@ -13,4 +13,26 @@ data class DependencyLatest
     @AbsentWhenNull override val contributed: Boolean? = null,
     @AbsentWhenNull override val configurations: List<String>? = null,
     @AbsentWhenNull override val platformProjects: List<String>? = null,
-  ) : Dependency()
+    @AbsentWhenNull override val constrainedBy: List<String>? = null,
+  ) : Dependency() {
+    /**
+     * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
+     * constraining platforms moved it past ten parameters.
+     */
+    fun copy(
+      group: String? = this.group,
+      name: String? = this.name,
+      version: String? = this.version,
+      projectUrl: String? = this.projectUrl,
+      userReason: String? = this.userReason,
+      latest: String = this.latest,
+      projects: List<String>? = this.projects,
+      contributed: Boolean? = this.contributed,
+      configurations: List<String>? = this.configurations,
+      platformProjects: List<String>? = this.platformProjects,
+    ): DependencyLatest =
+      copy(
+        group, name, version, projectUrl, userReason, latest, projects, contributed,
+        configurations, platformProjects, constrainedBy,
+      )
+  }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
@@ -13,4 +13,26 @@ data class DependencyOutdated
     @AbsentWhenNull override val contributed: Boolean? = null,
     @AbsentWhenNull override val configurations: List<String>? = null,
     @AbsentWhenNull override val platformProjects: List<String>? = null,
-  ) : Dependency()
+    @AbsentWhenNull override val constrainedBy: List<String>? = null,
+  ) : Dependency() {
+    /**
+     * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
+     * constraining platforms moved it past ten parameters.
+     */
+    fun copy(
+      group: String? = this.group,
+      name: String? = this.name,
+      version: String? = this.version,
+      projectUrl: String? = this.projectUrl,
+      userReason: String? = this.userReason,
+      available: VersionAvailable = this.available,
+      projects: List<String>? = this.projects,
+      contributed: Boolean? = this.contributed,
+      configurations: List<String>? = this.configurations,
+      platformProjects: List<String>? = this.platformProjects,
+    ): DependencyOutdated =
+      copy(
+        group, name, version, projectUrl, userReason, available, projects, contributed,
+        configurations, platformProjects, constrainedBy,
+      )
+  }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyUnresolved.kt
@@ -13,4 +13,26 @@ data class DependencyUnresolved
     @AbsentWhenNull override val contributed: Boolean? = null,
     @AbsentWhenNull override val configurations: List<String>? = null,
     @AbsentWhenNull override val platformProjects: List<String>? = null,
-  ) : Dependency()
+    @AbsentWhenNull override val constrainedBy: List<String>? = null,
+  ) : Dependency() {
+    /**
+     * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
+     * constraining platforms moved it past ten parameters.
+     */
+    fun copy(
+      group: String? = this.group,
+      name: String? = this.name,
+      version: String? = this.version,
+      projectUrl: String? = this.projectUrl,
+      userReason: String? = this.userReason,
+      reason: String = this.reason,
+      projects: List<String>? = this.projects,
+      contributed: Boolean? = this.contributed,
+      configurations: List<String>? = this.configurations,
+      platformProjects: List<String>? = this.platformProjects,
+    ): DependencyUnresolved =
+      copy(
+        group, name, version, projectUrl, userReason, reason, projects, contributed,
+        configurations, platformProjects, constrainedBy,
+      )
+  }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -56,6 +56,13 @@ class Coordinate(
   var platformProjects: List<String> = emptyList()
     private set
 
+  /**
+   * The platforms whose constraint is the version reported, empty otherwise. A platform project
+   * appears as its build tree path and an external one as its group and module.
+   */
+  var constrainedBy: List<String> = emptyList()
+    private set
+
   val key: Key
     get() = Key(groupId, artifactId)
 
@@ -102,6 +109,27 @@ class Coordinate(
     this.platformProjects = platformProjects
   }
 
+  internal constructor(
+    groupId: String?,
+    artifactId: String?,
+    version: String?,
+    userReason: String?,
+    versionConstraint: VersionConstraint?,
+    platformVersionConstraints: List<VersionConstraint>,
+    platformProjects: List<String>,
+    constrainedBy: List<String>,
+  ) : this(
+    groupId,
+    artifactId,
+    version,
+    userReason,
+    versionConstraint,
+    platformVersionConstraints,
+    platformProjects,
+  ) {
+    this.constrainedBy = constrainedBy
+  }
+
   override fun toString(): String {
     return "$groupId:$artifactId:$version"
   }
@@ -130,6 +158,22 @@ class Coordinate(
     result = 31 * result + artifactId.hashCode()
     result = 31 * result + version.hashCode()
     return result
+  }
+
+  /** A version constraint from a consumed platform, paired with the platform it came from. */
+  internal data class PlatformConstraint(
+    val source: String,
+    val constraint: VersionConstraint,
+  ) {
+    /**
+     * Whether the constraint is exactly this version. A range never matches, even when the range is
+     * what picked the version, so a platform constraining by a range is left out rather than
+     * included on a guess.
+     */
+    fun matches(version: String): Boolean =
+      constraint.strictVersion == version ||
+        constraint.requiredVersion == version ||
+        constraint.preferredVersion == version
   }
 
   data class Key(val groupId: String, val artifactId: String) : Comparable<Key> {
@@ -203,21 +247,31 @@ class Coordinate(
       )
     }
 
-    /** As above, additionally attaching the constraints a consumed platform states for it. */
+    /**
+     * As above, additionally attaching the constraints the consumed platforms place on it.
+     *
+     * Only a platform whose constraint is the resolved version is included, since one that lost out
+     * to a higher requirement is not why the row shows that version. Every collected constraint is
+     * still kept for the selection rules, where the question is whether any consumed platform rules
+     * out a candidate, not which one produced the current version.
+     */
     internal fun from(
       identifier: ModuleVersionIdentifier,
       declared: Map<Key, Coordinate?>,
-      platformConstraints: Map<Key, List<VersionConstraint>>,
+      platformConstraints: Map<Key, List<PlatformConstraint>>,
     ): Coordinate {
       val key = Key(identifier.group, identifier.name)
       val declaration = declared[key]
+      val constraints = platformConstraints[key].orEmpty()
       return Coordinate(
         identifier.group,
         identifier.name,
         identifier.version,
         declaration?.userReason,
         declaration?.versionConstraint,
-        platformConstraints[key].orEmpty(),
+        constraints.map { it.constraint },
+        emptyList(),
+        constraints.filter { it.matches(identifier.version) }.map { it.source }.distinct().sorted(),
       )
     }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -86,6 +86,7 @@ class DependencyStatus {
       contributed,
       configurations,
       platformProjects = coordinate.platformProjects,
+      constrainedBy = coordinate.constrainedBy,
     )
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -50,6 +50,7 @@ import java.util.TreeSet
  * @property skipped The configurations whose dependencies could not be inspected because applying the
  * resolutionStrategy to them failed.
  * @property platformProjectsByCoordinate The platform projects the build imports each coordinate through.
+ * @property constrainedByCoordinate The platforms that constrain each coordinate's version.
  *
  */
 class DependencyUpdatesReporter(
@@ -75,6 +76,7 @@ class DependencyUpdatesReporter(
   val configurationsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
   val skipped: List<SkippedConfiguration> = emptyList(),
   val platformProjectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
+  val constrainedByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
 ) {
   @Deprecated("Use the constructor that includes the skipped configurations.")
   constructor(
@@ -275,6 +277,7 @@ class DependencyUpdatesReporter(
       contributed = contributedFlag(coordinate),
       configurations = configurationsByCoordinate[coordinate],
       platformProjects = platformProjectsByCoordinate[coordinate],
+      constrainedBy = constrainedByCoordinate[coordinate],
     )
   }
 
@@ -293,6 +296,7 @@ class DependencyUpdatesReporter(
       contributed = contributedFlag(coordinate),
       configurations = configurationsByCoordinate[coordinate],
       platformProjects = platformProjectsByCoordinate[coordinate],
+      constrainedBy = constrainedByCoordinate[coordinate],
     )
   }
 
@@ -319,6 +323,7 @@ class DependencyUpdatesReporter(
       contributed = contributedFlag(declared),
       configurations = configurationsByCoordinate[declared],
       platformProjects = platformProjectsByCoordinate[declared],
+      constrainedBy = constrainedByCoordinate[declared],
     )
   }
 
@@ -344,6 +349,7 @@ class DependencyUpdatesReporter(
       contributed = contributedFlag(coordinate),
       configurations = configurationsByCoordinate[coordinate],
       platformProjects = platformProjectsByCoordinate[coordinate],
+      constrainedBy = constrainedByCoordinate[coordinate],
     )
   }
 
@@ -426,6 +432,7 @@ fun reporterFor(
   val contributedCoordinates = contributedCoordinates(statuses, logger)
   val configurationsByCoordinate = namedConfigurations(statuses, contributedCoordinates)
   val platformProjectsByCoordinate = platformProjectsByCoordinate(statuses, logger)
+  val constrainedByCoordinate = constrainedByCoordinate(statuses, logger)
   val unresolved = statuses.mapNotNullTo(mutableSetOf()) { it.unresolved }
   val projectUrls =
     statuses
@@ -451,7 +458,7 @@ fun reporterFor(
     reportfileName, currentVersions, latestVersions, upToDateVersions, downgradeVersions,
     upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
     gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate, contributedCoordinates,
-    configurationsByCoordinate, skipped, platformProjectsByCoordinate,
+    configurationsByCoordinate, skipped, platformProjectsByCoordinate, constrainedByCoordinate,
   )
 }
 
@@ -519,7 +526,8 @@ private fun platformProjectsByCoordinate(
       }
       val declaringStatuses =
         group.filter {
-          it.platformProjects.isEmpty() && !it.contributed && it.projectPath !in importers
+          it.platformProjects.isEmpty() && it.constrainedBy.isEmpty() && !it.contributed &&
+            it.projectPath !in importers
         }
       if (declaringStatuses.isNotEmpty()) {
         val declaringPaths = declaringStatuses.mapNotNull { it.projectPath }.distinct().sorted()
@@ -530,6 +538,38 @@ private fun platformProjectsByCoordinate(
         return@mapNotNull null
       }
       coordinate to importers.toList().sorted()
+    }.toMap()
+
+/**
+ * Returns the platforms that constrain each coordinate's version, unioned across projects. Left out
+ * when another project declares the coordinate with no platform constraining it there, since that
+ * declaration is the row to edit and the mark would point somewhere else.
+ */
+private fun constrainedByCoordinate(
+  statuses: List<PartialStatus>,
+  logger: Logger,
+): Map<Coordinate, List<String>> =
+  statuses
+    .groupBy { it.coordinate }
+    .mapNotNull { (coordinate, group) ->
+      val sources = group.flatMap { it.constrainedBy }.toSet()
+      if (sources.isEmpty()) {
+        return@mapNotNull null
+      }
+      val declaringStatuses =
+        group.filter {
+          it.constrainedBy.isEmpty() && it.platformProjects.isEmpty() && !it.contributed &&
+            it.projectPath !in sources
+        }
+      if (declaringStatuses.isNotEmpty()) {
+        val declaringPaths = declaringStatuses.mapNotNull { it.projectPath }.distinct().sorted()
+        logger.info(
+          "A project outside ${coordinate.groupId}:${coordinate.artifactId}'s bounding platforms " +
+            "declares it, so the platform mark is withheld: ${declaringPaths.joinToString(", ")}",
+        )
+        return@mapNotNull null
+      }
+      coordinate to sources.toList().sorted()
     }.toMap()
 
 /** Returns the projects behind each version of a key whose declared versions diverge. */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -26,6 +26,11 @@ data class PartialStatus
      * would replace the shipped arities that end there.
      */
     val platformProjects: List<String> = emptyList(),
+    /**
+     * The platforms that constrain this module's version, a project one by its build tree path and
+     * an external one by its module coordinate. Trails for the same reason as [platformProjects].
+     */
+    val constrainedBy: List<String> = emptyList(),
   ) {
     val coordinate: Coordinate
       get() = Coordinate(group, name, declaredVersion, userReason)
@@ -51,7 +56,29 @@ data class PartialStatus
     ): PartialStatus =
       copy(
         group, name, declaredVersion, userReason, latestVersion, projectUrl, unresolved, contributed,
-        configurations, projectPath, platformProjects,
+        configurations, projectPath, platformProjects, constrainedBy,
+      )
+
+    /**
+     * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
+     * constraining platforms moved it past eleven parameters.
+     */
+    fun copy(
+      group: String = this.group,
+      name: String = this.name,
+      declaredVersion: String = this.declaredVersion,
+      userReason: String? = this.userReason,
+      latestVersion: String = this.latestVersion,
+      projectUrl: String? = this.projectUrl,
+      unresolved: UnresolvedInfo? = this.unresolved,
+      contributed: Boolean = this.contributed,
+      configurations: List<String> = this.configurations,
+      projectPath: String? = this.projectPath,
+      platformProjects: List<String> = this.platformProjects,
+    ): PartialStatus =
+      copy(
+        group, name, declaredVersion, userReason, latestVersion, projectUrl, unresolved, contributed,
+        configurations, projectPath, platformProjects, constrainedBy,
       )
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.repositories.ArtifactRepository
@@ -692,7 +693,7 @@ class Resolver(
 
   /**
    * Returns the version constraints the consumed platforms state for each module that is declared
-   * with no version of its own, keyed by that module.
+   * with no version of its own, keyed by that module and paired with the platform each came from.
    *
    * Only a constraint edge whose source resolved as a platform qualifies. One from the resolution
    * root is the consumer's own `constraints {}` block, which is editable and thus governed by
@@ -705,8 +706,8 @@ class Resolver(
   private fun getPlatformConstraints(
     result: ResolutionResult,
     versionedKeys: Set<Coordinate.Key>,
-  ): Map<Coordinate.Key, List<VersionConstraint>> {
-    val constraints = hashMapOf<Coordinate.Key, MutableList<VersionConstraint>>()
+  ): Map<Coordinate.Key, List<Coordinate.PlatformConstraint>> {
+    val constraints = hashMapOf<Coordinate.Key, MutableList<Coordinate.PlatformConstraint>>()
     for (dependency in result.allDependencies) {
       if (dependency !is ResolvedDependencyResult || !dependency.isConstraint) {
         continue
@@ -731,7 +732,17 @@ class Resolver(
       if (key in versionedKeys) {
         continue
       }
-      constraints.getOrPut(key) { mutableListOf() }.add(versionConstraint)
+      val source =
+        when (val from = dependency.from.id) {
+          is ProjectComponentIdentifier -> from.buildTreePath
+          // Printed without its version: the one here is the resolved version rather than any
+          // declared in the build, and the platform's own row in the same report already shows it.
+          is ModuleComponentIdentifier -> "${from.group}:${from.module}"
+          else -> continue
+        }
+      constraints
+        .getOrPut(key) { mutableListOf() }
+        .add(Coordinate.PlatformConstraint(source, versionConstraint))
     }
     return constraints
   }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -2,6 +2,8 @@ package com.github.benmanes.gradle.versions
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+import groovy.json.JsonSlurper
+import groovy.xml.XmlParser
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -859,5 +861,515 @@ final class ConstraintsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
     !result.output.contains('Skipping configuration')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Names the platform project that constrains a versionless module'() {
+    given: 'a platform project stating the bound in its own constraints block'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the constrained row names the platform project holding the version'
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('constrained by the platform :platform')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Names the external platform that constrains a versionless module'() {
+    given: 'an external bom imported directly, bounding a versionless declaration'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:external-bom:1.0')
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the bom is named by its module, the version left to its own row'
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('constrained by the platform com.example:external-bom\n')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Names every platform that states the same bound'() {
+    given: 'two platform projects constraining the same module to the same version'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a', 'platform-b'\n"
+    ['platform-a', 'platform-b'].each { name ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            constraints {
+              api 'com.google.inject:guice:2.0'
+            }
+          }
+        """.stripIndent()
+    }
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation platform(project(':platform-b'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'both platforms are named, pluralized'
+    result.output.contains('constrained by the platforms :platform-a, :platform-b')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Marks the imported platform and the module it constrains on separate rows'() {
+    given: 'a platform project importing the bom that bounds a versionless declaration'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the bom row carries the importer and the constrained row carries the bom'
+    result.output.contains('imported by the platform :platform')
+    result.output.contains('constrained by the platform com.example:external-bom\n')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Withholds the bound when a project outside the platforms declares the module'() {
+    given: 'one project bounded by the platform and a sibling declaring the same version itself'
+    testProjectDir.newFile('settings.gradle') << "include 'app', 'other', 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('app')
+    testProjectDir.newFile('app/build.gradle') <<
+      """
+        dependencies {
+          implementation platform(project(':platform'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('other')
+    testProjectDir.newFile('other/build.gradle') <<
+      """
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        subprojects {
+          if (name != 'platform') {
+            apply plugin: 'java-library'
+          }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates', '--info', '--no-parallel')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the declaring project outranks the mark, which is reported rather than dropped silently'
+    !result.output.contains('constrained by the platform')
+    result.output.contains(
+      "A project outside com.google.inject:guice's bounding platforms declares it, " +
+        'so the platform mark is withheld: :other')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Names the constraining platform in the file reports'() {
+    given: 'an external bom bounding a versionless declaration'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform('com.example:external-bom:1.0')
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates', '-DoutputFormatter=json,xml')
+      .withPluginClasspath()
+      .build()
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def xmlReport = new XmlParser()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.xml'))
+
+    then: 'the machine readable reports carry the bound, and only where one was stated'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    def guice = jsonReport.outdated.dependencies.find { it.name == 'guice' }
+    guice.constrainedBy == ['com.example:external-bom']
+    def bom = jsonReport.outdated.dependencies.find { it.name == 'external-bom' }
+    !bom.containsKey('constrainedBy')
+    def guiceElement = xmlReport.outdated.dependencies.outdatedDependency.find {
+      it.name.text() == 'guice'
+    }
+    guiceElement.constrainedBy.constraint*.text() == ['com.example:external-bom']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Names only the platform whose stated bound is the version reported'() {
+    given: 'two platforms stating different bounds, of which the higher wins'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-low', 'platform-high'\n"
+    ['platform-low': '2.0', 'platform-high': '3.0'].each { name, version ->
+      testProjectDir.newFolder(name)
+      testProjectDir.newFile("$name/build.gradle") <<
+        """
+          plugins { id 'java-platform' }
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            constraints {
+              api 'com.google.inject:guice:${version}'
+            }
+          }
+        """.stripIndent()
+    }
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-low'))
+          implementation platform(project(':platform-high'))
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the platform whose bound lost is not named'
+    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
+    result.output.contains('constrained by the platform :platform-high')
+    !result.output.contains('constrained by the platforms')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Withholds the platform mark when a drag pushes the version past the bound'() {
+    given: 'a platform bound a transitive requirement overrides'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'\n"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform'))
+          implementation 'com.example:guice-consumer:1.0'
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the row keeps the true declaration rather than a bound that did not decide it'
+    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
+    !result.output.contains('constrained by the platform')
+    result.output.contains('declared in root project')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'Names an external platform by its module, not the version it resolved to'() {
+    given: 'an imported bom a library drags to a release the build never names'
+    testProjectDir.newFile('settings.gradle') << "include 'platform-a'\n"
+    testProjectDir.newFolder('platform-a')
+    testProjectDir.newFile('platform-a/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        javaPlatform {
+          allowDependencies()
+        }
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+        dependencies {
+          api platform('com.example:external-bom:1.0')
+        }
+      """.stripIndent()
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation platform(project(':platform-a'))
+          implementation 'com.example:external-bom-consumer:1.0'
+          implementation 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .withPluginClasspath()
+      .build()
+
+    then: 'the mark names a coordinate the bom row already carries the version for'
+    result.output.contains('com.example:external-bom [1.0 -> 2.0]')
+    result.output.contains('constrained by the platform com.example:external-bom\n')
+    !result.output.contains('com.example:external-bom:2.0')
+    result.task(':dependencyUpdates').outcome == SUCCESS
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
@@ -37,7 +37,7 @@ final class ConstructorVisibilitySpec extends Specification {
       .findAll { it.parameters.size() > 4 }
 
     expect:
-    constraintCarrying.size() == 3
+    constraintCarrying.size() == 4
     constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -128,6 +128,37 @@ final class PartialResultSpec extends Specification {
     decoded.statuses[0].platformProjects == []
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'The constraining platforms survive the round trip'() {
+    given:
+    def status = new PartialStatus('com.google.inject', 'guice', '2.0', null, '3.1', null, null,
+      false, [], ':app', [], [':platform', 'com.example:external-bom:1.0'])
+    def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [status], [])
+
+    when:
+    def json = result.toJson()
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    json.contains('"constrainedBy":[":platform","com.example:external-bom:1.0"]')
+    decoded.statuses[0].constrainedBy == [':platform', 'com.example:external-bom:1.0']
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
+  def 'A partial without the constraining platforms key reads as none'() {
+    given:
+    def json = '''
+      {"formatVersion":1,"projectPath":":","statuses":[{"group":"com.google.guava",
+      "name":"guava","declaredVersion":"1.0","latestVersion":"1.0"}],"buildscriptStatuses":[]}
+      '''.stripIndent()
+
+    when:
+    def decoded = PartialResult.fromJson(json)
+
+    then:
+    decoded.statuses[0].constrainedBy == []
+  }
+
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')
   def 'A partial without the skipped key reads as none skipped'() {
     given:


### PR DESCRIPTION
Fixes #1080.

This PR includes the platform behind a constrained module's version in that module's own entry, for a `java-platform` project in the build and for an imported BOM alike.

Before:

```text
The following dependencies have later milestone versions:
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
```

After:

```text
The following dependencies have later milestone versions:
 - com.google.inject:guice [2.0 -> 3.1]
     https://code.google.com/p/google-guice/
     constrained by the platform :platform
```

The platform is only printed when its constraint is the same version the report shows. If something else in the build required a higher version and won out, changing the platform wouldn't change that version, so nothing is printed. A constraint written as a range is never printed either, because I couldn't tell whether the range is what picked the version.

A matching `constrainedBy` is present in the JSON and XML reports.
