### PR TITLE
Fix: report the task settings inherited from an ancestor project

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -179,6 +179,16 @@ internal abstract class DependencyUpdatesParametersService :
   }
 }
 
+/**
+ * A project's settings that hold a plain value, read back from the accumulator task. Kept apart
+ * from [ResolvedParameters], where the predicates are never serialized into a task's inputs.
+ */
+internal class InheritedSettings(
+  val revision: String,
+  val checkConstraints: Boolean,
+  val checkBuildEnvironmentConstraints: Boolean,
+)
+
 /** The settings that apply to a single project's producer. */
 internal class ResolvedParameters(
   val revision: String,
@@ -195,7 +205,26 @@ internal fun registerAggregation(
   accumulator: TaskProvider<DependencyUpdatesTask>,
 ) {
   val service = parametersService(project.gradle)
-  accumulator.configure { task -> service.get().register(project.path, task.parameters) }
+  // Read here so that the provider below captures this rather than the project, which the
+  // configuration cache cannot serialize.
+  val path = project.path
+  // Realized after every project is configured, as the producers' inputs are, so that the values
+  // read back from the task are the ones the producers resolved with rather than only what is
+  // configured on this project. All three are taken from one resolution, so a read cannot mix a
+  // stale value with a fresh one.
+  val inherited =
+    project.provider {
+      val resolved = service.get().resolve(path)
+      InheritedSettings(
+        revision = resolved.revision,
+        checkConstraints = resolved.checkConstraints,
+        checkBuildEnvironmentConstraints = resolved.checkBuildEnvironmentConstraints,
+      )
+    }
+  accumulator.configure { task ->
+    service.get().register(path, task.parameters)
+    task.inherited.set(inherited)
+  }
   // Realizes the task, so that a configuration block on a task that nothing else realizes is still
   // applied before the producers read the settings.
   project.afterEvaluate { accumulator.get() }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -15,6 +15,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -37,15 +38,41 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   @get:Internal
   internal val parameters = DependencyUpdatesParameters()
 
+  /**
+   * The settings as the producers resolved them, wired by the plugin from the shared settings so
+   * that they are read back as resolved rather than as configured on this project alone. All three
+   * are taken from one resolution, so a read cannot mix them. The convention covers a task the
+   * plugin did not register, where only this project's own settings are known.
+   */
+  @get:Internal
+  internal val inherited: Property<InheritedSettings> =
+    project.objects.property(InheritedSettings::class.java).convention(
+      project.provider {
+        InheritedSettings(
+          revision =
+            settingOf(
+              parameters.revisionFromCommandLine,
+              "revision",
+              parameters.revision ?: DEFAULT_REVISION,
+            ),
+          checkConstraints =
+            settingOf(
+              parameters.checkConstraintsFromCommandLine,
+              parameters.checkConstraints ?: false,
+            ),
+          checkBuildEnvironmentConstraints =
+            settingOf(
+              parameters.checkBuildEnvironmentConstraintsFromCommandLine,
+              parameters.checkBuildEnvironmentConstraints ?: false,
+            ),
+        )
+      },
+    )
+
   /** Returns the resolution revision level. */
   @get:Input
   var revision: String
-    get() =
-      settingOf(
-        parameters.revisionFromCommandLine,
-        "revision",
-        parameters.revision ?: DEFAULT_REVISION,
-      )
+    get() = inherited.get().revision
     set(value) {
       parameters.revision = value
     }
@@ -198,8 +225,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
   @get:Input
   var checkConstraints: Boolean
-    get() =
-      settingOf(parameters.checkConstraintsFromCommandLine, parameters.checkConstraints ?: false)
+    get() = inherited.get().checkConstraints
     set(value) {
       parameters.checkConstraints = value
     }
@@ -229,11 +255,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
   @get:Input
   var checkBuildEnvironmentConstraints: Boolean
-    get() =
-      settingOf(
-        parameters.checkBuildEnvironmentConstraintsFromCommandLine,
-        parameters.checkBuildEnvironmentConstraints ?: false,
-      )
+    get() = inherited.get().checkBuildEnvironmentConstraints
     set(value) {
       parameters.checkBuildEnvironmentConstraints = value
     }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
@@ -110,6 +110,47 @@ final class AggregationConfigurationCacheSpec extends Specification {
       .parse(new File(testProjectDir.root, 'build/dependencyUpdates/report.json'))
   }
 
+  def 'Honors a setting inherited from an ancestor on the store and on the cache hit'() {
+    // A cache hit does not run configuration, so the shared service holds no settings at all when
+    // the task's inputs are replayed. The inherited values must therefore already be in the entry.
+    // The cases above configure the root's own task, which reads back correctly even when nothing
+    // is inherited, so only a subproject that configures none of its own covers this.
+    given:
+    new File(testProjectDir.root, 'build.gradle') <<
+      """
+        subprojects {
+          apply plugin: 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          revision = 'release'
+          checkConstraints = true
+        }
+      """.stripIndent()
+    new File(testProjectDir.root, 'app/build.gradle') <<
+      """
+        dependencies {
+          constraints {
+            implementation 'com.google.guava:guava:15.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def arguments = [':app:dependencyUpdates', '--no-parallel', '--configuration-cache']
+    def store = run(arguments)
+    def hit = run(arguments)
+
+    then:
+    store.task(':app:dependencyUpdates').outcome == SUCCESS
+    hit.output.contains('Reusing configuration cache')
+    // The header names the inherited revision, and the constrained guava is reported under the
+    // inherited check, on the store and again on the replay.
+    [store, hit].every { it.output.contains('The following dependencies have later release versions:') }
+    [store, hit].every { !it.output.contains('The following dependencies have later milestone versions:') }
+    [store, hit].every { it.output.contains('com.google.guava:guava') }
+  }
+
   @Unroll
   def 'Honors #hook on the store and on the cache hit'() {
     given:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSettingsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSettingsSpec.groovy
@@ -205,4 +205,90 @@ final class AggregationSettingsSpec extends Specification {
     result.output.contains('readBack=true')
     result.output.contains('com.google.inject:guice [2.0 -> 3.0]')
   }
+
+  def 'Prints the inherited revision in the header of a subproject report'() {
+    // The getters fell back to the value configured on this project while the producers resolved
+    // with the nearest ancestor's, so the default revision level was printed in the header over
+    // rows that had been resolved at the inherited one.
+    given:
+    new File(testProjectDir.root, 'build.gradle') <<
+      """
+        subprojects {
+          apply plugin: 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          revision = 'release'
+        }
+      """.stripIndent()
+
+    when:
+    def result = run([':app:dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':app:dependencyUpdates').outcome == SUCCESS
+    result.output.contains('The following dependencies have later release versions:')
+    !result.output.contains('The following dependencies have later milestone versions:')
+  }
+
+  def 'Reads back the inherited constraint checks in a subproject with none of its own'() {
+    // Neither check is visible in the report, so the getters are read back instead and compared
+    // against what the producers resolved with, which is what the two constrained rows show.
+    given:
+    new File(testProjectDir.root, 'build.gradle') <<
+      """
+        subprojects {
+          apply plugin: 'io.github.ben-manes.versions'
+        }
+
+        tasks.dependencyUpdates {
+          checkConstraints = true
+          checkBuildEnvironmentConstraints = true
+        }
+      """.stripIndent()
+    // Rewritten rather than appended to, as a buildscript block must come first in the script.
+    new File(testProjectDir.root, 'app/build.gradle').text =
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+
+          dependencies {
+            constraints {
+              classpath 'backport-util-concurrent:backport-util-concurrent:1.0'
+            }
+          }
+        }
+
+        tasks.register('readBack') {
+          def checkConstraints = tasks.dependencyUpdates.checkConstraints
+          def checkBuildEnvironmentConstraints =
+            tasks.dependencyUpdates.checkBuildEnvironmentConstraints
+          doLast {
+            println "readBack=\$checkConstraints,\$checkBuildEnvironmentConstraints"
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:2.0'
+          constraints {
+            implementation 'com.google.guava:guava:15.0'
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run([':app:readBack', ':app:dependencyUpdates', '--no-parallel'])
+
+    then:
+    result.task(':app:dependencyUpdates').outcome == SUCCESS
+    // guava is only a project constraint and backport-util-concurrent is only a buildscript one,
+    // so each row is printed only when its own inherited check applied. The getters must agree.
+    result.output.contains('com.google.guava:guava')
+    result.output.contains('backport-util-concurrent:backport-util-concurrent')
+    result.output.contains('readBack=true,true')
+  }
 }


### PR DESCRIPTION
Fixes #1086

The getters for `revision`, `checkConstraints` and `checkBuildEnvironmentConstraints` now return the value the producers resolved with. In a project where none of them is configured, that is the value inherited from the nearest ancestor where one is, which is what the producers already used. Before, in a build where only the root task is configured:

```
revision=milestone checkConstraints=false

The following dependencies have later milestone versions:
 - com.google.guava:guava [15.0 -> 33.7.1-jre]
```

After:

```
revision=release checkConstraints=true

The following dependencies have later release versions:
 - com.google.guava:guava [15.0 -> 33.7.1-jre]
```

`filterConfigurations`, `filterDeclaredConfigurations` and `resolutionStrategy` diverge the same way and are left alone: their values are build script closures, marked `@Transient` in `DependencyUpdatesParameters` so that the configuration cache never has to serialize them.
