### PR TITLE
Test against Gradle 9.7.1 from a single pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         if: matrix.java-version == 17
         uses: gradle/actions/setup-gradle@v5
         with:
-          gradle-version: '9.6.1'
+          gradle-version: '9.7.1'
 
       - name: Run examples on Gradle 9
         if: matrix.java-version == 17

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationSpec.groovy
@@ -129,7 +129,7 @@ final class AggregationSpec extends Specification {
     result.output.contains('com.google.guava:guava [15.0 -> 16.0-rc1]')
 
     where:
-    gradleVersion << ['9.0.0', '9.6.1']
+    gradleVersion << ['9.0.0', GradleVersions.CURRENT]
   }
 
   def 'Reports every projects producer in the merged report'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ApplyOrderSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ApplyOrderSpec.groovy
@@ -19,7 +19,7 @@ import spock.lang.Unroll
 @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1049')
 final class ApplyOrderSpec extends Specification {
   private static final String GRADLE_8 = '8.4'
-  private static final String GRADLE_9 = '9.7.0'
+  private static final String GRADLE_9 = GradleVersions.CURRENT
   private static final List<String> PLUGINS =
     ['io.github.ben-manes.versions', 'io.github.ben-manes.versions.contributor']
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -257,7 +257,7 @@ final class CompositeBuildSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.6.1')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments(':dependencyUpdates', '--configure-on-demand', '--parallel',
         '--configuration-cache')
@@ -1187,7 +1187,7 @@ final class CompositeBuildSpec extends Specification {
     result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
 
     where:
-    gradleVersion << ['9.0.0', '9.6.1']
+    gradleVersion << ['9.0.0', GradleVersions.CURRENT]
   }
 
   // The measured #801 trigger: a withModule id missing its ':name' half.
@@ -1254,7 +1254,7 @@ final class CompositeBuildSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.6.1')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments('dependencyUpdates', ':child:dependencyUpdates',
         '-DoutputFormatter=plain,json')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ContributorAggregationSpec.groovy
@@ -66,7 +66,7 @@ final class ContributorAggregationSpec extends Specification {
 
   private def run(String... arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()
@@ -187,7 +187,7 @@ final class ContributorAggregationSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.7.0')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments(':dependencyUpdates')
       .withPluginClasspath()
@@ -209,7 +209,7 @@ final class ContributorAggregationSpec extends Specification {
 
     when:
     def result = GradleRunner.create()
-      .withGradleVersion('9.7.0')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments(':app:dependencyUpdates')
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -356,7 +356,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    gradleVersion << ['8.4', '9.6.1']
+    gradleVersion << ['8.4', GradleVersions.CURRENT]
   }
 
   def 'a bound on an unpublished version moves the report line to the unresolved section'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -90,16 +90,16 @@ final class DifferentGradleVersionsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    gradleVersion | warningMode
-    '8.4'         | 'all'
-    '8.5'         | 'all'
-    '8.6'         | 'all'
-    '8.7'         | 'all'
-    '8.8'         | 'all'
-    '8.9'         | 'all'
-    '8.10'        | 'all'
-    '8.11.1'      | 'fail'
-    '9.6.1'       | 'fail'
+    gradleVersion          | warningMode
+    '8.4'                  | 'all'
+    '8.5'                  | 'all'
+    '8.6'                  | 'all'
+    '8.7'                  | 'all'
+    '8.8'                  | 'all'
+    '8.9'                  | 'all'
+    '8.10'                 | 'all'
+    '8.11.1'               | 'fail'
+    GradleVersions.CURRENT | 'fail'
   }
 
   @Unroll

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/GradleVersions.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/GradleVersions.groovy
@@ -1,0 +1,10 @@
+package com.github.benmanes.gradle.versions
+
+/**
+ * The Gradle releases the functional specs run against, named once so that keeping up with a new
+ * release is a single edit rather than a sweep of every spec that pins one.
+ */
+final class GradleVersions {
+  /** The latest Gradle release, which every spec that exercises the Gradle 9 line runs against. */
+  static final String CURRENT = '9.7.1'
+}

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/InitScriptAggregationSpec.groovy
@@ -95,7 +95,7 @@ final class InitScriptAggregationSpec extends Specification {
 
   private def run(String... arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/IsolatedProjectsAggregationSpec.groovy
@@ -70,7 +70,7 @@ final class IsolatedProjectsAggregationSpec extends Specification {
 
   private def runWith(String task, List<String> arguments = []) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments([task, '-Dorg.gradle.isolated-projects=true',
         '--configuration-cache'] + arguments)

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/KotlinDslUsageSpec.groovy
@@ -76,7 +76,7 @@ final class KotlinDslUsageSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    gradleVersion << ['8.4', '9.6.1']
+    gradleVersion << ['8.4', GradleVersions.CURRENT]
   }
 
   // Gradle 9 requires JVM 17.
@@ -116,7 +116,7 @@ final class KotlinDslUsageSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    gradleVersion << ['8.4', '9.6.1']
+    gradleVersion << ['8.4', GradleVersions.CURRENT]
   }
 
   def 'rejectVersionIf binds to the ComponentFilter overload from kotlin-dsl'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsClasspathSpec.groovy
@@ -120,7 +120,7 @@ final class SettingsClasspathSpec extends Specification {
       'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]'
 
     when:
-    def stored = runOn('9.7.0', arguments)
+    def stored = runOn(GradleVersions.CURRENT, arguments)
 
     then:
     stored.task(':dependencyUpdates').outcome == SUCCESS
@@ -128,7 +128,7 @@ final class SettingsClasspathSpec extends Specification {
     stored.output.contains(expected)
 
     when:
-    def hit = runOn('9.7.0', arguments)
+    def hit = runOn(GradleVersions.CURRENT, arguments)
 
     then:
     hit.task(':dependencyUpdates').outcome == SUCCESS

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/SettingsPluginAggregationSpec.groovy
@@ -75,7 +75,7 @@ final class SettingsPluginAggregationSpec extends Specification {
 
   private def runWith(List<String> arguments) {
     return GradleRunner.create()
-      .withGradleVersion('9.7.0')
+      .withGradleVersion(GradleVersions.CURRENT)
       .withProjectDir(testProjectDir.root)
       .withArguments(arguments)
       .withPluginClasspath()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
@@ -576,7 +576,7 @@ final class TaskOptionSpec extends Specification {
     on.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
-    gradleVersion << ['8.4', '9.7.1']
+    gradleVersion << ['8.4', GradleVersions.CURRENT]
   }
 
   def 'Prints every command line option the task accepts'() {


### PR DESCRIPTION
This PR runs the functional specs and the CI examples against Gradle 9.7.1, the current release. The pins had drifted apart: some specs were on 9.7.0, the rest and the workflow on 9.6.1. The specs are now pinned through a single `GradleVersions.CURRENT` constant, so the workflow is the only other place a Gradle version is declared.
