### PR TITLE
Split an entry merged from different latest versions (fixes #1082)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1723,6 +1723,25 @@ The following dependencies have later milestone versions:
      declared in root project
 ```
 
+One declared version can also have different latest versions across the
+projects, which happens when a platform bounds the module in some of them and
+not in others. Each of those latest versions is shown on an entry of its own,
+with the projects included the same way, rather than the newest of them being
+shown for every project:
+
+```text
+The following dependencies are using the latest milestone version:
+ - com.google.inject:guice:2.0
+     constrained by the platform :platform in root project
+
+The following dependencies have later milestone versions:
+ - com.google.inject:guice [2.0 -> 7.0.0]
+     declared in :platform
+```
+
+So a coordinate's group and name can appear on two entries, and in two sections
+of one report. The projects behind each entry are what separate them.
+
 The plain text and HTML reports name the first five projects and count the rest
 (`declared in :app, :lib, ... and 60 others`). The JSON and XML reports always
 carry the complete list, so use one of them when a tool needs every project.
@@ -2107,6 +2126,30 @@ build is on and work upward. Each section migrates to the version covered by
 the section above it, and the topmost migrates to the current release.
 *Important*s are must-dos, *Tip*s are actions you should or may want to take,
 and *Note*s are things worth knowing that need no action.
+
+### v0.61.0
+
+In the next release, a coordinate whose one declared version has different
+latest versions across the aggregated projects is shown on one entry per latest
+version, where the entries were merged into the newest of them before:
+
+> [!IMPORTANT]
+> - A coordinate's group and name can now appear on two entries of one report,
+>   and in two of its sections. The projects behind each entry are included in
+>   `projects` (see [Multi-project builds](#multi-project-builds)), which is what
+>   separates them. A tool that keys the entries by group and name alone has to
+>   key them by the projects as well.
+
+> [!NOTE]
+> - A module that a platform bounds in one project and not in another is now up
+>   to date in the bounded project and outdated in the other, rather than
+>   outdated in both. The merged entry showed the bounded project an upgrade
+>   that is not available in it.
+> - A split entry can include an attribution line that the merged one left out.
+>   The line is left out when a project outside the platform's importers
+>   declares the module. Once the entries are split, that project is on an entry
+>   of its own, so the line is printed again (see [Report
+>   format](#report-format)).
 
 ### v0.60.0
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/Dependency.kt
@@ -34,6 +34,15 @@ open class Dependency
      */
     @AbsentWhenNull open val constrainedBy: List<String>? = null,
   ) : Comparable<Dependency> {
+    /**
+     * The projects are compared last, so that two rows of one declared version with different
+     * latest versions are ordered apart. The report groups are sorted sets, and rows that compare
+     * as equal are dropped from them rather than printed. The subclasses that carry a latest
+     * version compare that too, so that the ordering does not rest on the projects alone.
+     *
+     * The separator is one a build tree path cannot contain, so that ["a", "b"] and ["a,b"] are not
+     * compared as one list.
+     */
     override fun compareTo(other: Dependency): Int {
       return compareValuesBy(
         this,
@@ -43,6 +52,7 @@ open class Dependency
         { it.version },
         { it.projectUrl },
         { it.userReason },
+        { it.projects?.joinToString("\u0000") },
       )
     }
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyLatest.kt
@@ -16,6 +16,19 @@ data class DependencyLatest
     @AbsentWhenNull override val constrainedBy: List<String>? = null,
   ) : Dependency() {
     /**
+     * The latest version is compared after everything the base class compares, so that two entries
+     * of one declared version are ordered apart by the version that separates them rather than only
+     * by the projects behind them.
+     */
+    override fun compareTo(other: Dependency): Int {
+      val byDependency = super.compareTo(other)
+      if (byDependency != 0 || other !is DependencyLatest) {
+        return byDependency
+      }
+      return compareValuesBy(this, other, { it.latest })
+    }
+
+    /**
      * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
      * constraining platforms moved it past ten parameters.
      */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/DependencyOutdated.kt
@@ -16,6 +16,25 @@ data class DependencyOutdated
     @AbsentWhenNull override val constrainedBy: List<String>? = null,
   ) : Dependency() {
     /**
+     * The available version is compared after everything the base class compares, so that two
+     * entries of one declared version are ordered apart by the version that separates them rather
+     * than only by the projects behind them.
+     */
+    override fun compareTo(other: Dependency): Int {
+      val byDependency = super.compareTo(other)
+      if (byDependency != 0 || other !is DependencyOutdated) {
+        return byDependency
+      }
+      return compareValuesBy(
+        this,
+        other,
+        { it.available.release },
+        { it.available.milestone },
+        { it.available.integration },
+      )
+    }
+
+    /**
      * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
      * constraining platforms moved it past ten parameters.
      */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -66,6 +66,32 @@ class Coordinate(
   val key: Key
     get() = Key(groupId, artifactId)
 
+  /**
+   * The latest version found for this row, set only when one declared version of the module has
+   * different latest versions across the aggregated projects. Null on every other row, so that an
+   * unsplit row has the identity it always had.
+   *
+   * It arrives through a constructor rather than a setter, because it is part of [equals],
+   * [hashCode] and [compareTo], and a coordinate already held in a hash map or a sorted set is
+   * unreachable and mis-ordered if its identity changes underneath the collection.
+   */
+  internal var divergentLatest: String? = null
+    private set
+
+  /**
+   * As above, additionally carrying the latest version that separates this row from the other rows
+   * of its declared version. Distinct from the constructor below by the type of its last parameter.
+   */
+  internal constructor(
+    groupId: String?,
+    artifactId: String?,
+    version: String?,
+    userReason: String?,
+    divergentLatest: String?,
+  ) : this(groupId, artifactId, version, userReason) {
+    this.divergentLatest = divergentLatest
+  }
+
   internal constructor(
     groupId: String?,
     artifactId: String?,
@@ -134,12 +160,16 @@ class Coordinate(
     return "$groupId:$artifactId:$version"
   }
 
+  // The split marker is compared as a string rather than as a version. It is here to keep the
+  // ordering consistent with equals, which a sorted set requires, and the order it imposes among
+  // the rows of one declared version is never the order the report prints them in.
   override fun compareTo(other: Coordinate): Int {
     return compareValuesBy(
       this,
       other,
       { it.key },
       { it.version },
+      { it.divergentLatest.orEmpty() },
     )
   }
 
@@ -150,6 +180,7 @@ class Coordinate(
     if (groupId != other.groupId) return false
     if (artifactId != other.artifactId) return false
     if (version != other.version) return false
+    if (divergentLatest != other.divergentLatest) return false
     return true
   }
 
@@ -157,6 +188,7 @@ class Coordinate(
     var result = groupId.hashCode()
     result = 31 * result + artifactId.hashCode()
     result = 31 * result + version.hashCode()
+    result = 31 * result + divergentLatest.hashCode()
     return result
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -427,15 +427,16 @@ fun reporterFor(
   gradleReleaseChannel: String,
   skipped: List<SkippedConfiguration> = emptyList(),
 ): DependencyUpdatesReporter {
-  val versions = VersionMapping(logger, statuses)
-  val projectsByCoordinate = divergentProjects(statuses)
-  val contributedCoordinates = contributedCoordinates(statuses, logger)
-  val configurationsByCoordinate = namedConfigurations(statuses, contributedCoordinates)
-  val platformProjectsByCoordinate = platformProjectsByCoordinate(statuses, logger)
-  val constrainedByCoordinate = constrainedByCoordinate(statuses, logger)
-  val unresolved = statuses.mapNotNullTo(mutableSetOf()) { it.unresolved }
+  val split = markDivergentlyResolved(statuses)
+  val versions = VersionMapping(logger, split)
+  val projectsByCoordinate = divergentProjects(split)
+  val contributedCoordinates = contributedCoordinates(split, logger)
+  val configurationsByCoordinate = namedConfigurations(split, contributedCoordinates)
+  val platformProjectsByCoordinate = platformProjectsByCoordinate(split, logger)
+  val constrainedByCoordinate = constrainedByCoordinate(split, logger)
+  val unresolved = split.mapNotNullTo(mutableSetOf()) { it.unresolved }
   val projectUrls =
-    statuses
+    split
       .filter { !it.projectUrl.isNullOrEmpty() }
       .associateBy(
         { mapOf("group" to it.group, "name" to it.name) },
@@ -467,19 +468,29 @@ private fun contributedCoordinates(
   statuses: List<PartialStatus>,
   logger: Logger,
 ): Set<Coordinate> {
-  val byCoordinate = statuses.groupBy { it.coordinate }
+  // Grouped by the declaration rather than by the coordinate, so that splitting a row does not put
+  // two disagreeing projects into groups that are each unanimous on their own.
+  val byDeclaration = statuses.groupBy { Declaration(it) }
   // Withheld when the projects disagree, which is a mark that cannot be trusted rather than one
   // that does not apply, so it is reported instead of passing as an ordinary unmarked entry.
-  for ((coordinate, group) in byCoordinate) {
+  for ((declaration, group) in byDeclaration) {
     if (group.any { it.contributed } && !group.all { it.contributed }) {
       logger.info(
-        "The projects disagree on whether a plugin contributed ${coordinate.groupId}:" +
-          "${coordinate.artifactId}, so it is left unmarked: contributed by " +
+        "The projects disagree on whether a plugin contributed ${declaration.group}:" +
+          "${declaration.name}, so it is left unmarked: contributed by " +
           group.filter { it.contributed }.mapNotNull { it.projectPath }.sorted().joinToString(", "),
       )
     }
   }
-  return byCoordinate.filterValues { group -> group.all { it.contributed } }.keys
+  return byDeclaration
+    .filterValues { group -> group.all { it.contributed } }
+    .values
+    .flatMapTo(mutableSetOf()) { group -> group.map { it.coordinate } }
+}
+
+/** One module at one declared version, which a split leaves as several coordinates. */
+private data class Declaration(val group: String, val name: String, val declaredVersion: String) {
+  constructor(status: PartialStatus) : this(status.group, status.name, status.declaredVersion)
 }
 
 /**
@@ -498,13 +509,18 @@ private fun namedConfigurations(
   contributed: Set<Coordinate>,
 ): Map<Coordinate, List<String>> =
   statuses
-    .groupBy { it.coordinate }
-    .filter { (coordinate, group) ->
-      coordinate in contributed ||
+    // Grouped by the declaration for the same reason as the marks above: whether a configuration
+    // was named in every observing project is a question about all of them, which a split narrows.
+    .groupBy { Declaration(it) }
+    .filter { (_, group) ->
+      group.any { it.coordinate in contributed } ||
         group.groupBy { it.projectPath }.values.all { project ->
           project.any { it.configurations.isNotEmpty() }
         }
-    }.mapValues { (_, group) -> group.flatMap { it.configurations }.distinct().sorted() }
+    }.flatMap { (_, group) ->
+      val names = group.flatMap { it.configurations }.distinct().sorted()
+      group.map { it.coordinate to names }
+    }.toMap()
     .filterValues { it.isNotEmpty() }
 
 /**
@@ -572,7 +588,54 @@ private fun constrainedByCoordinate(
       coordinate to sources.toList().sorted()
     }.toMap()
 
-/** Returns the projects behind each version of a key whose declared versions diverge. */
+/**
+ * Returns the statuses with the rows of a declared version whose latest version differs across the
+ * aggregated projects marked, so that each of those latest versions is printed on a row of its own.
+ *
+ * The marked rows are returned as copies and the argument is left alone, since this is a published
+ * entry point and the statuses a caller passes are its own.
+ *
+ * Merged, the newest of them is printed for every project, including the ones it is not available
+ * in. That is what happens when a platform bounds the module in one project and not in another.
+ * The rows are separated by the latest version rather than by the project, so that the projects
+ * which agree are printed on one row and included on it together, exactly as they are when their
+ * declared versions differ.
+ *
+ * An unresolved row has no latest version to be split by and is left whole. So is a coordinate with
+ * two latest versions inside a single project, which happens when its buildscript and its
+ * dependencies use different repositories. Splitting that one would leave two rows with the same
+ * project name, which the report's sorted groups compare as equal and drop, so this exclusion is
+ * what keeps a split row's projects disjoint.
+ */
+private fun markDivergentlyResolved(statuses: List<PartialStatus>): List<PartialStatus> {
+  if (statuses.mapTo(mutableSetOf()) { it.projectPath }.size <= 1) {
+    return statuses
+  }
+  val marked =
+    statuses
+      .withIndex()
+      .filter { (_, status) -> status.projectPath != null && status.unresolved == null }
+      .groupBy { (_, status) -> status.coordinate }
+      .values
+      .filter { statusesOfVersion ->
+        val byProject = statusesOfVersion.groupBy { (_, status) -> status.projectPath }
+        byProject.size > 1 &&
+          byProject.values.all { rows -> rows.mapTo(mutableSetOf()) { it.value.latestVersion }.size == 1 } &&
+          byProject.values.mapTo(mutableSetOf()) { it.first().value.latestVersion }.size > 1
+      }.flatten()
+      .mapTo(mutableSetOf()) { it.index }
+  if (marked.isEmpty()) {
+    return statuses
+  }
+  return statuses.mapIndexed { index, status ->
+    if (index in marked) status.copy(splitByLatest = true) else status
+  }
+}
+
+/**
+ * Returns the projects behind each version of a key whose declared versions differ, or whose one
+ * declared version has different latest versions across the projects.
+ */
 private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, List<String>> {
   if (statuses.mapTo(mutableSetOf()) { it.projectPath }.size <= 1) {
     return emptyMap()
@@ -581,8 +644,10 @@ private fun divergentProjects(statuses: List<PartialStatus>): Map<Coordinate, Li
     .filter { it.projectPath != null }
     .groupBy { Coordinate.Key(it.group, it.name) }
     .values
-    .filter { statusesOfKey -> statusesOfKey.mapTo(mutableSetOf()) { it.declaredVersion }.size > 1 }
-    .flatten()
+    .filter { statusesOfKey ->
+      statusesOfKey.mapTo(mutableSetOf()) { it.declaredVersion }.size > 1 ||
+        statusesOfKey.any { it.splitByLatest }
+    }.flatten()
     .groupBy({ it.coordinate }, { it.projectPath!! })
     .mapValues { (_, paths) -> paths.distinct().sorted() }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -31,12 +31,23 @@ data class PartialStatus
      * an external one by its module coordinate. Trails for the same reason as [platformProjects].
      */
     val constrainedBy: List<String> = emptyList(),
+    /**
+     * Whether one declared version of this module has different latest versions across the
+     * aggregated projects, which is settled by the aggregating task rather than by the producer.
+     * Trails for the same reason as [platformProjects], and transient because it is a fact about
+     * the whole report rather than about the project whose producer wrote this status.
+     */
+    @Transient val splitByLatest: Boolean = false,
   ) {
     val coordinate: Coordinate
-      get() = Coordinate(group, name, declaredVersion, userReason)
+      get() = Coordinate(group, name, declaredVersion, userReason, divergentLatest)
 
     val latestCoordinate: Coordinate
-      get() = Coordinate(group, name, latestVersion, userReason)
+      get() = Coordinate(group, name, latestVersion, userReason, divergentLatest)
+
+    /** The version that separates a split row from the other rows of its declared version. */
+    private val divergentLatest: String?
+      get() = latestVersion.takeIf { splitByLatest }
 
     /**
      * Keeps the `copy` a release shipped callable, which the generated one no longer is now that
@@ -56,7 +67,7 @@ data class PartialStatus
     ): PartialStatus =
       copy(
         group, name, declaredVersion, userReason, latestVersion, projectUrl, unresolved, contributed,
-        configurations, projectPath, platformProjects, constrainedBy,
+        configurations, projectPath, platformProjects, constrainedBy, splitByLatest,
       )
 
     /**
@@ -78,7 +89,30 @@ data class PartialStatus
     ): PartialStatus =
       copy(
         group, name, declaredVersion, userReason, latestVersion, projectUrl, unresolved, contributed,
-        configurations, projectPath, platformProjects, constrainedBy,
+        configurations, projectPath, platformProjects, constrainedBy, splitByLatest,
+      )
+
+    /**
+     * Keeps the `copy` a release shipped callable. The generated one no longer is, now that the
+     * split marker moved it past twelve parameters.
+     */
+    fun copy(
+      group: String = this.group,
+      name: String = this.name,
+      declaredVersion: String = this.declaredVersion,
+      userReason: String? = this.userReason,
+      latestVersion: String = this.latestVersion,
+      projectUrl: String? = this.projectUrl,
+      unresolved: UnresolvedInfo? = this.unresolved,
+      contributed: Boolean = this.contributed,
+      configurations: List<String> = this.configurations,
+      projectPath: String? = this.projectPath,
+      platformProjects: List<String> = this.platformProjects,
+      constrainedBy: List<String> = this.constrainedBy,
+    ): PartialStatus =
+      copy(
+        group, name, declaredVersion, userReason, latestVersion, projectUrl, unresolved, contributed,
+        configurations, projectPath, platformProjects, constrainedBy, splitByLatest,
       )
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstructorVisibilitySpec.groovy
@@ -31,14 +31,14 @@ final class ConstructorVisibilitySpec extends Specification {
     constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
   }
 
-  def 'The constraint-carrying Coordinate constructors are internal'() {
-    given:
-    def constraintCarrying = JvmClassMappingKt.getKotlinClass(Coordinate).constructors
+  def 'The constructors beyond the released arity are internal'() {
+    given: 'the four constraint-carrying overloads, plus the one carrying the split marker'
+    def beyondReleased = JvmClassMappingKt.getKotlinClass(Coordinate).constructors
       .findAll { it.parameters.size() > 4 }
 
     expect:
-    constraintCarrying.size() == 4
-    constraintCarrying.every { it.visibility == KVisibility.INTERNAL }
+    beyondReleased.size() == 5
+    beyondReleased.every { it.visibility == KVisibility.INTERNAL }
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/801')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DivergentVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DivergentVersionsSpec.groovy
@@ -16,6 +16,8 @@ import spock.lang.Specification
  */
 @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
 final class DivergentVersionsSpec extends Specification {
+  private static final String GUICE_URL = '     https://code.google.com/p/google-guice/'
+
   @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
   private String mavenRepoUrl
 
@@ -267,6 +269,225 @@ final class DivergentVersionsSpec extends Specification {
     xmlReport.outdated.dependencies.outdatedDependency[0].projects.project*.text() == [':']
     htmlReport.contains('declared in root project')
     htmlReport.contains('declared in :app')
+  }
+
+  /**
+   * Writes an aggregated build with one declared version of a module across its projects, each
+   * rejecting different candidates for it, so that a different latest version is found in each.
+   */
+  private void writeSplitBuild(Map<String, String> rejectByProject, String declaredVersion = '2.0') {
+    def subprojects = rejectByProject.keySet().findAll { it != ':' }
+    testProjectDir.newFile('settings.gradle') <<
+      (subprojects.empty ? '' : "include ${subprojects.collect { "'$it'" }.join(', ')}")
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          apply plugin: 'java'
+          apply plugin: 'io.github.ben-manes.versions'
+
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+
+          dependencies {
+            implementation 'com.google.inject:guice:$declaredVersion'
+          }
+
+          dependencyUpdates {
+            checkForGradleUpdate = false
+          }
+        }
+
+        dependencyUpdates {
+          rejectVersionIf { ${rejectByProject[':']} }
+        }
+      """.stripIndent()
+    rejectByProject.each { project, reject ->
+      if (project == ':') {
+        return
+      }
+      testProjectDir.newFolder(project)
+      testProjectDir.newFile("$project/build.gradle") <<
+        """
+          dependencyUpdates {
+            rejectVersionIf { $reject }
+          }
+        """.stripIndent()
+    }
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+  def 'Splits the rows of one declared version with different latest versions'() {
+    given:
+    writeSplitBuild([':': 'false', 'app': "it.candidate.version == '3.1'"])
+
+    when:
+    def result = run([':dependencyUpdates', '--no-parallel'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.inject:guice [2.0 -> 3.0]${nl}$GUICE_URL${nl}     declared in :app")
+    result.output.contains(
+      " - com.google.inject:guice [2.0 -> 3.1]${nl}$GUICE_URL${nl}     declared in root project")
+  }
+
+  def 'Splits the rows into their own sections when only one is outdated'() {
+    given:
+    writeSplitBuild([':': 'false', 'app': "it.candidate.version != '2.0'"])
+
+    when:
+    def result = run(
+      [':dependencyUpdates', '-DoutputFormatter=plain,json,xml', '--no-parallel'])
+    def nl = System.lineSeparator()
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+    def xmlReport = new XmlParser()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.xml'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(" - com.google.inject:guice:2.0${nl}     declared in :app")
+    result.output.contains(
+      " - com.google.inject:guice [2.0 -> 3.1]${nl}$GUICE_URL${nl}     declared in root project")
+    jsonReport.current.dependencies*.projects == [[':app']]
+    jsonReport.outdated.dependencies*.projects == [[':']]
+    jsonReport.outdated.dependencies[0].available.milestone == '3.1'
+    xmlReport.current.dependencies.dependency[0].projects.project*.text() == [':app']
+    xmlReport.outdated.dependencies.outdatedDependency[0].projects.project*.text() == [':']
+  }
+
+  def 'Includes both projects on one row when their latest versions match'() {
+    given:
+    writeSplitBuild(
+      [':': "it.candidate.version == '3.1'", 'app': 'false', 'lib': 'false'])
+
+    when:
+    def result = run([':dependencyUpdates', '--no-parallel'])
+    def nl = System.lineSeparator()
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.inject:guice [2.0 -> 3.0]${nl}$GUICE_URL${nl}     declared in root project")
+    result.output.contains(
+      " - com.google.inject:guice [2.0 -> 3.1]${nl}$GUICE_URL${nl}     declared in :app, :lib")
+    result.output.count('com.google.inject:guice') == 2
+  }
+
+  def 'Keeps every row of a three way split in one section'() {
+    given:
+    writeSplitBuild([
+      ':': 'false',
+      'app': "it.candidate.version == '3.1'",
+      'lib': "it.candidate.version in ['3.1', '3.0']",
+    ])
+
+    when:
+    def result = run([':dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.count('com.google.inject:guice') == 3
+    jsonReport.outdated.dependencies*.available.milestone.sort() == ['2.2', '3.0', '3.1']
+    jsonReport.outdated.dependencies*.projects.flatten().sort() == [':', ':app', ':lib']
+  }
+
+  def 'Splits the rows in the exceeded section'() {
+    given:
+    writeSplitBuild(
+      [':': "it.candidate.version == '3.1'", 'app': "it.candidate.version in ['3.1', '3.0']"],
+      '3.1')
+
+    when:
+    def result = run([':dependencyUpdates', '-DoutputFormatter=plain,json', '--no-parallel'])
+    def jsonReport = new JsonSlurper()
+      .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
+
+    then: 'each row shows the latest version found for it, not one shared across the key'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains('[3.1 <- 3.0]')
+    result.output.contains('[3.1 <- 2.2]')
+    jsonReport.exceeded.dependencies*.latest.sort() == ['2.2', '3.0']
+  }
+
+  def 'Splits the row a platform bounds in its consumer and not in the platform itself'() {
+    given: 'the platform declares the constraint that bounds the module in the project consuming it'
+    testProjectDir.newFile('settings.gradle') << "include 'platform'"
+    testProjectDir.newFolder('platform')
+    testProjectDir.newFile('platform/build.gradle') <<
+      """
+        plugins { id 'java-platform' }
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        subprojects {
+          apply plugin: 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+
+          tasks.dependencyUpdates {
+            checkConstraints = true
+            checkForGradleUpdate = false
+            rejectVersionIf { !it.satisfiesDeclaredBound }
+          }
+        }
+
+        dependencies {
+          api platform(project(':platform'))
+          api 'com.google.inject:guice'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run([':dependencyUpdates', '--no-parallel'])
+    def nl = System.lineSeparator()
+
+    then: 'the bounded row stays up to date rather than taking the platform row\'s upgrade'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      " - com.google.inject:guice:2.0${nl}" +
+        "     constrained by the platform :platform in root project")
+    result.output.contains(" - com.google.inject:guice [2.0 -> 3.1]${nl}$GUICE_URL")
+  }
+
+  def 'Keeps one row and no project names when the latest versions match'() {
+    given:
+    writeSplitBuild([':': 'false', 'app': 'false'])
+
+    when:
+    def result = run([':dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(' - com.google.inject:guice [2.0 -> 3.1]')
+    result.output.count('com.google.inject:guice') == 1
+    !result.output.contains('declared in')
   }
 
   def 'Names no project in a single project report'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PartialResultSpec.groovy
@@ -46,6 +46,18 @@ final class PartialResultSpec extends Specification {
     decoded.statuses[0].projectPath == null
   }
 
+  def 'The split marker is not serialized'() {
+    given:
+    def result = new PartialResult(PartialResult.FORMAT_VERSION, ':', [status('guava', '1.0')], [])
+
+    when:
+    def json = result.toJson()
+
+    then:
+    !json.contains('splitByLatest')
+    PartialResult.fromJson(json) == result
+  }
+
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1028')
   def 'A partial without the contributed key reads as declared'() {
     given:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SplitDivergentRowsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SplitDivergentRowsSpec.groovy
@@ -1,0 +1,87 @@
+package com.github.benmanes.gradle.versions
+
+import static com.github.benmanes.gradle.versions.updates.DependencyUpdatesReporterKt.reporterFor
+import static com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
+
+import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.github.benmanes.gradle.versions.updates.OutputFormatterArgument
+import com.github.benmanes.gradle.versions.updates.PartialStatus
+import com.github.benmanes.gradle.versions.updates.UnresolvedInfo
+import org.gradle.api.Action
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A specification for the conditions under which a coordinate the aggregated projects resolved
+ * differently is split, exercised against the reporter rather than through a build.
+ */
+@Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1032')
+final class SplitDivergentRowsSpec extends Specification {
+  private static PartialStatus status(String projectPath, String latestVersion,
+      List<String> constrainedBy = [], UnresolvedInfo unresolved = null) {
+    return new PartialStatus('com.google.inject', 'guice', '2.0', null, latestVersion, null,
+      unresolved, false, [], projectPath, [], constrainedBy)
+  }
+
+  private static Result reportOf(List<PartialStatus> statuses) {
+    def project = ProjectBuilder.builder().build()
+    def captured = null
+    def outputFormatter = [execute: { result -> captured = result }] as Action<Result>
+    reporterFor(statuses, project.path, project.logger, 'milestone',
+      new OutputFormatterArgument.CustomAction(outputFormatter), project.file('build'), 'report',
+      false, 'https://services.gradle.org/versions/', RELEASE_CANDIDATE.id).write()
+    return captured
+  }
+
+  def 'Leaves a version one project resolved two ways merged'() {
+    given: 'the root resolves the module twice, as its buildscript and its dependencies do'
+    def statuses = [
+      status(':', '3.1'),
+      status(':', '3.0'),
+      status(':app', '2.2'),
+    ]
+
+    when:
+    def result = reportOf(statuses)
+
+    then: 'splitting would leave two entries naming the root, so nothing is split'
+    result.outdated.dependencies.size() == 1
+    result.outdated.dependencies.first().available.milestone == '3.1'
+    result.outdated.dependencies.first().projects == null
+  }
+
+  def 'Splits a version each project resolved one way'() {
+    given:
+    def statuses = [
+      status(':', '3.1'),
+      status(':app', '3.0'),
+    ]
+
+    when:
+    def result = reportOf(statuses)
+
+    then:
+    result.outdated.dependencies.size() == 2
+    result.outdated.dependencies*.available.milestone.sort() == ['3.0', '3.1']
+    result.outdated.dependencies*.projects.flatten().sort() == [':', ':app']
+  }
+
+  def 'Leaves an unresolved row out of the split so it keeps its platform mark'() {
+    given: 'a third project fails to resolve the module a platform constrains for it'
+    def statuses = [
+      status(':', '3.1'),
+      status(':app', '3.0'),
+      status(':lib', 'none', ['com.example:bom'],
+        new UnresolvedInfo('com.google.inject', 'guice', '2.0', 'Could not resolve', '2.0')),
+    ]
+
+    when:
+    def result = reportOf(statuses)
+
+    then: 'the resolved rows split, and the unresolved row is still found by its own coordinate'
+    result.outdated.dependencies.size() == 2
+    result.unresolved.dependencies.size() == 1
+    result.unresolved.dependencies.first().constrainedBy == ['com.example:bom']
+  }
+}


### PR DESCRIPTION
An aggregated coordinate declared at one version in several projects was merged into a single entry, even when a different latest version was found for each. The newest was shown, including for the projects it isn't available in. Now each of those latest versions is shown on an entry of its own, with the projects behind it included, the same way a divergent declared version already is.

On the reproducer in #1082, before:

```text
The following dependencies have later milestone versions:
 - com.google.inject:guice [2.0 -> 7.0.0]
     https://github.com/google/guice
     constrained by the platform :platform
```

After:

```text
The following dependencies are using the latest milestone version:
 - com.google.inject:guice:2.0
     constrained by the platform :platform in root project

The following dependencies have later milestone versions:
 - com.google.inject:guice [2.0 -> 7.0.0]
     https://github.com/google/guice
     declared in :platform
```

Two entries of one declared version are ordered apart by their latest version and by the projects behind them, since the report groups are sorted sets and two entries that compare as equal are dropped rather than printed. Two latest versions can be found for one coordinate inside a single project, when its buildscript and its dependencies use different repositories. That case is left merged: splitting it would leave two entries with the same project name.

Fixes #1082
