### PR TITLE
Accept the task settings as command line options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,30 @@ How a pull request lands:
 - Beyond that, match the file you are editing: Kotlin sources carry no
   license header, comments are rare and explain only what the code cannot,
   and a README snippet is added in both Kotlin and Groovy.
+- Add a command line option, with `@Option`, to every task property a build
+  author sets to configure the report or where it is written, so that a single
+  run can change it without an edit to the build script. A property configured
+  with a predicate has no option, since no command line can express the logic.
+  The system properties named after `revision`, `gradleReleaseChannel`,
+  `outputFormatter`, `outputDir` and `reportfileName` predate the options and
+  remain for compatibility; where more than one is set, the option is the one
+  that applies, and no system property is added for a new property.
+- Gradle applies a command line option by calling a setter on the task. Have
+  that setter assign a separate field, not the field assigned from a build
+  script, and read them in order: the command line value first, then the system
+  property if there is one, then the configured value. Assigning the same field
+  fails three ways. A system property is read before the configured value, so
+  the value from `-Drevision` would be used instead of the one from
+  `--revision`. The configured value is read from the nearest project up the
+  hierarchy where one is set, so an option given on the root task would not
+  apply to a subproject that sets its own. And a `taskGraph.whenReady` or
+  `doFirst` block assigns the property after Gradle has applied the options,
+  overwriting the value from the command line.
+- An option applies only within the build it is invoked in. In a report that
+  merges an included build, that build's rows are resolved from that build's own
+  configuration, so they are unaffected by an option; document any behavior that
+  differs between the two in the README's [Composite
+  builds](README.md#composite-builds) section.
 - A change that an existing build has to react to, such as different report
   output or a behavior that is now off by default, also gets a subsection in
   the README's

--- a/README.md
+++ b/README.md
@@ -365,16 +365,18 @@ then return to the configured behavior on the next run:
 | `--gradle-release-channel` | `gradleReleaseChannel` | `release-candidate` |
 | `--gradle-versions-api-base-url` | `gradleVersionsApiBaseUrl` | `https://services.gradle.org/versions/` |
 | `--output-formatter` | `outputFormatter` | `text` |
-| `--output-dir` | `outputDir` | `build/dependencyUpdates` |
+| `--output-dir` | `outputDir` | `<buildDirectory>/dependencyUpdates` |
 | `--report-file-name` | `reportfileName` | `report` |
 | `--[no-]clean-legacy-partials` | `cleanLegacyPartials` | `false` |
 
 `--[no-]` marks the options that take no argument, so
 `--no-check-for-gradle-update` turns off a check that is enabled in the build
-script. A relative `--output-dir` is resolved against the project directory,
-which is where its default sits. Every option, its description, and the values
-`--revision` and `--gradle-release-channel` accept are printed by `gradle help
---task dependencyUpdates`.
+script. The `--output-dir` default is `dependencyUpdates` under the project's
+build directory, so `build/dependencyUpdates` in a standard layout; both it and
+a relative value given on the command line are resolved against the project
+directory. Every option, its description, and the values `--revision` and
+`--gradle-release-channel` accept are printed by `gradle help --task
+dependencyUpdates`.
 
 `--clean-legacy-partials` is a one-off cleanup rather than a report setting;
 see [v0.61.0](#v0610) for when to run it.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
   - [Cache invalidation](#cache-invalidation)
   - [Task properties](#task-properties)
     - [A recommended configuration](#a-recommended-configuration)
+    - [Every property](#every-property)
     - [Command line options](#command-line-options)
     - [What the report checks](#what-the-report-checks)
       - [Configuration filter](#configuration-filter)
@@ -34,6 +35,9 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
       - [Gradle versions API base URL](#gradle-versions-api-base-url)
     - [Report output](#report-output)
       - [Optional parameters](#optional-parameters)
+        - [`checkForGradleUpdate`](#checkforgradleupdate)
+        - [`outputDir`](#outputdir)
+        - [`reportfileName`](#reportfilename)
       - [Report format](#report-format)
   - [Multi-project builds](#multi-project-builds)
     - [Shared task settings](#shared-task-settings)
@@ -345,45 +349,46 @@ the build. A top-level `fun isNonStable(version: String)` compiles to the same
 JVM signature, so keeping both fails the build with a platform declaration
 clash.
 
+#### Every property
+
+Each property below configures the report or where it is written, and links to
+the section that describes it. A property taking a predicate or a closure has no
+command line option, since no command line can express the logic.
+
+| Property | Values | Default | Option |
+| --- | --- | --- | --- |
+| [`revision`](#revisions) | `release`, `milestone`, `integration` | `milestone` | `--revision` |
+| [`gradleReleaseChannel`](#gradle-release-channel) | `current`, `release-candidate`, `nightly` | `release-candidate` | `--gradle-release-channel` |
+| [`checkForGradleUpdate`](#checkforgradleupdate) | `true`, `false` | `true` | `--[no-]check-for-gradle-update` |
+| [`checkConstraints`](#constraints) | `true`, `false` | `false` | `--[no-]check-constraints` |
+| [`checkBuildEnvironmentConstraints`](#constraints) | `true`, `false` | `false` | `--[no-]check-build-environment-constraints` |
+| [`filterConfigurations`](#filterconfigurations) | a `Spec<Configuration>` | every configuration | |
+| [`filterDeclaredConfigurations`](#filterdeclaredconfigurations) | a `Spec<String>` | every name | |
+| [`rejectVersionIf`](#filtering-unstable-versions) | a predicate over the candidate | nothing rejected | |
+| [`outputFormatter`](#report-format) | `text`, `json`, `xml`, `html`, a comma separated list of those, or a `Reporter` | `text` | `--output-formatter` |
+| [`outputDir`](#outputdir) | a directory path | `<buildDirectory>/dependencyUpdates` | `--output-dir` |
+| [`reportfileName`](#reportfilename) | a file name, without the extension | `report` | `--report-file-name` |
+| [`gradleVersionsApiBaseUrl`](#gradle-versions-api-base-url) | a URL | `https://services.gradle.org/versions/` | `--gradle-versions-api-base-url` |
+| [`cleanLegacyPartials`](#v0610) | `true`, `false` | `false` | `--[no-]clean-legacy-partials` |
+
+The [`resolutionStrategy`](#filtering-unstable-versions) block is configured
+rather than set to a value, so it is absent from the table above.
+
 #### Command line options
 
-Every task property that configures the report or where it is written is also a
-command line option, so a single run can change what the report contains
-without an edit to the build script. Use one to see what a check leaves out,
-then return to the configured behavior on the next run:
+Each option in the table above changes a property for a single run, without an
+edit to the build script. Use one to see what a check leaves out, then return to
+the configured behavior on the next run:
 
 ```bash
 ./gradlew dependencyUpdates --no-check-constraints
 ```
 
-| Option | Property | Default |
-| --- | --- | --- |
-| `--revision` | `revision` | `milestone` |
-| `--[no-]check-constraints` | `checkConstraints` | `false` |
-| `--[no-]check-build-environment-constraints` | `checkBuildEnvironmentConstraints` | `false` |
-| `--[no-]check-for-gradle-update` | `checkForGradleUpdate` | `true` |
-| `--gradle-release-channel` | `gradleReleaseChannel` | `release-candidate` |
-| `--gradle-versions-api-base-url` | `gradleVersionsApiBaseUrl` | `https://services.gradle.org/versions/` |
-| `--output-formatter` | `outputFormatter` | `text` |
-| `--output-dir` | `outputDir` | `<buildDirectory>/dependencyUpdates` |
-| `--report-file-name` | `reportfileName` | `report` |
-| `--[no-]clean-legacy-partials` | `cleanLegacyPartials` | `false` |
-
 `--[no-]` marks the options that take no argument, so
 `--no-check-for-gradle-update` turns off a check that is enabled in the build
-script. The `--output-dir` default is `dependencyUpdates` under the project's
-build directory, so `build/dependencyUpdates` in a standard layout; both it and
-a relative value given on the command line are resolved against the project
-directory. Every option, its description, and the values `--revision` and
+script. Every option, its description, and the values `--revision` and
 `--gradle-release-channel` accept are printed by `gradle help --task
 dependencyUpdates`.
-
-`--clean-legacy-partials` is a one-off cleanup rather than a report setting;
-see [v0.61.0](#v0610) for when to run it.
-
-The properties configured with a predicate rather than a plain value have no
-option, since no command line can express the logic: `filterConfigurations`,
-`filterDeclaredConfigurations`, `rejectVersionIf` and a `resolutionStrategy`.
 
 Where more than one is set, the command line option is the one that applies,
 ahead of a system property and of what is configured in the build.
@@ -391,7 +396,7 @@ ahead of a system property and of what is configured in the build.
 An option applies within the build it is invoked in. Where a report merges an
 [included build](#composite-builds), that build's rows are resolved with its own
 configuration, since the option is not passed to the included build. A system
-property reaches it, being set for the whole JVM.
+property is, being set for the whole JVM.
 
 #### What the report checks
 
@@ -1109,12 +1114,12 @@ availability.
 ##### Optional parameters
 
 The `dependencyUpdates` task takes several optional parameters to adjust its
-behavior. The `revision`, `gradleReleaseChannel`, `outputFormatter`,
-`outputDir`, and `reportfileName` properties may also be set as system
-properties, which override the task configuration for ad hoc runs (e.g.
-`-Drevision=release`). The system properties predate the [command line
-options](#command-line-options) and the options are preferred; where both are
-set, the option is the one that applies:
+behavior. For an ad hoc run, change one with its [command line
+option](#command-line-options) (e.g. `--revision release`). The `revision`,
+`gradleReleaseChannel`, `outputFormatter`, `outputDir`, and `reportfileName`
+properties may also be set as system properties (e.g. `-Drevision=release`),
+which predate the options and are kept for the builds that use them; where both
+are set, the option is the one that applies:
 
 <details open>
 <summary>Kotlin</summary>
@@ -1145,6 +1150,32 @@ tasks.named("dependencyUpdates").configure {
 ```
 
 </details>
+
+###### `checkForGradleUpdate`
+
+Whether the report includes the Gradle releases the build could upgrade to,
+which are read from the [Gradle versions
+API](#gradle-versions-api-base-url) over the network for each
+[release channel](#gradle-release-channel) consulted. Turning it off skips those
+requests, which suits a build that runs offline or in a restricted environment:
+
+```bash
+./gradlew dependencyUpdates --no-check-for-gradle-update
+```
+
+###### `outputDir`
+
+The directory the report file is written into. A relative path is resolved
+against the project directory and an absolute one is used as given. The default
+is `dependencyUpdates` under the project's build directory, which is
+`build/dependencyUpdates` in a standard layout.
+
+###### `reportfileName`
+
+The report file's name, without an extension. Each formatter supplies its own,
+so `report` becomes `report.txt`, `report.json`, `report.xml` or `report.html`.
+Naming more than one formatter writes one file per format, all sharing this
+name.
 
 ##### Report format
 

--- a/README.md
+++ b/README.md
@@ -356,24 +356,25 @@ then return to the configured behavior on the next run:
 ./gradlew dependencyUpdates --no-check-constraints
 ```
 
-| Option | Property |
-| --- | --- |
-| `--revision` | `revision` |
-| `--[no-]check-constraints` | `checkConstraints` |
-| `--[no-]check-build-environment-constraints` | `checkBuildEnvironmentConstraints` |
-| `--[no-]check-for-gradle-update` | `checkForGradleUpdate` |
-| `--gradle-release-channel` | `gradleReleaseChannel` |
-| `--gradle-versions-api-base-url` | `gradleVersionsApiBaseUrl` |
-| `--output-formatter` | `outputFormatter` |
-| `--output-dir` | `outputDir` |
-| `--report-file-name` | `reportfileName` |
-| `--[no-]clean-legacy-partials` | `cleanLegacyPartials` |
+| Option | Property | Default |
+| --- | --- | --- |
+| `--revision` | `revision` | `milestone` |
+| `--[no-]check-constraints` | `checkConstraints` | `false` |
+| `--[no-]check-build-environment-constraints` | `checkBuildEnvironmentConstraints` | `false` |
+| `--[no-]check-for-gradle-update` | `checkForGradleUpdate` | `true` |
+| `--gradle-release-channel` | `gradleReleaseChannel` | `release-candidate` |
+| `--gradle-versions-api-base-url` | `gradleVersionsApiBaseUrl` | `https://services.gradle.org/versions/` |
+| `--output-formatter` | `outputFormatter` | `text` |
+| `--output-dir` | `outputDir` | `build/dependencyUpdates` |
+| `--report-file-name` | `reportfileName` | `report` |
+| `--[no-]clean-legacy-partials` | `cleanLegacyPartials` | `false` |
 
 `--[no-]` marks the options that take no argument, so
 `--no-check-for-gradle-update` turns off a check that is enabled in the build
-script. Every option, its description, and the values `--revision` and
-`--gradle-release-channel` accept are printed by `gradle help --task
-dependencyUpdates`.
+script. A relative `--output-dir` is resolved against the project directory,
+which is where its default sits. Every option, its description, and the values
+`--revision` and `--gradle-release-channel` accept are printed by `gradle help
+--task dependencyUpdates`.
 
 `--clean-legacy-partials` is a one-off cleanup rather than a report setting;
 see [v0.61.0](#v0610) for when to run it.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Plugin](https://www.mojohaus.org/versions-maven-plugin).
   - [Cache invalidation](#cache-invalidation)
   - [Task properties](#task-properties)
     - [A recommended configuration](#a-recommended-configuration)
+    - [Command line options](#command-line-options)
     - [What the report checks](#what-the-report-checks)
       - [Configuration filter](#configuration-filter)
         - [`filterConfigurations`](#filterconfigurations)
@@ -343,6 +344,51 @@ In Kotlin the `isNonStable` extension replaces a helper of that name already in
 the build. A top-level `fun isNonStable(version: String)` compiles to the same
 JVM signature, so keeping both fails the build with a platform declaration
 clash.
+
+#### Command line options
+
+Every task property that configures the report or where it is written is also a
+command line option, so a single run can change what the report contains
+without an edit to the build script. Use one to see what a check leaves out,
+then return to the configured behavior on the next run:
+
+```bash
+./gradlew dependencyUpdates --no-check-constraints
+```
+
+| Option | Property |
+| --- | --- |
+| `--revision` | `revision` |
+| `--[no-]check-constraints` | `checkConstraints` |
+| `--[no-]check-build-environment-constraints` | `checkBuildEnvironmentConstraints` |
+| `--[no-]check-for-gradle-update` | `checkForGradleUpdate` |
+| `--gradle-release-channel` | `gradleReleaseChannel` |
+| `--gradle-versions-api-base-url` | `gradleVersionsApiBaseUrl` |
+| `--output-formatter` | `outputFormatter` |
+| `--output-dir` | `outputDir` |
+| `--report-file-name` | `reportfileName` |
+| `--[no-]clean-legacy-partials` | `cleanLegacyPartials` |
+
+`--[no-]` marks the options that take no argument, so
+`--no-check-for-gradle-update` turns off a check that is enabled in the build
+script. Every option, its description, and the values `--revision` and
+`--gradle-release-channel` accept are printed by `gradle help --task
+dependencyUpdates`.
+
+`--clean-legacy-partials` is a one-off cleanup rather than a report setting;
+see [v0.61.0](#v0610) for when to run it.
+
+The properties configured with a predicate rather than a plain value have no
+option, since no command line can express the logic: `filterConfigurations`,
+`filterDeclaredConfigurations`, `rejectVersionIf` and a `resolutionStrategy`.
+
+Where more than one is set, the command line option is the one that applies,
+ahead of a system property and of what is configured in the build.
+
+An option applies within the build it is invoked in. Where a report merges an
+[included build](#composite-builds), that build's rows are resolved with its own
+configuration, since the option is not passed to the included build. A system
+property reaches it, being set for the whole JVM.
 
 #### What the report checks
 
@@ -1063,7 +1109,9 @@ The `dependencyUpdates` task takes several optional parameters to adjust its
 behavior. The `revision`, `gradleReleaseChannel`, `outputFormatter`,
 `outputDir`, and `reportfileName` properties may also be set as system
 properties, which override the task configuration for ad hoc runs (e.g.
-`-Drevision=release`):
+`-Drevision=release`). The system properties predate the [command line
+options](#command-line-options) and the options are preferred; where both are
+set, the option is the one that applies:
 
 <details open>
 <summary>Kotlin</summary>

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -46,9 +46,37 @@ internal fun isIsolatedProjectsEnabled(project: Project): Boolean =
     (project.gradle.startParameter as StartParameterInternal).isolatedProjects.get()
   }.getOrDefault(false)
 
+/**
+ * Returns the setting in effect. A command line option applies ahead of a system property, and
+ * both apply ahead of what is configured in the build.
+ */
+internal fun settingOf(
+  fromCommandLine: String?,
+  systemPropertyName: String,
+  configured: String,
+): String =
+  fromCommandLine
+    ?: System.getProperty(systemPropertyName)
+    ?: configured
+
+/**
+ * Returns the setting in effect for one that reads no system property, with a command line option
+ * ahead of what is configured in the build.
+ */
+internal fun <T : Any> settingOf(
+  fromCommandLine: T?,
+  configured: T,
+): T = fromCommandLine ?: configured
+
+/** The revision level resolved against when neither the build nor an override states one. */
+internal const val DEFAULT_REVISION = "milestone"
+
 /** The task settings that a project's producer reads while its input is realized; null is unset. */
 internal class DependencyUpdatesParameters {
   var revision: String? = null
+
+  /** Set by the task's command line option, which applies ahead of the two settings below. */
+  var revisionFromCommandLine: String? = null
 
   @Transient
   var filterConfigurations: Spec<Configuration>? = null
@@ -63,6 +91,13 @@ internal class DependencyUpdatesParameters {
   var resolutionStrategySet: Boolean = false
   var checkConstraints: Boolean? = null
   var checkBuildEnvironmentConstraints: Boolean? = null
+
+  /**
+   * Set by the task's command line options. Read ahead of every configured value in the chain, so
+   * that an option applies to a project where the setting is configured on its own task.
+   */
+  var checkConstraintsFromCommandLine: Boolean? = null
+  var checkBuildEnvironmentConstraintsFromCommandLine: Boolean? = null
 }
 
 /**
@@ -119,16 +154,27 @@ internal abstract class DependencyUpdatesParametersService :
         .toList()
     return ResolvedParameters(
       revision =
-        (System.getProperties()["revision"] as String?)
-          ?: chain.firstNotNullOfOrNull { it.revision } ?: "milestone",
+        settingOf(
+          fromCommandLine = chain.firstNotNullOfOrNull { it.revisionFromCommandLine },
+          systemPropertyName = "revision",
+          configured = chain.firstNotNullOfOrNull { it.revision } ?: DEFAULT_REVISION,
+        ),
       filterConfigurations =
         chain.firstNotNullOfOrNull { it.filterConfigurations } ?: ALL_CONFIGURATIONS,
       filterDeclaredConfigurations =
         chain.firstNotNullOfOrNull { it.filterDeclaredConfigurations } ?: ALL_DECLARED_CONFIGURATIONS,
       resolutionStrategy = chain.firstOrNull { it.resolutionStrategySet }?.resolutionStrategy,
-      checkConstraints = chain.firstNotNullOfOrNull { it.checkConstraints } ?: false,
+      checkConstraints =
+        settingOf(
+          fromCommandLine = chain.firstNotNullOfOrNull { it.checkConstraintsFromCommandLine },
+          configured = chain.firstNotNullOfOrNull { it.checkConstraints } ?: false,
+        ),
       checkBuildEnvironmentConstraints =
-        chain.firstNotNullOfOrNull { it.checkBuildEnvironmentConstraints } ?: false,
+        settingOf(
+          fromCommandLine =
+            chain.firstNotNullOfOrNull { it.checkBuildEnvironmentConstraintsFromCommandLine },
+          configured = chain.firstNotNullOfOrNull { it.checkBuildEnvironmentConstraints } ?: false,
+        ),
     )
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions.updates
 import com.github.benmanes.gradle.versions.reporter.Reporter
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.reporter.result.SkippedConfiguration
+import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentFilter
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
@@ -23,6 +24,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.api.tasks.options.OptionValues
 import java.io.File
 import javax.annotation.Nullable
 
@@ -38,15 +40,47 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   /** Returns the resolution revision level. */
   @get:Input
   var revision: String
-    get() = (System.getProperties()["revision"] ?: parameters.revision ?: "milestone") as String
+    get() =
+      settingOf(
+        parameters.revisionFromCommandLine,
+        "revision",
+        parameters.revision ?: DEFAULT_REVISION,
+      )
     set(value) {
       parameters.revision = value
     }
 
+  /** Sets the resolution revision level for this invocation alone. */
+  @Option(option = "revision", description = "Resolves against this revision level.")
+  internal fun setRevisionFromCommandLine(revision: String) {
+    parameters.revisionFromCommandLine = revision
+  }
+
+  /** Returns the revision levels `gradle help --task dependencyUpdates` lists for the option. */
+  @OptionValues("revision")
+  fun getRevisionValues(): List<String> = listOf("release", "milestone", "integration")
+
+  private var gradleReleaseChannelFromCommandLine: String? = null
+
   /** Returns the resolution revision level. */
   @Input
   var gradleReleaseChannel: String = RELEASE_CANDIDATE.id
-    get() = (System.getProperties()["gradleReleaseChannel"] ?: field) as String
+    get() = settingOf(gradleReleaseChannelFromCommandLine, "gradleReleaseChannel", field)
+
+  /** Sets the Gradle release channel for this invocation alone. */
+  @Option(
+    option = "gradle-release-channel",
+    description = "Reports the Gradle releases of this channel.",
+  )
+  internal fun setGradleReleaseChannelFromCommandLine(gradleReleaseChannel: String) {
+    gradleReleaseChannelFromCommandLine = gradleReleaseChannel
+  }
+
+  /** Returns the release channels `gradle help --task dependencyUpdates` lists for the option. */
+  @OptionValues("gradle-release-channel")
+  fun getGradleReleaseChannelValues(): List<String> = GradleReleaseChannel.values().map { it.id }
+
+  private var outputDirFromCommandLine: String? = null
 
   /** Returns the outputDir destination. */
   @Input
@@ -59,13 +93,27 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
       val base = if (relative == null || relative.path.isEmpty()) buildDirectory else relative
       "${base.path}/dependencyUpdates"
     }
-    get() = (System.getProperties()["outputDir"] ?: field) as String
+    get() = settingOf(outputDirFromCommandLine, "outputDir", field)
+
+  /** Sets where the report is written for this invocation alone. */
+  @Option(option = "output-dir", description = "Writes the report into this directory.")
+  internal fun setOutputDirFromCommandLine(outputDir: String) {
+    outputDirFromCommandLine = outputDir
+  }
+
+  private var reportfileNameFromCommandLine: String? = null
 
   /** Returns the filename of the report. */
   @Input
   @Optional
   var reportfileName: String = "report"
-    get() = (System.getProperties()["reportfileName"] ?: field) as String
+    get() = settingOf(reportfileNameFromCommandLine, "reportfileName", field)
+
+  /** Sets the report's file name for this invocation alone. */
+  @Option(option = "report-file-name", description = "Writes the report under this file name.")
+  internal fun setReportfileNameFromCommandLine(reportfileName: String) {
+    reportfileNameFromCommandLine = reportfileName
+  }
 
   /**
    * Sets an output formatting for the task result. It can either be a [String] referencing one of
@@ -98,9 +146,12 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
    */
   private var outputFormatterArgument: OutputFormatterArgument = OutputFormatterArgument.DEFAULT
 
+  private var outputFormatterFromCommandLine: String? = null
+
   @Input
   @Optional
   fun getOutputFormatterName(): String? {
+    namedOutputFormatter()?.let { return it }
     return with(outputFormatterArgument) {
       if (this is OutputFormatterArgument.BuiltIn) {
         formatterNames
@@ -110,20 +161,57 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     }
   }
 
+  /** Returns the formatter named on the command line or in a system property, if either is set. */
+  private fun namedOutputFormatter(): String? = outputFormatterFromCommandLine ?: System.getProperty("outputFormatter")
+
+  private var checkForGradleUpdateFromCommandLine: Boolean? = null
+
   // Groovy generates both get/is accessors for boolean properties unless we manually define some.
   // Gradle will reject this behavior starting in 7.0 so we make sure to define accessors ourselves.
   @Input
   var checkForGradleUpdate: Boolean = true
+    get() = settingOf(checkForGradleUpdateFromCommandLine, field)
+
+  /** Reports the available Gradle releases for this invocation alone. */
+  @Option(
+    option = "check-for-gradle-update",
+    description = "Reports the Gradle releases available for the build to upgrade to.",
+  )
+  internal fun setCheckForGradleUpdateFromCommandLine(checkForGradleUpdate: Boolean) {
+    checkForGradleUpdateFromCommandLine = checkForGradleUpdate
+  }
+
+  private var gradleVersionsApiBaseUrlFromCommandLine: String? = null
 
   @Input
   var gradleVersionsApiBaseUrl: String = "https://services.gradle.org/versions/"
+    get() = settingOf(gradleVersionsApiBaseUrlFromCommandLine, field)
+
+  /** Reads the Gradle releases from another service for this invocation alone. */
+  @Option(
+    option = "gradle-versions-api-base-url",
+    description = "Reads the Gradle releases from this service rather than the public one.",
+  )
+  internal fun setGradleVersionsApiBaseUrlFromCommandLine(gradleVersionsApiBaseUrl: String) {
+    gradleVersionsApiBaseUrlFromCommandLine = gradleVersionsApiBaseUrl
+  }
 
   @get:Input
   var checkConstraints: Boolean
-    get() = parameters.checkConstraints ?: false
+    get() =
+      settingOf(parameters.checkConstraintsFromCommandLine, parameters.checkConstraints ?: false)
     set(value) {
       parameters.checkConstraints = value
     }
+
+  /** Reports the constrained versions for this invocation alone. */
+  @Option(
+    option = "check-constraints",
+    description = "Reports the versions that a constraints block manages.",
+  )
+  internal fun setCheckConstraintsFromCommandLine(checkConstraints: Boolean) {
+    parameters.checkConstraintsFromCommandLine = checkConstraints
+  }
 
   @get:Internal
   var filterConfigurations: Spec<Configuration>
@@ -141,10 +229,23 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
   @get:Input
   var checkBuildEnvironmentConstraints: Boolean
-    get() = parameters.checkBuildEnvironmentConstraints ?: false
+    get() =
+      settingOf(
+        parameters.checkBuildEnvironmentConstraintsFromCommandLine,
+        parameters.checkBuildEnvironmentConstraints ?: false,
+      )
     set(value) {
       parameters.checkBuildEnvironmentConstraints = value
     }
+
+  /** Reports the build environment's constrained versions for this invocation alone. */
+  @Option(
+    option = "check-build-environment-constraints",
+    description = "Reports the versions that a constraints block manages for the build environment.",
+  )
+  internal fun setCheckBuildEnvironmentConstraintsFromCommandLine(checkBuildEnvironmentConstraints: Boolean) {
+    parameters.checkBuildEnvironmentConstraintsFromCommandLine = checkBuildEnvironmentConstraints
+  }
 
   @Internal
   @Nullable
@@ -342,10 +443,17 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
   /** Returns the outputDir format. */
   private fun outputFormatter(): OutputFormatterArgument {
-    val outputFormatterProperty = System.getProperties()["outputFormatter"] as? String
-
-    return outputFormatterProperty?.let { OutputFormatterArgument.BuiltIn(it) }
+    return namedOutputFormatter()?.let { OutputFormatterArgument.BuiltIn(it) }
       ?: outputFormatterArgument
+  }
+
+  /** Sets the report's format for this invocation alone, as a comma separated list of names. */
+  @Option(
+    option = "output-formatter",
+    description = "Writes the report in these formats, as a comma separated list.",
+  )
+  internal fun setOutputFormatterFromCommandLine(outputFormatter: String) {
+    outputFormatterFromCommandLine = outputFormatter
   }
 
   /**

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
@@ -1,0 +1,604 @@
+package com.github.benmanes.gradle.versions
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+final class TaskOptionSpec extends Specification {
+  @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+
+  def 'setup'() {
+    mavenRepoUrl = getClass().getResource('/maven/').toURI()
+  }
+
+  private File written
+
+  /** Fails with the reason rather than an IOException when a spec writes two root build files. */
+  private File rootBuildFile() {
+    if (written != null) {
+      throw new IllegalStateException('The root build file was already written by this spec')
+    }
+    written = testProjectDir.newFile('build.gradle')
+    return written
+  }
+
+  private void buildFile(String configured = '', String buildscript = '') {
+    rootBuildFile() <<
+      """
+        ${buildscript}
+
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        ${configured}
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+  }
+
+  private void declaringBuildFile(String configured = '') {
+    rootBuildFile() <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        ${configured}
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+        }
+      """.stripIndent()
+  }
+
+  private def run(String... arguments) {
+    return GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .build()
+  }
+
+  def 'Reports a constrained version when the check is turned on from the command line'() {
+    given:
+    buildFile()
+
+    when:
+    def result = run('dependencyUpdates', '--check-constraints')
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Omits a constrained version when the command line turns off what is configured in the build'() {
+    given:
+    buildFile('tasks.dependencyUpdates { checkConstraints = true }')
+
+    when:
+    def result = run('dependencyUpdates', '--no-check-constraints')
+
+    then:
+    !result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reports a build environment constraint when the check is turned on from the command line'() {
+    given:
+    buildFile(
+      '',
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            constraints {
+              classpath 'com.google.guava:guava:15.0'
+            }
+          }
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates', '--check-build-environment-constraints')
+
+    then:
+    result.output.contains('com.google.guava:guava [15.0 -> ')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Omits the Gradle release check when the command line turns it off'() {
+    given:
+    buildFile()
+
+    when:
+    def result = run('dependencyUpdates', '--no-check-for-gradle-update')
+
+    then:
+    !result.output.contains(' - Gradle: [')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reads the Gradle versions api from the base url given on the command line'() {
+    given:
+    buildFile()
+
+    when:
+    def result = run(
+      'dependencyUpdates', '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('[ERROR] [release channel: current]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Resolves against the revision level given on the command line'() {
+    given:
+    declaringBuildFile()
+
+    when:
+    def result = run('dependencyUpdates', '--revision', 'release')
+
+    then:
+    result.output.contains('release version')
+    !result.output.contains('Failed to determine the latest version')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Resolves against the command line revision ahead of the system property'() {
+    given:
+    declaringBuildFile()
+
+    when: 'the revision in the system property is one the producer can resolve against'
+    def result = run('dependencyUpdates', '-Drevision=release', '--revision', 'bogus')
+
+    then: 'the producer resolved against the command line, so it found no version at all'
+    result.output.contains('Failed to determine the latest version')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Resolves against the command line revision ahead of what is configured in the build'() {
+    given:
+    declaringBuildFile("tasks.dependencyUpdates { revision = 'bogus' }")
+
+    when:
+    def result = run('dependencyUpdates', '--revision', 'release')
+
+    then:
+    !result.output.contains('Failed to determine the latest version')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reports the Gradle releases of the channel given on the command line'() {
+    given:
+    declaringBuildFile()
+
+    when: 'the api is unreachable, so an error is printed for each release channel consulted'
+    def result = run(
+      'dependencyUpdates',
+      '--gradle-release-channel', 'nightly',
+      '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('[release channel: nightly]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Writes the report to the directory given on the command line, ahead of the system property'() {
+    given:
+    declaringBuildFile()
+
+    when:
+    def result = run(
+      'dependencyUpdates',
+      '-DreportfileName=fromSystemProperty',
+      '-DoutputDir=build/fromSystemProperty',
+      '--report-file-name', 'fromCommandLine',
+      '--output-dir', 'build/fromCommandLine')
+
+    then:
+    new File(testProjectDir.root, 'build/fromCommandLine/fromCommandLine.txt').exists()
+    !new File(testProjectDir.root, 'build/fromSystemProperty').exists()
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Writes the report in the format given on the command line, ahead of the system property'() {
+    given:
+    declaringBuildFile()
+
+    when:
+    def result = run(
+      'dependencyUpdates',
+      '-DoutputFormatter=xml',
+      '--output-formatter', 'json',
+      '--output-dir', 'build/formatted')
+
+    then:
+    new File(testProjectDir.root, 'build/formatted/report.json').exists()
+    !new File(testProjectDir.root, 'build/formatted/report.xml').exists()
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reports a constrained version for a subproject with the check turned off on its own task'() {
+    given: 'the subproject has its own task settings, which its producers inherit from'
+    testProjectDir.newFile('settings.gradle') << "include 'lib'"
+    rootBuildFile() <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          apply plugin: 'java-library'
+
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = false
+        }
+
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+
+    when: 'the option is given to the aggregating task alone, by path'
+    def result = run(':dependencyUpdates', '--check-constraints')
+
+    then: 'the option applies to the subproject, which its own configured value would outrank'
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Omits a build environment constraint when the command line turns the check off'() {
+    given:
+    buildFile(
+      'tasks.dependencyUpdates { checkBuildEnvironmentConstraints = true }',
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            constraints {
+              classpath 'com.google.guava:guava:15.0'
+            }
+          }
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates', '--no-check-build-environment-constraints')
+
+    then:
+    !result.output.contains('com.google.guava:guava [15.0 -> ')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reads the option rather than the entry cached under the opposite one'() {
+    given:
+    buildFile()
+
+    when: 'the entry is stored with the check on, then the opposite is asked for'
+    run('dependencyUpdates', '--check-constraints', '--configuration-cache')
+    def reused = run('dependencyUpdates', '--check-constraints', '--configuration-cache')
+    def off = run('dependencyUpdates', '--no-check-constraints', '--configuration-cache')
+
+    then:
+    reused.output.contains('Reusing configuration cache')
+    reused.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !off.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+  }
+
+  def 'Resolves against the system property ahead of what is configured in the build'() {
+    given: 'a revision the producers cannot resolve against, configured in the build'
+    declaringBuildFile("tasks.dependencyUpdates { revision = 'bogus' }")
+
+    when: 'the revision in the system property is one they can, with no option in play'
+    def result = run('dependencyUpdates', '-Drevision=release')
+
+    then:
+    !result.output.contains('Failed to determine the latest version')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Writes the report under the file name given as a system property, ahead of the build'() {
+    given:
+    declaringBuildFile("tasks.dependencyUpdates { reportfileName = 'fromBuild' }")
+
+    when:
+    def result = run('dependencyUpdates', '-DreportfileName=fromSystemProperty')
+
+    then:
+    new File(testProjectDir.root, 'build/dependencyUpdates/fromSystemProperty.txt').exists()
+    !new File(testProjectDir.root, 'build/dependencyUpdates/fromBuild.txt').exists()
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Turns off the Gradle release check from the command line, against the configured value'() {
+    given:
+    declaringBuildFile('tasks.dependencyUpdates { checkForGradleUpdate = true }')
+
+    when:
+    def result = run('dependencyUpdates', '--no-check-for-gradle-update')
+
+    then:
+    !result.output.contains(' - Gradle: [')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reads the versions api from the command line url, ahead of the one configured in the build'() {
+    given:
+    declaringBuildFile(
+      "tasks.dependencyUpdates { gradleVersionsApiBaseUrl = 'https://services.gradle.org/versions/' }")
+
+    when:
+    def result = run(
+      'dependencyUpdates', '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('[ERROR] [release channel: current]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Reports a build environment constraint for a subproject with it turned off on its own task'() {
+    given:
+    testProjectDir.newFile('settings.gradle') << "include 'lib'"
+    rootBuildFile() <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        allprojects {
+          apply plugin: 'java-library'
+
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('lib')
+    testProjectDir.newFile('lib/build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            constraints {
+              classpath 'com.google.guava:guava:15.0'
+            }
+          }
+        }
+
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkBuildEnvironmentConstraints = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run(':dependencyUpdates', '--check-build-environment-constraints')
+
+    then:
+    result.output.contains('com.google.guava:guava [15.0 -> ')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Keeps the command line value against a write made once the task graph is ready'() {
+    given: 'a write that lands after Gradle has applied the command line options'
+    buildFile('gradle.taskGraph.whenReady { tasks.dependencyUpdates.checkForGradleUpdate = true }')
+
+    when:
+    def result = run('dependencyUpdates', '--no-check-for-gradle-update')
+
+    then:
+    !result.output.contains(' - Gradle: [')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Keeps the constraints check against a write made once the task graph is ready'() {
+    given:
+    buildFile('gradle.taskGraph.whenReady { tasks.dependencyUpdates.checkConstraints = false }')
+
+    when:
+    def result = run('dependencyUpdates', '--check-constraints', '--no-check-for-gradle-update')
+
+    then:
+    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'Resolves an included build merged into the report with that build\'s own settings'() {
+    given: 'one report merging an included build, each build applying the plugin'
+    def classpath = getClass().classLoader.getResource('plugin-classpath.txt').readLines()
+      .collect { it.replace('\\', '\\\\') }.collect { "'$it'" }.join(', ')
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    rootBuildFile() <<
+      """
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.inject:guice:2.0'
+          dependencyUpdatesAggregation 'com.example:child:1.0'
+        }
+      """.stripIndent()
+    testProjectDir.newFolder('child')
+    testProjectDir.newFile('child/settings.gradle') << "rootProject.name = 'child'"
+    testProjectDir.newFile('child/build.gradle') <<
+      """
+        buildscript {
+          dependencies {
+            classpath files(${classpath})
+          }
+        }
+
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        group = 'com.example'
+        version = '1.0'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api 'com.google.guava:guava:15.0'
+        }
+      """.stripIndent()
+
+    when: 'a revision no producer can resolve against is given on the command line'
+    def viaOption = run('dependencyUpdates', '--revision', 'bogus')
+
+    then: 'the invoking build resolves against it and the included build keeps its own'
+    !viaOption.output.contains('com.google.inject:guice [2.0 ->')
+    viaOption.output.contains('com.google.guava:guava [15.0 ->')
+
+    when: 'the same revision is given as a system property, which is set for the whole JVM'
+    def viaSystemProperty = run('dependencyUpdates', '-Drevision=bogus')
+
+    then: 'both builds resolve against it'
+    !viaSystemProperty.output.contains('com.google.inject:guice [2.0 ->')
+    !viaSystemProperty.output.contains('com.google.guava:guava [15.0 ->')
+  }
+
+  @Unroll
+  def 'Binds the options under Gradle #gradleVersion'() {
+    given: 'the plugin on the buildscript classpath, so a pinned Gradle runs it'
+    def classpath = getClass().classLoader.getResource('plugin-classpath.txt').readLines()
+      .collect { it.replace('\\', '\\\\') }.collect { "'$it'" }.join(', ')
+    rootBuildFile() <<
+      """
+        buildscript {
+          dependencies {
+            classpath files(${classpath})
+          }
+        }
+
+        apply plugin: 'java-library'
+        apply plugin: 'io.github.ben-manes.versions'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          constraints {
+            api 'com.google.inject:guice:2.0'
+          }
+        }
+      """.stripIndent()
+
+    when: 'the option turns the check on, and its --no- counterpart turns it off again'
+    def on = GradleRunner.create()
+      .withGradleVersion(gradleVersion)
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates', '--check-constraints', '--no-check-for-gradle-update')
+      .build()
+    def off = GradleRunner.create()
+      .withGradleVersion(gradleVersion)
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates', '--no-check-constraints', '--no-check-for-gradle-update')
+      .build()
+
+    then: 'the internal method the option binds to is reached at both ends of the range'
+    on.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    !off.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    on.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    gradleVersion << ['8.4', '9.7.1']
+  }
+
+  def 'Prints every command line option the task accepts'() {
+    given:
+    buildFile()
+
+    when:
+    def result = run('help', '--task', 'dependencyUpdates')
+
+    then:
+    def output = result.output
+    output.contains('--check-constraints')
+    output.contains('--no-check-constraints')
+    output.contains('--check-build-environment-constraints')
+    output.contains('--check-for-gradle-update')
+    output.contains('--gradle-versions-api-base-url')
+    output.contains('--revision')
+    output.contains('--gradle-release-channel')
+    output.contains('--output-dir')
+    output.contains('--report-file-name')
+    output.contains('--clean-legacy-partials')
+    output.contains('Available values are:')
+    ['release', 'milestone', 'integration'].every { output.contains(it) }
+    ['current', 'release-candidate', 'nightly'].every { output.contains(it) }
+    output.contains('--output-formatter')
+  }
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
@@ -5,6 +5,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -528,6 +529,7 @@ final class TaskOptionSpec extends Specification {
   }
 
   @Unroll
+  @IgnoreIf({ data.gradleVersion.startsWith('9') && !jvm.java17Compatible })
   def 'Binds the options under Gradle #gradleVersion'() {
     given: 'the plugin on the buildscript classpath, so a pinned Gradle runs it'
     def classpath = getClass().classLoader.getResource('plugin-classpath.txt').readLines()


### PR DESCRIPTION
This PR adds a command line option to every `dependencyUpdates` property with a plain value, so a single run can change what the report contains without an edit to the build script. Where more than one is set, the command line option is the one that applies, ahead of the system property of the same name and of what is configured in the build. There is no option for the properties configured with a predicate, since no command line can express the logic. An option applies only within the build it is invoked in, so in a report that merges an included build, that build's rows are resolved from that build's own configuration, as documented beside the option table in the README.

I'd suggest task options as the preferred execution-time configuration approach over system properties going forward. They appear in `gradle help --task dependencyUpdates`, a misspelled option fails the build where `-DcheckConstraint=true` is silently ignored, and each is scoped to the task rather than to the whole JVM. The five existing system properties are unchanged.

Both a build script assignment and a command line option are applied through `Property.set()`. The system property is read between them, and there is nowhere in a `Property` to put it, so each option is backed by a separate field rather than by a `Property`. The members these options are declared on are `internal`, so moving them to the Provider API later would not be visible to a build.

If at some point in the future we find the command line options to be a suitable replacement, we could consider deprecating the system properties for removal by printing a warning when they're used that points to migration instructions. Removing them outright in this release is the alternative, and I could do that here instead. Then we could move forward with the [Provider API](https://github.com/gradle/build-tool-roadmap/issues/28) for the options now. I kept the system properties to be conservative and not force a significant migration on existing builds and build logic.
