### PR TITLE
Fix: read a dynamic version as a bound on the buildscript classpath (fixes #1090)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ tasks.named("dependencyUpdates").configure {
   version is itself a pre-release (see [Filtering unstable
   versions](#filtering-unstable-versions)).
 - `!satisfiesDeclaredBound` rejects a candidate outside a `strictly` or
-  `reject` bound the build declares, or outside the version a consumed
-  platform sets (see [Respecting declared
-  bounds](#respecting-declared-bounds)).
+  `reject` bound the build declares, outside a dynamic version declared on the
+  buildscript classpath, or outside the version a consumed platform sets (see
+  [Respecting declared bounds](#respecting-declared-bounds)).
 
 Each piece stands alone: drop any line whose behavior you do not want, and the
 rest keep working.
@@ -964,6 +964,16 @@ reads it, so `strictly "[5.3, 6["` admits 5.3.26 and excludes 6.0.1, and
 bound a candidate: a `require` version is a floor resolution may rise above, a
 range included, and a `prefer` version only breaks a tie, so a plain
 `implementation("group:name:1.2.3")` is not bounded by this rule.
+
+The buildscript classpath is the exception. There a dynamic required version
+bounds the candidate, so a plugin declared as `version "[1.0, 2["` or
+`version "1.+"` is not offered 2.0, whether the version was written in the
+`plugins` block or came from a version catalog alias. Gradle flattens an alias to
+a bare required version on the marker it synthesizes, leaving the two forms
+identical, and a plugin has one declaration, so the interval is the version
+declared rather than a floor something else may push past. The version already
+resolved stays in bound, since a transitive requirement on a classpath can push
+the selection past the interval.
 
 A module declared without a version is additionally bound by the version a
 consumed platform sets for it, since the build cannot take that upgrade without
@@ -2225,6 +2235,13 @@ version, where the entries were merged into the newest of them before:
 >   alone has to key them by the projects as well.
 
 > [!NOTE]
+> - A dependency on the buildscript classpath declared with a dynamic version,
+>   `[1.0, 2[` or `1.+`, is no longer offered a version outside it under
+>   `rejectVersionIf { !satisfiesDeclaredBound }`. The presence of a version
+>   catalog no longer changes that answer either: where the `plugins` block
+>   versioned a plugin inline as a range, the upgrade was withheld when an unused
+>   alias for the same plugin was present in the catalog and offered when it was
+>   not (see [Respecting declared bounds](#respecting-declared-bounds)).
 > - A module that a platform bounds in one project and not in another is now up
 >   to date in the bounded project and outdated in the other, rather than
 >   outdated in both. The merged entry printed an upgrade that is not available

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -502,7 +502,7 @@ private fun registerProducer(
               // configuration, so naming it would describe a script rather than a plugin.
               nameDeclaringConfiguration = false,
               // The plugins block deposits its flattened markers only on these classpaths, so
-              // only they recover a catalog plugin constraint.
+              // only they read a dynamic required version as a bound.
               scriptClasspaths = true,
               skipped,
             )

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Coordinate.kt
@@ -57,6 +57,15 @@ class Coordinate(
     private set
 
   /**
+   * Whether the build declared this coordinate on a script classpath, the sole route by which a
+   * plugin marker enters a build. A marker has one declaration and no competing edge, so a dynamic
+   * required version written on it, `[1.0, 2[` or `1.+`, is read as a bound rather than as a
+   * floor. False for a coordinate a platform scan or a substitution rule reached instead.
+   * https://github.com/ben-manes/gradle-versions-plugin/issues/755
+   */
+  internal var onScriptClasspath: Boolean = false
+
+  /**
    * The platforms whose constraint is the version reported, empty otherwise. A platform project
    * appears as its build tree path and an external one as its group and module.
    */

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -1,7 +1,6 @@
 package com.github.benmanes.gradle.versions.updates
 
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
-import com.github.benmanes.gradle.versions.updates.resolutionstrategy.statesVersionRange
 import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
 import groovy.xml.slurpersupport.NodeChildren
@@ -17,8 +16,6 @@ import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
@@ -60,22 +57,6 @@ class Resolver(
   // while skipping one costs an attribution at most.
   private val failedPlatformScans = hashSetOf<Set<ModuleDependency>>()
 
-  // Gradle flattens a version-catalog plugin alias to a bare required range on the marker
-  // dependency it synthesizes for the buildscript classpath, dropping strictly/prefer/reject.
-  // https://github.com/ben-manes/gradle-versions-plugin/issues/755
-  private val pluginCatalogConstraints: Map<Coordinate.Key, List<VersionConstraint>> by lazy {
-    val catalogs = project.extensions.findByType(VersionCatalogsExtension::class.java)
-    val constraints = hashMapOf<Coordinate.Key, MutableList<VersionConstraint>>()
-    catalogs?.forEach { catalog ->
-      for (alias in catalog.pluginAliases) {
-        val plugin = catalog.findPlugin(alias).orElse(null)?.orNull ?: continue
-        val key = Coordinate.Key(plugin.pluginId, "${plugin.pluginId}.gradle.plugin")
-        constraints.getOrPut(key) { mutableListOf() }.add(plugin.version)
-      }
-    }
-    constraints
-  }
-
   init {
     logRepositories()
   }
@@ -104,9 +85,8 @@ class Resolver(
 
   /**
    * Returns the version status as above, naming the configuration of a dependency declared directly
-   * against it when asked, which the buildscript's configurations are resolved without, and
-   * recovering catalog plugin constraints only on a script classpath, the sole route by which a
-   * plugin marker enters a build.
+   * against it when asked, which the buildscript's configurations are resolved without, and marking
+   * the coordinates of a script classpath, the sole route by which a plugin marker enters a build.
    */
   internal fun resolve(
     configuration: Configuration,
@@ -397,12 +377,7 @@ class Resolver(
     nameDeclaringConfiguration: Boolean,
     scriptClasspath: Boolean,
   ): CurrentCoordinates {
-    val declared =
-      getResolvableDependencies(configuration)
-        .associateBy { it.key }
-        .mapValues { (_, coordinate) ->
-          if (scriptClasspath) recoverPluginCatalogConstraint(coordinate) else coordinate
-        }
+    val declared = getResolvableDependencies(configuration).associateBy { it.key }
     // An empty configuration is still resolved below, so that a listener contributing to it has
     // run by the time the declared set is read again. That resolution costs nothing. One
     // containing only project or file dependencies is skipped, as resolving it would not, unless it
@@ -510,6 +485,18 @@ class Resolver(
       } else {
         emptySet()
       }
+
+    // A plugin marker reaches a build only here, and only as a single declaration with nothing to
+    // resolve against it, which is what lets its dynamic required version be read as a bound. Only
+    // what the classpath declares qualifies: a platform source is discovered by walking a
+    // platform's own graph rather than declared here, and a substitution target is reached through
+    // a rule rather than written down, so both keep the floor semantics of an ordinary
+    // declaration.
+    if (scriptClasspath) {
+      for (key in declared.keys + contributed.map { it.key }) {
+        coordinates[key]?.onScriptClasspath = true
+      }
+    }
 
     return CurrentCoordinates(
       coordinates,
@@ -650,49 +637,6 @@ class Resolver(
       )
     }
   }
-
-  /**
-   * Returns the coordinate rebuilt with the catalog's constraint, when a plugin-catalog alias
-   * flattened to the coordinate's bare required version explains it unambiguously.
-   *
-   * An alias whose constraint is no more than that required version explains the declaration just
-   * as well as a rich one, so it counts toward the ambiguity rather than being passed over. An
-   * exact required version recovers nothing even when one alias explains it: a version written
-   * inline in the plugins block cannot be told apart from one the catalog supplied once
-   * Gradle has flattened it, and crediting the alias's bound to an inline declaration would hide
-   * upgrades it never rejected. A required range keeps its own interval as the declared bound
-   * either way, so recovering it can add no more than the alias's preference and in-range rejects.
-   */
-  private fun recoverPluginCatalogConstraint(coordinate: Coordinate): Coordinate {
-    val declaredConstraint = coordinate.versionConstraint ?: return coordinate
-    // A versionless declaration has an empty required version, which an alias that only rejects
-    // would match, attaching a bound to a declaration with no version to bound.
-    if (isRich(declaredConstraint) || declaredConstraint.requiredVersion.isEmpty()) {
-      return coordinate
-    }
-    val candidates =
-      pluginCatalogConstraints[coordinate.key].orEmpty()
-        .filter { it.requiredVersion == declaredConstraint.requiredVersion }
-        .distinctBy { listOf(it.requiredVersion, it.strictVersion, it.preferredVersion, it.rejectedVersions) }
-    if (candidates.size > 1) {
-      project.logger.info(
-        "Multiple version catalog aliases for ${coordinate.key} state differing version constraints; " +
-          "keeping the declared constraint",
-      )
-      return coordinate
-    }
-    if (!statesVersionRange(declaredConstraint.requiredVersion)) {
-      return coordinate
-    }
-    val recovered = candidates.singleOrNull()?.takeIf { isRich(it) } ?: return coordinate
-    return Coordinate(coordinate.groupId, coordinate.artifactId, coordinate.version, coordinate.userReason, recovered)
-  }
-
-  /** Whether the constraint is more than a bare required version. */
-  private fun isRich(constraint: VersionConstraint): Boolean =
-    constraint.strictVersion.isNotEmpty() ||
-      constraint.preferredVersion.isNotEmpty() ||
-      constraint.rejectedVersions.isNotEmpty()
 
   /**
    * Returns the version constraints the consumed platforms set for each module declared without a

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
@@ -114,6 +114,7 @@ class ComponentSelectionRulesWithCurrent(
       current.version,
       current.versionConstraint,
       current.platformVersionConstraints,
+      current.onScriptClasspath,
     )
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -5,7 +5,6 @@ import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector
 
 class ComponentSelectionWithCurrent internal constructor(
   private val delegate: ComponentSelection,
@@ -17,6 +16,11 @@ class ComponentSelectionWithCurrent internal constructor(
    * module's declaration has its own version or no consumed platform bounds it.
    */
   val platformVersionConstraints: List<VersionConstraint>,
+  /**
+   * Whether the declaration sits on a script classpath, where a dynamic required version is read
+   * as a bound.
+   */
+  private val onScriptClasspath: Boolean = false,
 ) : ComponentSelection by delegate {
   /** Retained so the arity released before the constraint was added still links. */
   constructor(
@@ -29,9 +33,18 @@ class ComponentSelectionWithCurrent internal constructor(
    * resolution reads it, so that a range is honored rather than compared as a string.
    *
    * Only `strictly` and `reject` bound a candidate. A `require` version is a floor that resolution
-   * may rise above, a range included, and a `prefer` version is consulted only to break a tie, so
-   * neither excludes an upgrade the build already permits. True for a module that declared no
-   * bound at all.
+   * may rise above, and a `prefer` version is consulted only to break a tie, so neither excludes an
+   * upgrade the build already permits. True for a module that declared no bound at all.
+   *
+   * A *dynamic* required version, such as `[1.0, 2[` or `1.+`, is the one exception, and it applies
+   * on a script classpath alone. A plugin marker has a single declaration and no competing
+   * requirement, so the interval is the version declared rather than a floor. It is also the only
+   * form a version-catalog plugin alias survives as, since Gradle flattens the alias to a bare
+   * required version on the marker; reading it is what lets both declaration forms answer alike,
+   * which they must, as the marker is identical either way. The version currently selected is
+   * always within bound, since a transitive requirement on a classpath can push the selection past
+   * the interval.
+   * https://github.com/ben-manes/gradle-versions-plugin/issues/755
    *
    * A module declared without a version is additionally bounded by the constraints the platforms
    * the consumer depends on set for it, and the version currently selected is always within
@@ -39,7 +52,7 @@ class ComponentSelectionWithCurrent internal constructor(
    */
   val satisfiesDeclaredBound: Boolean
     get() =
-      DeclaredBound.accepts(versionConstraint, candidate.version) &&
+      DeclaredBound.accepts(versionConstraint, candidate.version, currentVersion, onScriptClasspath) &&
         DeclaredBound.acceptsPlatformSupplied(platformVersionConstraints, currentVersion, candidate.version)
 
   override fun toString(): String {
@@ -73,6 +86,8 @@ private object DeclaredBound {
   fun accepts(
     constraint: VersionConstraint?,
     candidate: String,
+    currentVersion: String,
+    dynamicRequiredBounds: Boolean,
   ): Boolean {
     val parser = scheme
     if (parser == null || constraint == null) {
@@ -80,7 +95,16 @@ private object DeclaredBound {
     }
     return try {
       val strict = constraint.strictVersion
-      if (strict.isNotEmpty() && !parser.parseSelector(strict).accept(candidate)) {
+      val outOfBound =
+        if (strict.isNotEmpty()) {
+          !parser.parseSelector(strict).accept(candidate)
+        } else {
+          // The selected version is left in bound, since a transitive requirement can push the
+          // selection past an interval that is only a floor.
+          dynamicRequiredBounds && candidate != currentVersion &&
+            excludedByDynamicRequired(constraint.requiredVersion, candidate)
+        }
+      if (outOfBound) {
         false
       } else {
         constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
@@ -90,14 +114,23 @@ private object DeclaredBound {
     }
   }
 
-  /** Whether the version parses as a range selector, the form a rich constraint flattens to. */
-  fun statesRange(version: String): Boolean {
+  /**
+   * Whether the required version is dynamic and excludes the candidate. A selector admitting every
+   * version, `latest.release` among them, therefore bounds nothing. The catch is a guard for a
+   * release that moves the parser or rejects a form Gradle itself accepted, which leaves the bound
+   * unknown rather than failing the whole report, as [accepts] does for a linkage failure.
+   */
+  private fun excludedByDynamicRequired(
+    version: String,
+    candidate: String,
+  ): Boolean {
     val parser = scheme
     if (parser == null || version.isEmpty()) {
       return false
     }
     return try {
-      parser.parseSelector(version) is VersionRangeSelector
+      val selector = parser.parseSelector(version)
+      selector.isDynamic && !selector.accept(candidate)
     } catch (e: Exception) {
       false
     }
@@ -133,6 +166,3 @@ private object DeclaredBound {
     }
   }
 }
-
-/** Whether the version parses as a range selector, the form a rich constraint flattens to. */
-internal fun statesVersionRange(version: String): Boolean = DeclaredBound.statesRange(version)

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -256,6 +256,52 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().outdated.dependencies[0].available.milestone == '3.1'
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+  def 'a script classpath does not report the version it resolved as a downgrade'() {
+    given: 'a classpath range a transitive requires more than, so resolution rises above it'
+    // The versionless guava declaration is what makes the copy resolve transitively, which is the
+    // only way guice-consumer's requirement can push guice past its range. Drop it and the report
+    // never reaches the case below.
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          configurations.create('probeClasspath')
+          dependencies {
+            constraints {
+              probeClasspath 'com.google.guava:guava:15.0'
+            }
+            probeClasspath 'com.google.guava:guava'
+            probeClasspath 'com.google.inject:guice:[2.0, 3.0['
+            probeClasspath 'com.example:guice-consumer:1.0'
+          }
+        }
+
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          rejectVersionIf {
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
+
+    when:
+    def result = run()
+
+    then: 'the selected version is in bound even where the interval alone would exclude it'
+    !result.output.contains('com.google.inject:guice [3.0 <- ')
+    result.output.contains(' - com.google.inject:guice:3.0')
+  }
+
   def 'a module with no declared bound is not bounded'() {
     given: 'a plain declaration is a floor resolution may rise above, not a bound'
     writeBuildFile(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/PluginMarkerCatalogSpec.groovy
@@ -11,8 +11,9 @@ import spock.lang.Unroll
 
 /**
  * Gradle flattens a version-catalog plugin alias to a bare required range on the buildscript
- * classpath marker, dropping {@code strictly}/{@code prefer}/{@code reject}. These specs pin the
- * recovery that rebuilds the marker's constraint from the catalog it came from.
+ * classpath marker, dropping {@code strictly}/{@code prefer}/{@code reject}, and leaves a marker
+ * indistinguishable from one the plugins block versioned inline. These specs pin the reading that
+ * bounds such a marker by the range it carries, whichever form declared it.
  */
 @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
 final class PluginMarkerCatalogSpec extends Specification {
@@ -102,7 +103,67 @@ final class PluginMarkerCatalogSpec extends Specification {
     gradleVersion << ['current', '8.4']
   }
 
-  def 'the rule reads the catalog declaration verbatim'() {
+  @Unroll
+  def 'a range written inline in the plugins block bounds the marker #catalogState'() {
+    given:
+    pluginManagementSettings()
+    if (withCatalog) {
+      catalog(
+        """
+          [versions]
+          demo = { strictly = "[1.0, 2[", prefer = "1.0" }
+
+          [plugins]
+          demo = { id = "com.example.settings-demo", version.ref = "demo" }
+        """)
+    }
+    buildFile(
+      "id 'com.example.settings-demo' version '[1.0, 2[' apply false",
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then: 'an unused alias for the same id is not what the report follows from'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
+
+    where:
+    catalogState                | withCatalog
+    'with a catalog present'    | true
+    'with no catalog at all'    | false
+  }
+
+  def 'a plus-shorthand version bounds the marker'() {
+    given:
+    pluginManagementSettings()
+    buildFile(
+      "id 'com.example.settings-demo' version '1.+' apply false",
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = runOn('current')
+
+    then: 'the shorthand states an interval as much as a bracketed range does'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    !result.output.contains(
+      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
+    result.output.contains(
+      ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
+  }
+
+  def "the rule reads the marker's flattened constraint"() {
     given:
     pluginManagementSettings()
     catalog(
@@ -129,13 +190,13 @@ final class PluginMarkerCatalogSpec extends Specification {
     when:
     def result = runOn('current')
 
-    then:
+    then: 'a rule is handed what the build declared, never a bound rebuilt on its behalf'
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains(
-      "PROBE strict='[1.0, 2[' prefer='1.0' required='[1.0, 2['")
+      "PROBE strict='' prefer='' required='[1.0, 2['")
   }
 
-  def 'a version rewritten by eachPlugin recovers nothing'() {
+  def 'a version rewritten by eachPlugin replaces the declared range'() {
     given:
     pluginManagementSettings(
       """
@@ -177,7 +238,7 @@ final class PluginMarkerCatalogSpec extends Specification {
       ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:2.0')
   }
 
-  def 'two aliases for one id with differing constraints recover nothing'() {
+  def 'differing catalog aliases for one id do not change the marker bound'() {
     given:
     pluginManagementSettings()
     catalog(
@@ -194,76 +255,6 @@ final class PluginMarkerCatalogSpec extends Specification {
       'alias(libs.plugins.demoAlpha) apply false',
       """
         rejectVersionIf {
-          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-            println "PROBE strict='\${versionConstraint?.strictVersion}'"
-          }
-          !satisfiesDeclaredBound
-        }
-      """)
-
-    when:
-    def result = runOn('current', ['--info'])
-
-    then: 'no alias is credited, so nothing bounds the report and 2.0 is offered'
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains("PROBE strict=''")
-    result.output.contains(
-      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
-    result.output.contains(
-      'Multiple version catalog aliases for com.example.settings-demo:com.example.settings-demo.gradle.plugin ' +
-        'state differing version constraints; keeping the declared constraint')
-  }
-
-  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
-  def 'a plain alias for one id blocks recovery from a rich one'() {
-    given:
-    pluginManagementSettings()
-    catalog(
-      """
-        [plugins]
-        demoPlain = { id = "com.example.settings-demo", version = "1.0" }
-        demoBounded = { id = "com.example.settings-demo", version = { require = "1.0", reject = ["2.0"] } }
-      """)
-    buildFile(
-      'alias(libs.plugins.demoPlain) apply false',
-      """
-        rejectVersionIf {
-          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-            println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
-          }
-          !satisfiesDeclaredBound
-        }
-      """)
-
-    when:
-    def result = runOn('current', ['--info'])
-
-    then:
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains('PROBE rejects=[]')
-    result.output.contains(
-      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
-    result.output.contains(
-      'Multiple version catalog aliases for com.example.settings-demo:com.example.settings-demo.gradle.plugin ' +
-        'state differing version constraints; keeping the declared constraint')
-  }
-
-  def 'two aliases for one id with identical constraints still recover'() {
-    given:
-    pluginManagementSettings()
-    catalog(
-      """
-        [versions]
-        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
-
-        [plugins]
-        demoAlpha = { id = "com.example.settings-demo", version.ref = "demo" }
-        demoBeta = { id = "com.example.settings-demo", version.ref = "demo" }
-      """)
-    buildFile(
-      'alias(libs.plugins.demoAlpha) apply false',
-      """
-        rejectVersionIf {
           !satisfiesDeclaredBound
         }
       """)
@@ -271,7 +262,7 @@ final class PluginMarkerCatalogSpec extends Specification {
     when:
     def result = runOn('current')
 
-    then:
+    then: 'the range on the marker is what applies, so a second alias for the id is beside the point'
     result.task(':dependencyUpdates').outcome == SUCCESS
     !result.output.contains(
       'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
@@ -279,16 +270,8 @@ final class PluginMarkerCatalogSpec extends Specification {
       ' - com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0')
   }
 
-  def 'a project dependency on the marker coordinate recovers nothing from the catalog'() {
+  def 'a project dependency stating a range is not bounded by it'() {
     given:
-    catalog(
-      """
-        [versions]
-        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
-
-        [plugins]
-        demo = { id = "com.example.settings-demo", version.ref = "demo" }
-      """)
     testProjectDir.newFile('build.gradle') <<
       """
         plugins {
@@ -317,205 +300,14 @@ final class PluginMarkerCatalogSpec extends Specification {
     when:
     def result = runOn('current')
 
-    then: 'the alias states a strictly the declaration never did, so 2.0 stays on offer'
+    then: 'a transitive can push an ordinary module past its range without failing the build'
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains(
       'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
   }
 
-  def 'a project dependency at a plain version recovers nothing'() {
-    given:
-    catalog(
-      """
-        [plugins]
-        demo = { id = "com.example.settings-demo", version = { require = "1.0", reject = ["2.0"] } }
-      """)
-    testProjectDir.newFile('build.gradle') <<
-      """
-        plugins {
-          id 'java-library'
-          id 'io.github.ben-manes.versions'
-        }
-
-        repositories {
-          maven {
-            url = '${mavenRepoUrl}'
-          }
-        }
-
-        dependencies {
-          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
-        }
-
-        tasks.named('dependencyUpdates').configure {
-          checkForGradleUpdate = false
-          rejectVersionIf {
-            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-              println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
-            }
-            !satisfiesDeclaredBound
-          }
-        }
-      """.stripIndent()
-
-    when:
-    def result = runOn('current')
-
-    then:
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains('PROBE rejects=[]')
-    result.output.contains(
-      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
-  }
-
-  def 'a project dependency stating the alias range recovers nothing'() {
-    given:
-    catalog(
-      """
-        [versions]
-        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
-
-        [plugins]
-        demo = { id = "com.example.settings-demo", version.ref = "demo" }
-      """)
-    testProjectDir.newFile('build.gradle') <<
-      """
-        plugins {
-          id 'java-library'
-          id 'io.github.ben-manes.versions'
-        }
-
-        repositories {
-          maven {
-            url = '${mavenRepoUrl}'
-          }
-        }
-
-        dependencies {
-          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:[1.0, 2['
-        }
-
-        tasks.named('dependencyUpdates').configure {
-          checkForGradleUpdate = false
-          rejectVersionIf {
-            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-              println "PROBE strict='\${versionConstraint?.strictVersion}'" +
-                " prefer='\${versionConstraint?.preferredVersion}'"
-            }
-            !satisfiesDeclaredBound
-          }
-        }
-      """.stripIndent()
-
-    when:
-    def result = runOn('current')
-
-    then: 'nothing is credited from the alias, so the strictly it states never applies'
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains("PROBE strict='' prefer=''")
-    result.output.contains(
-      'com.example.settings-demo:com.example.settings-demo.gradle.plugin [1.0 -> 2.0]')
-  }
-
-  def 'a versionless declaration recovers nothing from a reject-only alias'() {
-    given:
-    catalog(
-      """
-        [plugins]
-        demo = { id = "com.example.settings-demo", version = { reject = ["2.0"] } }
-      """)
-    testProjectDir.newFile('build.gradle') <<
-      """
-        plugins {
-          id 'java-library'
-          id 'io.github.ben-manes.versions'
-        }
-
-        repositories {
-          maven {
-            url = '${mavenRepoUrl}'
-          }
-        }
-
-        dependencies {
-          constraints {
-            implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin:1.0'
-          }
-          implementation 'com.example.settings-demo:com.example.settings-demo.gradle.plugin'
-        }
-
-        tasks.named('dependencyUpdates').configure {
-          checkForGradleUpdate = false
-          rejectVersionIf {
-            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-              println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
-            }
-            return false
-          }
-        }
-      """.stripIndent()
-
-    when:
-    def result = runOn('current')
-
-    then:
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains('PROBE rejects=[]')
-  }
-
-  def 'a declaration with its own rich constraint keeps it'() {
-    given:
-    catalog(
-      """
-        [versions]
-        demo = { strictly = "[1.0, 2[", reject = ["1.0"] }
-
-        [plugins]
-        demo = { id = "com.example.settings-demo", version.ref = "demo" }
-      """)
-    testProjectDir.newFile('build.gradle') <<
-      """
-        plugins {
-          id 'java-library'
-          id 'io.github.ben-manes.versions'
-        }
-
-        repositories {
-          maven {
-            url = '${mavenRepoUrl}'
-          }
-        }
-
-        dependencies {
-          implementation('com.example.settings-demo:com.example.settings-demo.gradle.plugin') {
-            version {
-              strictly '[1.0, 2['
-            }
-          }
-        }
-
-        tasks.named('dependencyUpdates').configure {
-          checkForGradleUpdate = false
-          rejectVersionIf {
-            if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-              println "PROBE rejects=\${versionConstraint?.rejectedVersions}"
-            }
-            return false
-          }
-        }
-      """.stripIndent()
-
-    when:
-    def result = runOn('current')
-
-    then:
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains('PROBE rejects=[]')
-  }
-
-  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
   @Unroll
-  def 'an exact version from #declaration recovers nothing'() {
+  def 'an exact version from #declaration does not bound the marker'() {
     given:
     pluginManagementSettings()
     catalog(
@@ -537,7 +329,7 @@ final class PluginMarkerCatalogSpec extends Specification {
     when:
     def result = runOn('current')
 
-    then: 'the flattened exact version could as well be stated inline, so no bound is credited'
+    then: 'an exact required version is a floor resolution may rise above, as it is elsewhere'
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('PROBE rejects=[]')
     result.output.contains(
@@ -547,35 +339,5 @@ final class PluginMarkerCatalogSpec extends Specification {
     declaration         | pluginsLine
     'the plugins block' | "id 'com.example.settings-demo' version '1.0' apply false"
     'the catalog alias' | 'alias(libs.plugins.demo) apply false'
-  }
-
-  def 'a plain string plugin version recovers nothing'() {
-    given:
-    pluginManagementSettings()
-    catalog(
-      """
-        [versions]
-        demo = { strictly = "[1.0, 2[", prefer = "1.0" }
-
-        [plugins]
-        demo = { id = "com.example.settings-demo", version.ref = "demo" }
-      """)
-    buildFile(
-      "id 'com.example.settings-demo' version '1.0' apply false",
-      """
-        rejectVersionIf {
-          if (candidate.module == 'com.example.settings-demo.gradle.plugin') {
-            println "PROBE strict='\${versionConstraint?.strictVersion}'"
-          }
-          return false
-        }
-      """)
-
-    when:
-    def result = runOn('current')
-
-    then:
-    result.task(':dependencyUpdates').outcome == SUCCESS
-    result.output.contains("PROBE strict=''")
   }
 }


### PR DESCRIPTION
Fixes #1090.

Gradle flattens a version-catalog plugin alias to a bare required version on the marker it synthesizes, and the marker for a version written inline in the `plugins` block is identical to it field for field, so nothing distinguishes the declaration that the recovery added for #755 applies the alias's `strictly` to. Reading a dynamic required version as the bound on the buildscript classpath instead keeps #755's case working without consulting the catalog at all, and the two declaration forms are then treated the same. Off the classpath a required version stays a floor, which is what the README documents and what the guice case in `DeclaredVersionConstraintSpec` pins.

The version already resolved stays in bound, since a transitive on a classpath can push the selection above the interval and a downgrade would otherwise be reported to the newest version still inside it. `1.+` is bounded alongside `[1.0, 2[`, as Gradle caps both the same way. The reading covers the whole classpath rather than plugin markers alone, so a `buildscript` `classpath` entry declared with a dynamic version is bounded the same way.
