### PR TITLE
Replace the `!satisfiesDeclaredBound` recipe with a `rejectOutOfBoundVersions` task property

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,16 +61,15 @@ How a pull request lands:
 - Beyond that, match the file you are editing: Kotlin sources carry no
   license header, comments are rare and explain only what the code cannot,
   and a README snippet is added in both Kotlin and Groovy.
-- A policy, which is anything that decides which entries appear in the report,
-  is a task property. A fact about a candidate, which is anything that cannot
-  be worked out from a build script alone, is a member of the `rejectVersionIf`
-  receiver, and exists so that a policy not shipped here can still be written
-  in a build script. Configuring `resolutionStrategy` changes the resolution
-  the candidates come from, and the output properties cover only where and how
-  the report is written; neither is a place for a policy. A policy documented
-  as a recipe to copy into a build script belongs on the task instead, since a
-  command line option reaches a task property and reaches no rule written in a
-  build script.
+- A setting that affects which entries appear in the report goes on the task
+  as a property, so that it can be set from the command line. A fact about a
+  candidate that cannot be worked out from a build script alone, such as
+  whether the candidate lies within a declared bound, goes on the
+  `rejectVersionIf` receiver, so that a rule that is not built in can still be
+  written in a build script. Do not document a setting as a `rejectVersionIf`
+  recipe to copy into a build script. `resolutionStrategy` is only for how the
+  candidates are resolved, and the output properties only for where and how
+  the report is written.
 - Add a command line option, with `@Option`, to every task property a build
   author sets to configure the report or where it is written, so that a single
   run can change it without an edit to the build script. A property configured

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,16 @@ How a pull request lands:
 - Beyond that, match the file you are editing: Kotlin sources carry no
   license header, comments are rare and explain only what the code cannot,
   and a README snippet is added in both Kotlin and Groovy.
+- A policy, which is anything that decides which entries appear in the report,
+  is a task property. A fact about a candidate, which is anything that cannot
+  be worked out from a build script alone, is a member of the `rejectVersionIf`
+  receiver, and exists so that a policy not shipped here can still be written
+  in a build script. Configuring `resolutionStrategy` changes the resolution
+  the candidates come from, and the output properties cover only where and how
+  the report is written; neither is a place for a policy. A policy documented
+  as a recipe to copy into a build script belongs on the task instead, since a
+  command line option reaches a task property and reaches no rule written in a
+  build script.
 - Add a command line option, with `@Option`, to every task property a build
   author sets to configure the report or where it is written, so that a single
   run can change it without an edit to the build script. A property configured

--- a/README.md
+++ b/README.md
@@ -913,10 +913,10 @@ tasks.named("dependencyUpdates").configure {
 
 ##### Respecting declared bounds
 
-The report stays inside the bounds written in the build itself. A candidate
-outside a bound on the declaration, or outside the version fixed by a consumed
-platform, is left out, so the only versions listed are ones the build can
-actually move to. `rejectOutOfBoundVersions` turns that off:
+The report is held to the bounds written in the build. A candidate outside a
+bound on the declaration, or outside the version fixed by a consumed platform,
+is left out, so the only versions listed are ones the build can actually be
+moved to. Set `rejectOutOfBoundVersions` to `false` to turn that off:
 
 <details open>
 <summary>Kotlin</summary>
@@ -944,8 +944,8 @@ tasks.named("dependencyUpdates").configure {
 
 To see what is left out, without an edit to the build script, run
 `./gradlew dependencyUpdates --no-reject-out-of-bound-versions`. Run it to
-learn what a bounded module could move to if the bound were lifted, such as
-whether a fix shipped in the module before its platform caught up.
+learn what a bounded module could be moved to if the bound were lifted, such
+as whether a fix was released for the module ahead of its platform.
 
 A bound is read the way dependency resolution reads it, so `strictly "[5.3,
 6["` admits 5.3.26 and excludes 6.0.1, and `reject "[3.0,)"` excludes
@@ -954,12 +954,12 @@ everything from 3.0 up. Only `strictly` and `reject` bound a candidate: a
 `prefer` version only breaks a tie, so a plain
 `implementation("group:name:1.2.3")` is not bounded.
 
-The bound is not applied in two cases where it settles nothing. A candidate no
-newer than the version in use is not an upgrade, so it stays, and a module
-whose version already exceeds everything published is still listed on the
+The bound is not applied in two cases where it makes no difference. A
+candidate no newer than the version in use is not an upgrade, so it stays, and
+a module at a version above everything published is still listed on the
 exceeded row. Where the version in use already lies outside the bound, the
-bound is not applied at all, since a transitive requirement that pushed the
-version past a platform leaves that platform bounding nothing.
+bound is not applied at all: once a transitive requirement has pushed the
+version past a platform, the platform no longer bounds anything.
 
 The same bound is readable from a rule. The constraint written on a
 declaration is available as `versionConstraint`, Gradle's
@@ -968,7 +968,7 @@ For a module declared without a version, the constraints fixed for that module
 by the consumed platforms are available as `platformVersionConstraints`. It
 is a list rather than a single value, because more than one consumed platform
 can bound the same module. The query that finds candidates is deliberately
-unbounded, so a rule that respects a declared bound reads it from
+unbounded, so a rule that applies a declared bound reads it from
 `versionConstraint` rather than restating it. It is null for a module no
 declaration was matched to, such as one a substitution rule resolved to, so
 guard for that. `satisfiesDeclaredBound`, the verdict a rule applied before the
@@ -2233,7 +2233,7 @@ and *Note*s are things worth knowing that need no action.
 ### v0.61.0
 
 In the next release, the report is held to the bounds written in the build
-without a rule to ask for it, and a coordinate whose one declared version has
+without a rule written for it, and a coordinate with one declared version and
 different latest versions across the aggregated projects is shown on one entry
 per latest version, where the entries were merged into the newest of them
 before:
@@ -2252,16 +2252,17 @@ before:
 >   alone has to key them by the projects as well.
 
 > [!TIP]
-> - Drop `!satisfiesDeclaredBound` from a `rejectVersionIf` rule, since
->   `rejectOutOfBoundVersions` now applies the bound on its own. The member is
+> - Drop `!satisfiesDeclaredBound` from a `rejectVersionIf` rule, since the
+>   bound is now applied by `rejectOutOfBoundVersions`. The member is
 >   deprecated and will be removed in a later release; a warning is printed
->   once per project when a rule reads it. A rule that keeps the clause still
->   rejects under `--no-reject-out-of-bound-versions`.
+>   once per project when a rule reads it. With the clause still in a rule,
+>   the same candidates are rejected under `--no-reject-out-of-bound-versions`
+>   as without it.
 
 > [!NOTE]
-> - The presence of a version catalog no longer changes whether a plugin the
->   `plugins` block versioned inline as a range is offered an upgrade past that
->   range. The upgrade was withheld when an unused alias for the same plugin was
+> - The presence of a version catalog no longer changes whether a plugin
+>   versioned inline as a range in the `plugins` block is offered an upgrade
+>   past that range. The upgrade was withheld when an unused alias for the same plugin was
 >   present in the catalog and offered when it was not (see [Respecting declared
 >   bounds](#respecting-declared-bounds)).
 > - A module that a platform bounds in one project and not in another is now up

--- a/README.md
+++ b/README.md
@@ -298,8 +298,7 @@ fun String.isNonStable(): Boolean {
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
   checkConstraints = true
   rejectVersionIf {
-    (candidate.version.isNonStable() && !currentVersion.isNonStable()) ||
-      !satisfiesDeclaredBound
+    candidate.version.isNonStable() && !currentVersion.isNonStable()
   }
 }
 ```
@@ -319,8 +318,7 @@ def isNonStable = { String version ->
 tasks.named("dependencyUpdates").configure {
   checkConstraints = true
   rejectVersionIf {
-    (isNonStable(candidate.version) && !isNonStable(currentVersion)) ||
-      !satisfiesDeclaredBound
+    isNonStable(candidate.version) && !isNonStable(currentVersion)
   }
 }
 ```
@@ -332,10 +330,11 @@ tasks.named("dependencyUpdates").configure {
 - The stability clause rejects a pre-release candidate unless the current
   version is itself a pre-release (see [Filtering unstable
   versions](#filtering-unstable-versions)).
-- `!satisfiesDeclaredBound` rejects a candidate outside a `strictly` or
-  `reject` bound the build declares, outside a dynamic version declared on the
-  buildscript classpath, or outside the version a consumed platform sets (see
-  [Respecting declared bounds](#respecting-declared-bounds)).
+- A candidate outside a `strictly` or `reject` bound written in the build,
+  outside a dynamic version declared on the buildscript classpath, or outside
+  the version fixed by a consumed platform, is already left out by
+  `rejectOutOfBoundVersions`, which is on by default (see [Respecting declared
+  bounds](#respecting-declared-bounds)).
 
 Each piece stands alone: drop any line whose behavior you do not want, and the
 rest keep working.
@@ -364,6 +363,7 @@ command line option, since no command line can express the logic.
 | [`checkBuildEnvironmentConstraints`](#constraints) | `true`, `false` | `false` | `--[no-]check-build-environment-constraints` |
 | [`filterConfigurations`](#filterconfigurations) | a `Spec<Configuration>` | every configuration | |
 | [`filterDeclaredConfigurations`](#filterdeclaredconfigurations) | a `Spec<String>` | every name | |
+| [`rejectOutOfBoundVersions`](#respecting-declared-bounds) | `true`, `false` | `true` | `--[no-]reject-out-of-bound-versions` |
 | [`rejectVersionIf`](#filtering-unstable-versions) | a predicate over the candidate | nothing rejected | |
 | [`outputFormatter`](#report-format) | `text`, `json`, `xml`, `html`, a comma separated list of those, or a `Reporter` | `text` | `--output-formatter` |
 | [`outputDir`](#outputdir) | a directory path | `<buildDirectory>/dependencyUpdates` | `--output-dir` |
@@ -913,31 +913,19 @@ tasks.named("dependencyUpdates").configure {
 
 ##### Respecting declared bounds
 
-A rule can also keep the report inside what the build itself declared. The
-constraint written on a declaration is available as `versionConstraint`,
-Gradle's own
-[`VersionConstraint`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/VersionConstraint.html).
-For a module the build declares without a version, the constraints its consumed
-platforms set for that module are available as `platformVersionConstraints`. It
-is a list rather than a single value, because more than one consumed platform
-can bound the same module. The query that finds candidates is deliberately
-unbounded, so a rule respecting what the build declared reads it from
-`versionConstraint` rather than restating it. It is null for a module no
-declaration was matched to, such as one a substitution rule resolved to, so
-guard for that.
+The report stays inside the bounds written in the build itself. A candidate
+outside a bound on the declaration, or outside the version fixed by a consumed
+platform, is left out, so the only versions listed are ones the build can
+actually move to. `rejectOutOfBoundVersions` turns that off:
 
 <details open>
 <summary>Kotlin</summary>
-
-Keep the report inside the bound the build already declares:
 
 ```kotlin
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-  rejectVersionIf {
-    !satisfiesDeclaredBound
-  }
+  rejectOutOfBoundVersions = false
 }
 ```
 
@@ -946,24 +934,47 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 <details>
 <summary>Groovy</summary>
 
-Keep the report inside the bound the build already declares:
-
 ```groovy
 tasks.named("dependencyUpdates").configure {
-  rejectVersionIf {
-    !satisfiesDeclaredBound
-  }
+  rejectOutOfBoundVersions = false
 }
 ```
 
 </details>
 
-`satisfiesDeclaredBound` reads a declared range the way dependency resolution
-reads it, so `strictly "[5.3, 6["` admits 5.3.26 and excludes 6.0.1, and
-`reject "[3.0,)"` excludes everything from 3.0 up. Only `strictly` and `reject`
-bound a candidate: a `require` version is a floor resolution may rise above, a
-range included, and a `prefer` version only breaks a tie, so a plain
-`implementation("group:name:1.2.3")` is not bounded by this rule.
+To see what is left out, without an edit to the build script, run
+`./gradlew dependencyUpdates --no-reject-out-of-bound-versions`.
+
+A bound is read the way dependency resolution reads it, so `strictly "[5.3,
+6["` admits 5.3.26 and excludes 6.0.1, and `reject "[3.0,)"` excludes
+everything from 3.0 up. Only `strictly` and `reject` bound a candidate: a
+`require` version is a floor resolution may rise above, a range included, and a
+`prefer` version only breaks a tie, so a plain
+`implementation("group:name:1.2.3")` is not bounded.
+
+Less is left out than a hand-written rule leaves out, in two cases where a
+bound settles nothing. A candidate no newer than the version in use is not an
+upgrade, so it stays, and a module whose version already exceeds everything
+published is still listed on the exceeded row. Where the version in use already
+lies outside the bound, the bound is not applied at all, since a transitive
+requirement that pushed the version past a platform leaves that platform
+bounding nothing. A hand-written rule rejects both, so
+`rejectOutOfBoundVersions = false` beside a `rejectVersionIf {
+!satisfiesDeclaredBound }` reproduces the stricter behavior exactly.
+
+The same bound is readable from a rule. The
+constraint written on a declaration is available as `versionConstraint`,
+Gradle's own
+[`VersionConstraint`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/VersionConstraint.html),
+and the verdict behind the property is available as `satisfiesDeclaredBound`.
+For a module declared without a version, the constraints fixed for that module
+by the consumed platforms are available as `platformVersionConstraints`. It
+is a list rather than a single value, because more than one consumed platform
+can bound the same module. The query that finds candidates is deliberately
+unbounded, so a rule that respects a declared bound reads it from
+`versionConstraint` rather than restating it. It is null for a module no
+declaration was matched to, such as one a substitution rule resolved to, so
+guard for that.
 
 The buildscript classpath is the exception. There a dynamic required version
 bounds the candidate, so a plugin declared as `version "[1.0, 2["` or
@@ -1004,9 +1015,8 @@ dependencies {
 
 </details>
 
-`satisfiesDeclaredBound` bounds `log4j-core` at `2.16.0` even though
-`versionConstraint` is empty for it, because the bound comes from the platform
-instead:
+`log4j-core` is bounded at `2.16.0` even though `versionConstraint` is empty
+for it, because the bound comes from the platform instead:
 
 ```text
 The following dependencies are using the latest milestone version:
@@ -1861,7 +1871,8 @@ task by that name now fails with a duplicate-task error—rename yours.
 
 The settings that control resolution (`revision`, `rejectVersionIf` or a full
 `resolutionStrategy`, `filterConfigurations`, `filterDeclaredConfigurations`,
-`checkConstraints`, and `checkBuildEnvironmentConstraints`) are inherited from
+`checkConstraints`, `checkBuildEnvironmentConstraints`, and
+`rejectOutOfBoundVersions`) are inherited from
 the nearest project up the hierarchy whose task set them. Configuring the root
 project's task therefore covers every project, unless a subproject configures
 its own (see [Task properties](#task-properties)).
@@ -2223,25 +2234,36 @@ and *Note*s are things worth knowing that need no action.
 
 ### v0.61.0
 
-In the next release, a coordinate whose one declared version has different
-latest versions across the aggregated projects is shown on one entry per latest
-version, where the entries were merged into the newest of them before:
+In the next release, the report is held to the bounds written in the build
+without a rule to ask for it, and a coordinate whose one declared version has
+different latest versions across the aggregated projects is shown on one entry
+per latest version, where the entries were merged into the newest of them
+before:
 
 > [!IMPORTANT]
+> - A candidate outside a `strictly` or `reject` bound written in the build,
+>   outside a dynamic version declared on the buildscript classpath, or outside
+>   the version fixed by a consumed platform, is left out of the report, where
+>   it was listed before. Set `rejectOutOfBoundVersions = false` to list it
+>   again, or pass `--no-reject-out-of-bound-versions` for a single run (see
+>   [Respecting declared bounds](#respecting-declared-bounds)).
 > - A coordinate's group and name can now appear on two entries of one report,
 >   and in two of its sections. The projects for each entry are included in
 >   `projects` (see [Multi-project builds](#multi-project-builds)), which is
 >   what distinguishes them. A tool that keys the entries by group and name
 >   alone has to key them by the projects as well.
 
+> [!TIP]
+> - A build that wrote `rejectVersionIf { !satisfiesDeclaredBound }` can drop
+>   the clause, which `rejectOutOfBoundVersions` now applies on its own.
+>   Keeping it changes nothing.
+
 > [!NOTE]
-> - A dependency on the buildscript classpath declared with a dynamic version,
->   `[1.0, 2[` or `1.+`, is no longer offered a version outside it under
->   `rejectVersionIf { !satisfiesDeclaredBound }`. The presence of a version
->   catalog no longer changes that answer either: where the `plugins` block
->   versioned a plugin inline as a range, the upgrade was withheld when an unused
->   alias for the same plugin was present in the catalog and offered when it was
->   not (see [Respecting declared bounds](#respecting-declared-bounds)).
+> - The presence of a version catalog no longer changes whether a plugin the
+>   `plugins` block versioned inline as a range is offered an upgrade past that
+>   range. The upgrade was withheld when an unused alias for the same plugin was
+>   present in the catalog and offered when it was not (see [Respecting declared
+>   bounds](#respecting-declared-bounds)).
 > - A module that a platform bounds in one project and not in another is now up
 >   to date in the bounded project and outdated in the other, rather than
 >   outdated in both. The merged entry printed an upgrade that is not available

--- a/README.md
+++ b/README.md
@@ -980,9 +980,10 @@ bounds the candidate, so a plugin declared as `version "[1.0, 2["` or
 `plugins` block or came from a version catalog alias. Gradle flattens an alias to
 a bare required version on the marker it synthesizes, leaving the two forms
 identical, and a plugin has one declaration, so the interval is the version
-declared rather than a floor something else may push past. The version already
-resolved stays in bound, since a transitive requirement on a classpath can push
-the selection past the interval.
+declared rather than a floor something else may push past. Where a transitive
+requirement on a classpath has pushed the selection past the interval, the
+version already resolved lies outside the bound, and the bound is not applied,
+as above.
 
 A module declared without a version is additionally bound by the version a
 consumed platform sets for it, since the build cannot take that upgrade without
@@ -2255,9 +2256,10 @@ before:
 > - Drop `!satisfiesDeclaredBound` from a `rejectVersionIf` rule, since the
 >   bound is now applied by `rejectOutOfBoundVersions`. The member is
 >   deprecated and will be removed in a later release; a warning is printed
->   once per project when a rule reads it. With the clause still in a rule,
->   the same candidates are rejected under `--no-reject-out-of-bound-versions`
->   as without it.
+>   once per project when a rule reads it, and a Kotlin DSL build that treats
+>   compiler warnings as errors has to drop the clause before upgrading. With
+>   the clause still in a rule, the same candidates are rejected under
+>   `--no-reject-out-of-bound-versions` as without it.
 
 > [!NOTE]
 > - The presence of a version catalog no longer changes whether a plugin

--- a/README.md
+++ b/README.md
@@ -943,7 +943,9 @@ tasks.named("dependencyUpdates").configure {
 </details>
 
 To see what is left out, without an edit to the build script, run
-`./gradlew dependencyUpdates --no-reject-out-of-bound-versions`.
+`./gradlew dependencyUpdates --no-reject-out-of-bound-versions`. Run it to
+learn what a bounded module could move to if the bound were lifted, such as
+whether a fix shipped in the module before its platform caught up.
 
 A bound is read the way dependency resolution reads it, so `strictly "[5.3,
 6["` admits 5.3.26 and excludes 6.0.1, and `reject "[3.0,)"` excludes

--- a/README.md
+++ b/README.md
@@ -952,21 +952,16 @@ everything from 3.0 up. Only `strictly` and `reject` bound a candidate: a
 `prefer` version only breaks a tie, so a plain
 `implementation("group:name:1.2.3")` is not bounded.
 
-Less is left out than a hand-written rule leaves out, in two cases where a
-bound settles nothing. A candidate no newer than the version in use is not an
-upgrade, so it stays, and a module whose version already exceeds everything
-published is still listed on the exceeded row. Where the version in use already
-lies outside the bound, the bound is not applied at all, since a transitive
-requirement that pushed the version past a platform leaves that platform
-bounding nothing. A hand-written rule rejects both, so
-`rejectOutOfBoundVersions = false` beside a `rejectVersionIf {
-!satisfiesDeclaredBound }` reproduces the stricter behavior exactly.
+The bound is not applied in two cases where it settles nothing. A candidate no
+newer than the version in use is not an upgrade, so it stays, and a module
+whose version already exceeds everything published is still listed on the
+exceeded row. Where the version in use already lies outside the bound, the
+bound is not applied at all, since a transitive requirement that pushed the
+version past a platform leaves that platform bounding nothing.
 
-The same bound is readable from a rule. The
-constraint written on a declaration is available as `versionConstraint`,
-Gradle's own
-[`VersionConstraint`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/VersionConstraint.html),
-and the verdict behind the property is available as `satisfiesDeclaredBound`.
+The same bound is readable from a rule. The constraint written on a
+declaration is available as `versionConstraint`, Gradle's
+[`VersionConstraint`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/VersionConstraint.html).
 For a module declared without a version, the constraints fixed for that module
 by the consumed platforms are available as `platformVersionConstraints`. It
 is a list rather than a single value, because more than one consumed platform
@@ -974,7 +969,8 @@ can bound the same module. The query that finds candidates is deliberately
 unbounded, so a rule that respects a declared bound reads it from
 `versionConstraint` rather than restating it. It is null for a module no
 declaration was matched to, such as one a substitution rule resolved to, so
-guard for that.
+guard for that. `satisfiesDeclaredBound`, the verdict a rule applied before the
+property did, is deprecated and will be removed in a later release.
 
 The buildscript classpath is the exception. There a dynamic required version
 bounds the candidate, so a plugin declared as `version "[1.0, 2["` or
@@ -2254,9 +2250,11 @@ before:
 >   alone has to key them by the projects as well.
 
 > [!TIP]
-> - A build that wrote `rejectVersionIf { !satisfiesDeclaredBound }` can drop
->   the clause, which `rejectOutOfBoundVersions` now applies on its own.
->   Keeping it changes nothing.
+> - Drop `!satisfiesDeclaredBound` from a `rejectVersionIf` rule, since
+>   `rejectOutOfBoundVersions` now applies the bound on its own. The member is
+>   deprecated and will be removed in a later release; a warning is printed
+>   once per project when a rule reads it. A rule that keeps the clause still
+>   rejects under `--no-reject-out-of-bound-versions`.
 
 > [!NOTE]
 > - The presence of a version catalog no longer changes whether a plugin the

--- a/examples/groovy/build.gradle
+++ b/examples/groovy/build.gradle
@@ -39,6 +39,7 @@ def isNonStable = { String version ->
 
 tasks.named("dependencyUpdates").configure {
   checkForGradleUpdate = true
+  rejectOutOfBoundVersions = true
 
   // Example 1: reject all non stable versions
   rejectVersionIf {
@@ -69,11 +70,6 @@ tasks.named("dependencyUpdates").configure {
   }
   rejectVersionIf {
     maturityLevel(candidate.version) < maturityLevel(currentVersion)
-  }
-
-  // Example 5: keep the report inside the bound the build already declares
-  rejectVersionIf {
-    !satisfiesDeclaredBound
   }
 }
 

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -72,13 +72,9 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     maturityLevel(candidate.version) < maturityLevel(currentVersion)
   }
 
-  // Example 5: keep the report inside the bound the build already declares
-  rejectVersionIf {
-    !satisfiesDeclaredBound
-  }
-
   // optional parameters
   checkForGradleUpdate = true
+  rejectOutOfBoundVersions = true
   outputFormatter = "json"
   outputDir = "build/dependencyUpdates"
   reportfileName = "report"

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -219,7 +219,7 @@ internal fun registerAggregation(
   val path = project.path
   // Realized after every project is configured, as the producers' inputs are, so that the values
   // read back from the task are the ones the producers resolved with rather than only what is
-  // configured on this project. All three are taken from one resolution, so a read cannot mix a
+  // configured on this project. All four are taken from one resolution, so a read cannot mix a
   // stale value with a fresh one.
   val inherited =
     project.provider {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -488,6 +488,8 @@ private fun registerProducer(
               .filter { it.isCanBeResolved }
 
           val skipped = mutableListOf<SkippedInfo>()
+          // Shared by both resolutions below, so the deprecation is warned once for the project.
+          val onDeprecatedBoundRead = deprecatedBoundWarning(project)
           val statuses =
             statusesOf(
               project,
@@ -498,6 +500,7 @@ private fun registerProducer(
               nameDeclaringConfiguration = true,
               scriptClasspaths = false,
               skipped,
+              onDeprecatedBoundRead,
             )
           val buildscriptStatuses =
             statusesOf(
@@ -515,6 +518,7 @@ private fun registerProducer(
               // only they read a dynamic required version as a bound.
               scriptClasspaths = true,
               skipped,
+              onDeprecatedBoundRead,
             )
           // Warned once the whole project's configurations and script classpaths are known, as the
           // two calls above share this list and a configuration skipped by each would otherwise be
@@ -595,12 +599,19 @@ private fun statusesOf(
   nameDeclaringConfiguration: Boolean,
   scriptClasspaths: Boolean,
   skipped: MutableList<SkippedInfo>,
+  onDeprecatedBoundRead: () -> Unit,
 ): List<PartialStatus> {
   if (configurations.isEmpty()) {
     return emptyList()
   }
   val resolver =
-    Resolver(project, parameters.resolutionStrategy, checkConstraints, parameters.rejectOutOfBoundVersions)
+    Resolver(
+      project,
+      parameters.resolutionStrategy,
+      checkConstraints,
+      parameters.rejectOutOfBoundVersions,
+      onDeprecatedBoundRead,
+    )
   // Snapshotted for every configuration before the first resolution, as resolving one
   // configuration runs the lazy actions of the configurations it extends. A build that read the
   // dependencies while configuring has already run them, which the discount below corrects for.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -91,6 +91,7 @@ internal class DependencyUpdatesParameters {
   var resolutionStrategySet: Boolean = false
   var checkConstraints: Boolean? = null
   var checkBuildEnvironmentConstraints: Boolean? = null
+  var rejectOutOfBoundVersions: Boolean? = null
 
   /**
    * Set by the task's command line options. Read ahead of every configured value in the chain, so
@@ -98,6 +99,7 @@ internal class DependencyUpdatesParameters {
    */
   var checkConstraintsFromCommandLine: Boolean? = null
   var checkBuildEnvironmentConstraintsFromCommandLine: Boolean? = null
+  var rejectOutOfBoundVersionsFromCommandLine: Boolean? = null
 }
 
 /**
@@ -175,6 +177,11 @@ internal abstract class DependencyUpdatesParametersService :
             chain.firstNotNullOfOrNull { it.checkBuildEnvironmentConstraintsFromCommandLine },
           configured = chain.firstNotNullOfOrNull { it.checkBuildEnvironmentConstraints } ?: false,
         ),
+      rejectOutOfBoundVersions =
+        settingOf(
+          fromCommandLine = chain.firstNotNullOfOrNull { it.rejectOutOfBoundVersionsFromCommandLine },
+          configured = chain.firstNotNullOfOrNull { it.rejectOutOfBoundVersions } ?: true,
+        ),
     )
   }
 }
@@ -187,6 +194,7 @@ internal class InheritedSettings(
   val revision: String,
   val checkConstraints: Boolean,
   val checkBuildEnvironmentConstraints: Boolean,
+  val rejectOutOfBoundVersions: Boolean,
 )
 
 /** The settings that apply to a single project's producer. */
@@ -197,6 +205,7 @@ internal class ResolvedParameters(
   val resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
   val checkConstraints: Boolean,
   val checkBuildEnvironmentConstraints: Boolean,
+  val rejectOutOfBoundVersions: Boolean,
 )
 
 /** Registers the per-project producers and wires their results into the accumulator task. */
@@ -219,6 +228,7 @@ internal fun registerAggregation(
         revision = resolved.revision,
         checkConstraints = resolved.checkConstraints,
         checkBuildEnvironmentConstraints = resolved.checkBuildEnvironmentConstraints,
+        rejectOutOfBoundVersions = resolved.rejectOutOfBoundVersions,
       )
     }
   accumulator.configure { task ->
@@ -589,7 +599,8 @@ private fun statusesOf(
   if (configurations.isEmpty()) {
     return emptyList()
   }
-  val resolver = Resolver(project, parameters.resolutionStrategy, checkConstraints)
+  val resolver =
+    Resolver(project, parameters.resolutionStrategy, checkConstraints, parameters.rejectOutOfBoundVersions)
   // Snapshotted for every configuration before the first resolution, as resolving one
   // configuration runs the lazy actions of the configurations it extends. A build that read the
   // dependencies while configuring has already run them, which the discount below corrects for.

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -40,7 +40,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
   /**
    * The settings as the producers resolved them, wired by the plugin from the shared settings so
-   * that they are read back as resolved rather than as configured on this project alone. All three
+   * that they are read back as resolved rather than as configured on this project alone. All four
    * are taken from one resolution, so a read cannot mix them. The convention covers a task the
    * plugin did not register, where only this project's own settings are known.
    */
@@ -281,7 +281,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
       parameters.rejectOutOfBoundVersions = value
     }
 
-  /** Reports the versions outside a declared bound for this invocation alone. */
+  /** Leaves out the versions outside a declared bound for this invocation alone. */
   @Option(
     option = "reject-out-of-bound-versions",
     description = "Leaves out the versions outside a declared bound or a consumed platform's.",

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -65,6 +65,11 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
               parameters.checkBuildEnvironmentConstraintsFromCommandLine,
               parameters.checkBuildEnvironmentConstraints ?: false,
             ),
+          rejectOutOfBoundVersions =
+            settingOf(
+              parameters.rejectOutOfBoundVersionsFromCommandLine,
+              parameters.rejectOutOfBoundVersions ?: true,
+            ),
         )
       },
     )
@@ -267,6 +272,22 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   )
   internal fun setCheckBuildEnvironmentConstraintsFromCommandLine(checkBuildEnvironmentConstraints: Boolean) {
     parameters.checkBuildEnvironmentConstraintsFromCommandLine = checkBuildEnvironmentConstraints
+  }
+
+  @get:Input
+  var rejectOutOfBoundVersions: Boolean
+    get() = inherited.get().rejectOutOfBoundVersions
+    set(value) {
+      parameters.rejectOutOfBoundVersions = value
+    }
+
+  /** Reports the versions outside a declared bound for this invocation alone. */
+  @Option(
+    option = "reject-out-of-bound-versions",
+    description = "Leaves out the versions outside a declared bound or a consumed platform's.",
+  )
+  internal fun setRejectOutOfBoundVersionsFromCommandLine(rejectOutOfBoundVersions: Boolean) {
+    parameters.rejectOutOfBoundVersionsFromCommandLine = rejectOutOfBoundVersions
   }
 
   @Internal

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -41,6 +41,7 @@ import org.gradle.maven.MavenModule
 import org.gradle.maven.MavenPomArtifact
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Resolves the configuration to determine the version status of its dependencies.
@@ -65,6 +66,8 @@ class Resolver(
   // depends on the resolving configuration's own attributes, constraints and resolution strategy,
   // while skipping one costs an attribution at most.
   private val failedPlatformScans = hashSetOf<Set<ModuleDependency>>()
+
+  private val warnedDeprecatedBound = AtomicBoolean()
 
   init {
     logRepositories()
@@ -400,13 +403,25 @@ class Resolver(
     }
   }
 
+  /** Warned once per project, since a rule is evaluated for every candidate of every configuration. */
+  private fun warnDeprecatedBound() {
+    if (warnedDeprecatedBound.compareAndSet(false, true)) {
+      project.logger.warn(
+        "satisfiesDeclaredBound is deprecated; drop it from rejectVersionIf, " +
+          "since rejectOutOfBoundVersions applies the declared bound instead.",
+      )
+    }
+  }
+
   /** Adds a custom resolution strategy only applicable for the dependency updates task.  */
   private fun addCustomResolutionStrategy(
     configuration: Configuration,
     currentCoordinates: Map<Coordinate.Key, Coordinate>,
   ) {
     configuration.resolutionStrategy { inner ->
-      resolutionStrategy?.execute(ResolutionStrategyWithCurrent(inner, currentCoordinates))
+      resolutionStrategy?.execute(
+        ResolutionStrategyWithCurrent(inner, currentCoordinates, ::warnDeprecatedBound),
+      )
     }
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -46,18 +46,26 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Resolves the configuration to determine the version status of its dependencies.
  */
-class Resolver(
+class Resolver internal constructor(
   private val project: Project,
   private val resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
   private val checkConstraints: Boolean,
   private val rejectOutOfBoundVersions: Boolean,
+  /** Called when a rule reads the deprecated bound, so the warning is printed once per project. */
+  private val onDeprecatedBoundRead: () -> Unit,
 ) {
   /** Retained so the arity released before the bound filter was added still links. */
   constructor(
     project: Project,
     resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
     checkConstraints: Boolean,
-  ) : this(project, resolutionStrategy, checkConstraints, rejectOutOfBoundVersions = false)
+  ) : this(
+    project,
+    resolutionStrategy,
+    checkConstraints,
+    rejectOutOfBoundVersions = true,
+    onDeprecatedBoundRead = deprecatedBoundWarning(project),
+  )
 
   private var projectUrls = ConcurrentHashMap<ModuleVersionIdentifier, ProjectUrl>()
 
@@ -66,8 +74,6 @@ class Resolver(
   // depends on the resolving configuration's own attributes, constraints and resolution strategy,
   // while skipping one costs an attribution at most.
   private val failedPlatformScans = hashSetOf<Set<ModuleDependency>>()
-
-  private val warnedDeprecatedBound = AtomicBoolean()
 
   init {
     logRepositories()
@@ -403,16 +409,6 @@ class Resolver(
     }
   }
 
-  /** Warned once per project, since a rule is evaluated for every candidate of every configuration. */
-  private fun warnDeprecatedBound() {
-    if (warnedDeprecatedBound.compareAndSet(false, true)) {
-      project.logger.warn(
-        "satisfiesDeclaredBound is deprecated; drop it from rejectVersionIf, " +
-          "since rejectOutOfBoundVersions applies the declared bound instead.",
-      )
-    }
-  }
-
   /** Adds a custom resolution strategy only applicable for the dependency updates task.  */
   private fun addCustomResolutionStrategy(
     configuration: Configuration,
@@ -420,7 +416,7 @@ class Resolver(
   ) {
     configuration.resolutionStrategy { inner ->
       resolutionStrategy?.execute(
-        ResolutionStrategyWithCurrent(inner, currentCoordinates, ::warnDeprecatedBound),
+        ResolutionStrategyWithCurrent(inner, currentCoordinates, onDeprecatedBoundRead),
       )
     }
   }
@@ -1064,4 +1060,20 @@ internal fun configurationsOf(
     pending.addAll(next.extendsFrom)
   }
   return names.mapValues { (_, held) -> held.toList() }
+}
+
+/**
+ * Warns once, however many rules read the deprecated bound across the project's resolutions,
+ * since a rule is evaluated for every candidate of every configuration and script classpath.
+ */
+internal fun deprecatedBoundWarning(project: Project): () -> Unit {
+  val warned = AtomicBoolean()
+  return {
+    if (warned.compareAndSet(false, true)) {
+      project.logger.warn(
+        "satisfiesDeclaredBound is deprecated; drop it from rejectVersionIf, " +
+          "since rejectOutOfBoundVersions applies the declared bound instead.",
+      )
+    }
+  }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -380,8 +380,8 @@ class Resolver internal constructor(
   }
 
   /**
-   * Adds the filter that holds the report to the bound declared for a module, leaving out the
-   * upgrades [ComponentSelectionWithCurrent.isUpgradeOutOfDeclaredBound] marks as out of bound.
+   * Adds the filter that leaves out the upgrades outside the bound declared for a module, which
+   * [ComponentSelectionWithCurrent.isUpgradeOutOfDeclaredBound] identifies.
    *
    * Registered after the rules configured in the build, since a rejected candidate is not passed
    * to the rules that follow, and a rule written in a build script is still evaluated for every

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -398,9 +398,7 @@ class Resolver internal constructor(
       ResolutionStrategyWithCurrent(inner, currentCoordinates).componentSelection { rules ->
         rules.all(
           Action<ComponentSelectionWithCurrent> { current ->
-            @Suppress("SENSELESS_COMPARISON")
-            val isNotNull = current.currentVersion != null && current.candidate.version != null
-            if (isNotNull && current.isUpgradeOutOfDeclaredBound) {
+            if (current.isUpgradeOutOfDeclaredBound) {
               current.reject("Rejected by rejectOutOfBoundVersions")
             }
           },

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -238,10 +238,10 @@ class Resolver internal constructor(
     // The copy inherits activated dependency locking but has no lock state of its own.
     copy.resolutionStrategy.deactivateDependencyLocking()
 
+    addDeclaredBoundFilter(copy, current.coordinates)
     addRevisionFilter(copy, revision, current.coordinates)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, current.coordinates)
-    addDeclaredBoundFilter(copy, current.coordinates)
 
     disableAutoTargetJvm(copy)
     return copy
@@ -383,9 +383,11 @@ class Resolver internal constructor(
    * Adds the filter that leaves out the upgrades outside the bound declared for a module, which
    * [ComponentSelectionWithCurrent.isUpgradeOutOfDeclaredBound] identifies.
    *
-   * Registered after the rules configured in the build, since a rejected candidate is not passed
-   * to the rules that follow, and a rule written in a build script is still evaluated for every
-   * candidate it was evaluated for before.
+   * Registered first, ahead of the revision filter and the rules configured in the build, since a
+   * rejected candidate is not passed to the rules that follow: the revision filter reads each
+   * candidate's metadata, which resolves it, and a rule can only reject, so an out-of-bound
+   * candidate costs nothing further and the report is the same. The version in use is never
+   * rejected here, so a rule reading the deprecated bound is still warned.
    */
   private fun addDeclaredBoundFilter(
     configuration: Configuration,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -1,5 +1,6 @@
 package com.github.benmanes.gradle.versions.updates
 
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
@@ -48,7 +49,15 @@ class Resolver(
   private val project: Project,
   private val resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
   private val checkConstraints: Boolean,
+  private val rejectOutOfBoundVersions: Boolean,
 ) {
+  /** Retained so the arity released before the bound filter was added still links. */
+  constructor(
+    project: Project,
+    resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
+    checkConstraints: Boolean,
+  ) : this(project, resolutionStrategy, checkConstraints, rejectOutOfBoundVersions = false)
+
   private var projectUrls = ConcurrentHashMap<ModuleVersionIdentifier, ProjectUrl>()
 
   // The platform declarations whose scan threw, so a configuration inheriting the same ones does
@@ -223,6 +232,7 @@ class Resolver(
     addRevisionFilter(copy, revision, current.coordinates)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, current.coordinates)
+    addDeclaredBoundFilter(copy, current.coordinates)
 
     disableAutoTargetJvm(copy)
     return copy
@@ -356,6 +366,36 @@ class Resolver(
             revisionFilter(selectionAction, selectionAction.metadata)
           }
         }
+      }
+    }
+  }
+
+  /**
+   * Adds the filter that holds the report to the bound declared for a module, leaving out the
+   * upgrades [ComponentSelectionWithCurrent.isUpgradeOutOfDeclaredBound] marks as out of bound.
+   *
+   * Registered after the rules configured in the build, since a rejected candidate is not passed
+   * to the rules that follow, and a rule written in a build script is still evaluated for every
+   * candidate it was evaluated for before.
+   */
+  private fun addDeclaredBoundFilter(
+    configuration: Configuration,
+    currentCoordinates: Map<Coordinate.Key, Coordinate>,
+  ) {
+    if (!rejectOutOfBoundVersions) {
+      return
+    }
+    configuration.resolutionStrategy { inner ->
+      ResolutionStrategyWithCurrent(inner, currentCoordinates).componentSelection { rules ->
+        rules.all(
+          Action<ComponentSelectionWithCurrent> { current ->
+            @Suppress("SENSELESS_COMPARISON")
+            val isNotNull = current.currentVersion != null && current.candidate.version != null
+            if (isNotNull && current.isUpgradeOutOfDeclaredBound) {
+              current.reject("Rejected by rejectOutOfBoundVersions")
+            }
+          },
+        )
       }
     }
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
@@ -64,9 +64,11 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
   }
 
   companion object {
-    private fun makeVersionComparator(): Comparator<String> {
+    private fun makeVersionComparator(): Comparator<String> = versionComparator(VersionParser())
+
+    /** Orders version strings the way dependency resolution orders them, through the given parser. */
+    internal fun versionComparator(versionParser: VersionParser): Comparator<String> {
       val baseComparator = DefaultVersionComparator().asVersionComparator()
-      val versionParser = VersionParser()
       return Comparator { string1, string2 ->
         baseComparator.compare(versionParser.transform(string1), versionParser.transform(string2))
       }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionRulesWithCurrent.kt
@@ -8,10 +8,17 @@ import org.gradle.api.artifacts.ComponentSelectionRules
 import org.gradle.internal.rules.RuleSourceBackedRuleAction
 import org.gradle.model.internal.type.ModelType
 
-class ComponentSelectionRulesWithCurrent(
+class ComponentSelectionRulesWithCurrent internal constructor(
   private val delegate: ComponentSelectionRules,
   private val currentCoordinates: Map<Coordinate.Key, Coordinate>,
+  private val onDeprecatedBoundRead: () -> Unit,
 ) {
+  /** Retained so the arity released before the deprecation warning was added still links. */
+  constructor(
+    delegate: ComponentSelectionRules,
+    currentCoordinates: Map<Coordinate.Key, Coordinate>,
+  ) : this(delegate, currentCoordinates, {})
+
   fun all(selectionAction: Action<in ComponentSelectionWithCurrent>): ComponentSelectionRulesWithCurrent {
     delegate.all {
       wrapComponentSelection(it)?.let { wrapped ->
@@ -115,6 +122,7 @@ class ComponentSelectionRulesWithCurrent(
       current.versionConstraint,
       current.platformVersionConstraints,
       current.onScriptClasspath,
+      onDeprecatedBoundRead,
     )
   }
 }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -23,6 +23,8 @@ class ComponentSelectionWithCurrent internal constructor(
    * as a bound.
    */
   private val onScriptClasspath: Boolean = false,
+  /** Called when a rule reads [satisfiesDeclaredBound], so the deprecation can be warned once. */
+  private val onDeprecatedBoundRead: () -> Unit = {},
 ) : ComponentSelection by delegate {
   /** Retained so the arity released before the constraint was added still links. */
   constructor(
@@ -52,16 +54,29 @@ class ComponentSelectionWithCurrent internal constructor(
    * the consumer depends on set for it, and the version currently selected is always within
    * bound.
    */
-  val satisfiesDeclaredBound: Boolean
+  internal val withinDeclaredBound: Boolean
     get() =
       DeclaredBound.accepts(versionConstraint, candidate.version, currentVersion, onScriptClasspath) &&
         DeclaredBound.acceptsPlatformSupplied(platformVersionConstraints, currentVersion, candidate.version)
 
   /**
+   * Whether the candidate lies within the declared bound, as [withinDeclaredBound] reads it.
+   *
+   * Deprecated: the task's `rejectOutOfBoundVersions` property leaves a candidate outside the
+   * declared bound out of the report on its own, so nothing is left for a rule to reject.
+   */
+  @Deprecated("rejectOutOfBoundVersions applies the declared bound; drop the clause from rejectVersionIf.")
+  val satisfiesDeclaredBound: Boolean
+    get() {
+      onDeprecatedBoundRead()
+      return withinDeclaredBound
+    }
+
+  /**
    * Whether the candidate is an upgrade that lies outside the declared bound, which is what the
    * task's `rejectOutOfBoundVersions` property leaves out of the report.
    *
-   * The condition is narrower than [satisfiesDeclaredBound], which is evaluated for the candidate
+   * The condition is narrower than [withinDeclaredBound], which is evaluated for the candidate
    * alone. A candidate no newer than the version in use is not an upgrade at all, and rejecting it
    * would take the exceeded entry off the report without withholding anything. Where the version
    * in use already lies outside the bound, nothing is held to that bound, so an upgrade past it is
@@ -76,7 +91,7 @@ class ComponentSelectionWithCurrent internal constructor(
           currentVersion,
           onScriptClasspath,
         ) &&
-        !satisfiesDeclaredBound
+        !withinDeclaredBound
 
   override fun toString(): String {
     return """\

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -6,7 +6,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector
 
 class ComponentSelectionWithCurrent internal constructor(
   private val delegate: ComponentSelection,
@@ -179,14 +178,20 @@ private object DeclaredBound {
     }
   }
 
-  /** Whether the version parses as a range selector, the form a rich constraint flattens to. */
-  private fun statesRange(version: String): Boolean {
+  /**
+   * Whether the text is a selector rather than a version, which is what a constraint reported with
+   * no declaration beside it carries where a resolved version would sit. A range and a dynamic
+   * version are selectors, and so is a single-version range such as `[2.0]`, which parses to the
+   * exact selector for a different string.
+   */
+  private fun isSelectorText(version: String): Boolean {
     val parser = scheme
     if (parser == null || version.isEmpty()) {
       return false
     }
     return try {
-      parser.parseSelector(version) is VersionRangeSelector
+      val selector = parser.parseSelector(version)
+      selector.isDynamic || selector.selector != version
     } catch (e: Exception) {
       false
     }
@@ -263,9 +268,9 @@ private object DeclaredBound {
     dynamicRequiredBounds: Boolean,
   ): Boolean =
     try {
-      // Where a constraint is reported with no declaration beside it, the range sits where a
-      // resolved version would, and a range cannot be compared against the bound it duplicates.
-      statesRange(currentVersion) ||
+      // Where a constraint is reported with no declaration beside it, its selector sits where a
+      // resolved version would, and a selector cannot be compared against the bound it duplicates.
+      isSelectorText(currentVersion) ||
         (
           admitsDeclared(constraint, currentVersion, dynamicRequiredBounds) &&
             platformConstraints.all { admits(it, currentVersion) }
@@ -289,7 +294,7 @@ private object DeclaredBound {
   ): Boolean {
     val order = comparator
     val versions = parser
-    if (order == null || versions == null || currentVersion.isEmpty() || statesRange(currentVersion)) {
+    if (order == null || versions == null || currentVersion.isEmpty() || isSelectorText(currentVersion)) {
       return true
     }
     return try {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -77,20 +77,19 @@ class ComponentSelectionWithCurrent internal constructor(
    *
    * The condition is narrower than [withinDeclaredBound], which is evaluated for the candidate
    * alone. A candidate no newer than the version in use is not an upgrade at all, and rejecting it
-   * would take the exceeded entry off the report without withholding anything. Where the version
-   * in use already lies outside the bound, nothing is held to that bound, so an upgrade past it is
-   * still available.
+   * would take the exceeded entry off the report while leaving nothing out. Each bound is applied
+   * only where the version in use lies within it: a platform that a transitive requirement pushed
+   * the version past bounds nothing, while a second platform pinning the version in use still does.
    */
   internal val isUpgradeOutOfDeclaredBound: Boolean
     get() =
-      DeclaredBound.isNewer(currentVersion, candidate.version) &&
-        DeclaredBound.holds(
-          versionConstraint,
-          platformVersionConstraints,
-          currentVersion,
-          onScriptClasspath,
-        ) &&
-        !withinDeclaredBound
+      DeclaredBound.isUpgradeOutOfBound(
+        versionConstraint,
+        platformVersionConstraints,
+        currentVersion,
+        candidate.version,
+        onScriptClasspath,
+      )
 
   override fun toString(): String {
     return """\
@@ -148,8 +147,8 @@ private object DeclaredBound {
 
   /**
    * Whether the constraint the build declared admits the version. Split out of [accepts] so that
-   * [holds] can ask it of the resolved version itself, which [accepts] leaves in bound rather than
-   * testing against a dynamic required bound.
+   * [isUpgradeOutOfBound] can ask it of the resolved version itself, which [accepts] leaves in bound
+   * rather than testing against a dynamic required bound.
    */
   private fun admitsDeclared(
     constraint: VersionConstraint?,
@@ -257,26 +256,30 @@ private object DeclaredBound {
   }
 
   /**
-   * Whether the version resolved for the module lies within the bound written for it. Where the
-   * resolved version already lies outside that bound, nothing is held to it, which is reached most
-   * often by a transitive requirement pushing the selection past a platform.
+   * Whether the candidate is an upgrade outside a bound the resolved version lies within. A bound
+   * the resolved version already lies outside is not applied, which is reached most often by a
+   * transitive requirement pushing the selection past a platform; the other bounds on the module
+   * still are. A constraint reported with no declaration beside it carries its selector where a
+   * resolved version would sit, so the declared bound applies to every candidate there.
    */
-  fun holds(
+  fun isUpgradeOutOfBound(
     constraint: VersionConstraint?,
     platformConstraints: List<VersionConstraint>,
     currentVersion: String,
+    candidate: String,
     dynamicRequiredBounds: Boolean,
   ): Boolean =
     try {
-      // Where a constraint is reported with no declaration beside it, its selector sits where a
-      // resolved version would, and a selector cannot be compared against the bound it duplicates.
-      isSelectorText(currentVersion) ||
+      isNewer(currentVersion, candidate) &&
         (
-          admitsDeclared(constraint, currentVersion, dynamicRequiredBounds) &&
-            platformConstraints.all { admits(it, currentVersion) }
+          (
+            (isSelectorText(currentVersion) || admitsDeclared(constraint, currentVersion, dynamicRequiredBounds)) &&
+              !admitsDeclared(constraint, candidate, dynamicRequiredBounds)
+          ) ||
+            platformConstraints.any { admits(it, currentVersion) && !admits(it, candidate) }
         )
     } catch (e: LinkageError) {
-      true
+      false
     }
 
   /**

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -1,11 +1,13 @@
 package com.github.benmanes.gradle.versions.updates.resolutionstrategy
 
-import org.gradle.api.artifacts.ComponentSelection
 import com.github.benmanes.gradle.versions.updates.VersionMapping
+import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector
+import java.util.concurrent.ConcurrentHashMap
 
 class ComponentSelectionWithCurrent internal constructor(
   private val delegate: ComponentSelection,
@@ -137,6 +139,15 @@ private object DeclaredBound {
     }
   }
 
+  // A declared selector is parsed once, since the filter is evaluated for every candidate of a
+  // module and Gradle's parser caches no selector. The strings are the few a build declares.
+  private val selectors = ConcurrentHashMap<String, VersionSelector>()
+
+  private fun selector(
+    scheme: DefaultVersionSelectorScheme,
+    text: String,
+  ): VersionSelector = selectors.computeIfAbsent(text) { scheme.parseSelector(it) }
+
   fun accepts(
     constraint: VersionConstraint?,
     candidate: String,
@@ -165,14 +176,14 @@ private object DeclaredBound {
       val strict = constraint.strictVersion
       val outOfBound =
         if (strict.isNotEmpty()) {
-          !parser.parseSelector(strict).accept(version)
+          !selector(parser, strict).accept(version)
         } else {
           dynamicRequiredBounds && excludedByDynamicRequired(constraint.requiredVersion, version)
         }
       if (outOfBound) {
         false
       } else {
-        constraint.rejectedVersions.none { parser.parseSelector(it).accept(version) }
+        constraint.rejectedVersions.none { selector(parser, it).accept(version) }
       }
     } catch (e: LinkageError) {
       true
@@ -191,7 +202,7 @@ private object DeclaredBound {
       return false
     }
     return try {
-      val selector = parser.parseSelector(version)
+      val selector = selector(parser, version)
       selector.isDynamic || selector.selector != version
     } catch (e: Exception) {
       false
@@ -213,7 +224,7 @@ private object DeclaredBound {
       return false
     }
     return try {
-      val selector = parser.parseSelector(version)
+      val selector = selector(parser, version)
       selector.isDynamic && !selector.accept(candidate)
     } catch (e: Exception) {
       false
@@ -252,9 +263,9 @@ private object DeclaredBound {
     val parser = scheme ?: return true
     val strict = constraint.strictVersion
     val required = constraint.requiredVersion
-    return (strict.isEmpty() || parser.parseSelector(strict).accept(version)) &&
-      (required.isEmpty() || parser.parseSelector(required).accept(version)) &&
-      constraint.rejectedVersions.none { parser.parseSelector(it).accept(version) }
+    return (strict.isEmpty() || selector(parser, strict).accept(version)) &&
+      (required.isEmpty() || selector(parser, required).accept(version)) &&
+      constraint.rejectedVersions.none { selector(parser, it).accept(version) }
   }
 
   /**

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -4,7 +4,9 @@ import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector
 
 class ComponentSelectionWithCurrent internal constructor(
   private val delegate: ComponentSelection,
@@ -55,6 +57,27 @@ class ComponentSelectionWithCurrent internal constructor(
       DeclaredBound.accepts(versionConstraint, candidate.version, currentVersion, onScriptClasspath) &&
         DeclaredBound.acceptsPlatformSupplied(platformVersionConstraints, currentVersion, candidate.version)
 
+  /**
+   * Whether the candidate is an upgrade that lies outside the declared bound, which is what the
+   * task's `rejectOutOfBoundVersions` property leaves out of the report.
+   *
+   * The condition is narrower than [satisfiesDeclaredBound], which is evaluated for the candidate
+   * alone. A candidate no newer than the version in use is not an upgrade at all, and rejecting it
+   * would take the exceeded entry off the report without withholding anything. Where the version
+   * in use already lies outside the bound, nothing is held to that bound, so an upgrade past it is
+   * still available.
+   */
+  internal val isUpgradeOutOfDeclaredBound: Boolean
+    get() =
+      DeclaredBound.isNewer(currentVersion, candidate.version) &&
+        DeclaredBound.holds(
+          versionConstraint,
+          platformVersionConstraints,
+          currentVersion,
+          onScriptClasspath,
+        ) &&
+        !satisfiesDeclaredBound
+
   override fun toString(): String {
     return """\
 ComponentSelectionWithCurrent{
@@ -83,10 +106,40 @@ private object DeclaredBound {
     }
   }
 
+  private val comparator: Comparator<Version>? by lazy {
+    try {
+      DefaultVersionComparator().asVersionComparator()
+    } catch (e: LinkageError) {
+      null
+    }
+  }
+
+  private val parser: VersionParser? by lazy {
+    try {
+      VersionParser()
+    } catch (e: LinkageError) {
+      null
+    }
+  }
+
   fun accepts(
     constraint: VersionConstraint?,
     candidate: String,
     currentVersion: String,
+    dynamicRequiredBounds: Boolean,
+  ): Boolean =
+    // The selected version is left in bound, since a transitive requirement can push the selection
+    // past an interval that is only a floor.
+    admitsDeclared(constraint, candidate, dynamicRequiredBounds && candidate != currentVersion)
+
+  /**
+   * Whether the constraint the build declared admits the version. Split out of [accepts] so that
+   * [holds] can ask it of the resolved version itself, which [accepts] leaves in bound rather than
+   * testing against a dynamic required bound.
+   */
+  private fun admitsDeclared(
+    constraint: VersionConstraint?,
+    version: String,
     dynamicRequiredBounds: Boolean,
   ): Boolean {
     val parser = scheme
@@ -97,20 +150,30 @@ private object DeclaredBound {
       val strict = constraint.strictVersion
       val outOfBound =
         if (strict.isNotEmpty()) {
-          !parser.parseSelector(strict).accept(candidate)
+          !parser.parseSelector(strict).accept(version)
         } else {
-          // The selected version is left in bound, since a transitive requirement can push the
-          // selection past an interval that is only a floor.
-          dynamicRequiredBounds && candidate != currentVersion &&
-            excludedByDynamicRequired(constraint.requiredVersion, candidate)
+          dynamicRequiredBounds && excludedByDynamicRequired(constraint.requiredVersion, version)
         }
       if (outOfBound) {
         false
       } else {
-        constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
+        constraint.rejectedVersions.none { parser.parseSelector(it).accept(version) }
       }
     } catch (e: LinkageError) {
       true
+    }
+  }
+
+  /** Whether the version parses as a range selector, the form a rich constraint flattens to. */
+  private fun statesRange(version: String): Boolean {
+    val parser = scheme
+    if (parser == null || version.isEmpty()) {
+      return false
+    }
+    return try {
+      parser.parseSelector(version) is VersionRangeSelector
+    } catch (e: Exception) {
+      false
     }
   }
 
@@ -154,14 +217,69 @@ private object DeclaredBound {
       return true
     }
     return try {
-      constraints.all { constraint ->
-        val strict = constraint.strictVersion
-        val required = constraint.requiredVersion
-        (strict.isEmpty() || parser.parseSelector(strict).accept(candidate)) &&
-          (required.isEmpty() || parser.parseSelector(required).accept(candidate)) &&
-          constraint.rejectedVersions.none { parser.parseSelector(it).accept(candidate) }
-      }
+      constraints.all { admits(it, candidate) }
     } catch (e: LinkageError) {
+      true
+    }
+  }
+
+  /** Whether the constraint the platform supplied admits the version, as [accepts] reads one. */
+  private fun admits(
+    constraint: VersionConstraint,
+    version: String,
+  ): Boolean {
+    val parser = scheme ?: return true
+    val strict = constraint.strictVersion
+    val required = constraint.requiredVersion
+    return (strict.isEmpty() || parser.parseSelector(strict).accept(version)) &&
+      (required.isEmpty() || parser.parseSelector(required).accept(version)) &&
+      constraint.rejectedVersions.none { parser.parseSelector(it).accept(version) }
+  }
+
+  /**
+   * Whether the version resolved for the module lies within the bound written for it. Where the
+   * resolved version already lies outside that bound, nothing is held to it, which is reached most
+   * often by a transitive requirement pushing the selection past a platform.
+   */
+  fun holds(
+    constraint: VersionConstraint?,
+    platformConstraints: List<VersionConstraint>,
+    currentVersion: String,
+    dynamicRequiredBounds: Boolean,
+  ): Boolean =
+    try {
+      // Where a constraint is reported with no declaration beside it, the range sits where a
+      // resolved version would, and a range cannot be compared against the bound it duplicates.
+      statesRange(currentVersion) ||
+        (
+          admitsDeclared(constraint, currentVersion, dynamicRequiredBounds) &&
+            platformConstraints.all { admits(it, currentVersion) }
+        )
+    } catch (e: LinkageError) {
+      true
+    }
+
+  /**
+   * Whether the candidate is newer than the version resolved for the module, ordered the way
+   * dependency resolution orders versions, since a candidate that is not an upgrade is not one to
+   * leave out. An unreadable version counts as newer, so the bound still applies as it did before.
+   *
+   * Compared rather than parsed as a selector, since a version is not a selector: a resolved
+   * version containing a bracket or a comma parses as an exact selector matching nothing, which
+   * would silently answer no for every candidate.
+   */
+  fun isNewer(
+    currentVersion: String,
+    candidate: String,
+  ): Boolean {
+    val order = comparator
+    val versions = parser
+    if (order == null || versions == null || currentVersion.isEmpty() || statesRange(currentVersion)) {
+      return true
+    }
+    return try {
+      order.compare(versions.transform(candidate), versions.transform(currentVersion)) > 0
+    } catch (e: Exception) {
       true
     }
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -297,12 +297,15 @@ private object DeclaredBound {
   ): Boolean {
     val order = comparator
     val versions = parser
-    if (order == null || versions == null || currentVersion.isEmpty() || isSelectorText(currentVersion)) {
+    if (order == null || versions == null || currentVersion.isEmpty()) {
       return true
     }
     return try {
-      order.compare(versions.transform(candidate), versions.transform(currentVersion)) > 0
+      isSelectorText(currentVersion) ||
+        order.compare(versions.transform(candidate), versions.transform(currentVersion)) > 0
     } catch (e: Exception) {
+      true
+    } catch (e: LinkageError) {
       true
     }
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ComponentSelectionWithCurrent.kt
@@ -1,10 +1,10 @@
 package com.github.benmanes.gradle.versions.updates.resolutionstrategy
 
 import org.gradle.api.artifacts.ComponentSelection
+import com.github.benmanes.gradle.versions.updates.VersionMapping
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 
 class ComponentSelectionWithCurrent internal constructor(
@@ -111,25 +111,27 @@ ComponentSelectionWithCurrent{
  * than failing the report, which is why the linkage failure is caught instead of thrown.
  */
 private object DeclaredBound {
-  private val scheme: DefaultVersionSelectorScheme? by lazy {
-    try {
-      DefaultVersionSelectorScheme(DefaultVersionComparator(), VersionParser())
-    } catch (e: LinkageError) {
-      null
-    }
-  }
-
-  private val comparator: Comparator<Version>? by lazy {
-    try {
-      DefaultVersionComparator().asVersionComparator()
-    } catch (e: LinkageError) {
-      null
-    }
-  }
-
+  // One parser for the scheme and the comparator, since each keeps a cache of every version
+  // string it reads for the classloader's life.
   private val parser: VersionParser? by lazy {
     try {
       VersionParser()
+    } catch (e: LinkageError) {
+      null
+    }
+  }
+
+  private val scheme: DefaultVersionSelectorScheme? by lazy {
+    try {
+      parser?.let { DefaultVersionSelectorScheme(DefaultVersionComparator(), it) }
+    } catch (e: LinkageError) {
+      null
+    }
+  }
+
+  private val comparator: Comparator<String>? by lazy {
+    try {
+      parser?.let { VersionMapping.versionComparator(it) }
     } catch (e: LinkageError) {
       null
     }
@@ -296,13 +298,11 @@ private object DeclaredBound {
     candidate: String,
   ): Boolean {
     val order = comparator
-    val versions = parser
-    if (order == null || versions == null || currentVersion.isEmpty()) {
+    if (order == null || currentVersion.isEmpty()) {
       return true
     }
     return try {
-      isSelectorText(currentVersion) ||
-        order.compare(versions.transform(candidate), versions.transform(currentVersion)) > 0
+      isSelectorText(currentVersion) || order.compare(candidate, currentVersion) > 0
     } catch (e: Exception) {
       true
     } catch (e: LinkageError) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ResolutionStrategyWithCurrent.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/resolutionstrategy/ResolutionStrategyWithCurrent.kt
@@ -7,10 +7,17 @@ import org.gradle.api.artifacts.DependencyResolveDetails
 import org.gradle.api.artifacts.DependencySubstitutions
 import org.gradle.api.artifacts.ResolutionStrategy
 
-class ResolutionStrategyWithCurrent(
+class ResolutionStrategyWithCurrent internal constructor(
   private val delegate: ResolutionStrategy,
   private val currentCoordinates: Map<Coordinate.Key, Coordinate>,
+  private val onDeprecatedBoundRead: () -> Unit,
 ) {
+  /** Retained so the arity released before the deprecation warning was added still links. */
+  constructor(
+    delegate: ResolutionStrategy,
+    currentCoordinates: Map<Coordinate.Key, Coordinate>,
+  ) : this(delegate, currentCoordinates, {})
+
   fun failOnVersionConflict(): ResolutionStrategyWithCurrent {
     delegate.failOnVersionConflict()
     return this
@@ -57,6 +64,7 @@ class ResolutionStrategyWithCurrent(
     return ComponentSelectionRulesWithCurrent(
       delegate.componentSelection,
       currentCoordinates,
+      onDeprecatedBoundRead,
     )
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -677,7 +677,7 @@ final class CompositeBuildSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
     def bom = jsonReport.outdated.dependencies.find { it.name == 'external-bom' }
     bom.platformProjects == [':platforms']
-    def guice = jsonReport.outdated.dependencies.find { it.name == 'guice' }
+    def guice = jsonReport.current.dependencies.find { it.name == 'guice' }
     !guice.containsKey('platformProjects')
     def bomElement = xmlReport.outdated.dependencies.outdatedDependency.find {
       it.name.text() == 'external-bom'

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -495,7 +495,7 @@ final class ConstraintsSpec extends Specification {
       .build()
 
     then: 'the versionless declaration is checked, at the version the platform supplied'
-    result.output.contains('org.apache.logging.log4j:log4j-core [2.16.0 -> 2.17.0]')
+    result.output.contains('org.apache.logging.log4j:log4j-core:2.16.0')
     result.task(':dependencyUpdates').outcome == SUCCESS
 
     where:
@@ -954,7 +954,7 @@ final class ConstraintsSpec extends Specification {
       .build()
 
     then: 'the bom is named by its module, the version left to its own row'
-    result.output.contains('com.google.inject:guice [2.0 -> 3.1]')
+    result.output.contains('com.google.inject:guice:2.0')
     result.output.contains('constrained by the platform com.example:external-bom\n')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
@@ -1128,6 +1128,9 @@ final class ConstraintsSpec extends Specification {
 
         tasks.dependencyUpdates {
           checkConstraints = true
+          // The mark is withheld from a merged entry, which the bound would otherwise split by
+          // holding the importing project to the platform while the declaring one rises past it.
+          rejectOutOfBoundVersions = false
         }
       """.stripIndent()
 
@@ -1186,11 +1189,11 @@ final class ConstraintsSpec extends Specification {
 
     then: 'the machine readable reports carry the bound, and only where one was stated'
     result.task(':dependencyUpdates').outcome == SUCCESS
-    def guice = jsonReport.outdated.dependencies.find { it.name == 'guice' }
+    def guice = jsonReport.current.dependencies.find { it.name == 'guice' }
     guice.constrainedBy == ['com.example:external-bom']
     def bom = jsonReport.outdated.dependencies.find { it.name == 'external-bom' }
     !bom.containsKey('constrainedBy')
-    def guiceElement = xmlReport.outdated.dependencies.outdatedDependency.find {
+    def guiceElement = xmlReport.current.dependencies.dependency.find {
       it.name.text() == 'guice'
     }
     guiceElement.constrainedBy.constraint*.text() == ['com.example:external-bom']

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ConstraintsSpec.groovy
@@ -1252,10 +1252,13 @@ final class ConstraintsSpec extends Specification {
       .withPluginClasspath()
       .build()
 
-    then: 'the platform whose bound lost is not named'
-    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
-    result.output.contains('constrained by the platform :platform-high')
+    then: 'the platform whose bound won still bounds the module, and is the only one named'
+    result.output.contains(
+      ' - com.google.inject:guice:3.0\n     constrained by the platform :platform-high in root project')
     !result.output.contains('constrained by the platforms')
+
+    and: 'the upgrade past that bound is listed on the platform declaring it'
+    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -232,6 +232,29 @@ final class DeclaredVersionConstraintSpec extends Specification {
     guice.available.milestone == '2.2'
   }
 
+  def 'a constraint stating a single-version range still bounds the report'() {
+    given: 'a strictly written as [2.0], which parses to the exact version but reads as a range'
+    writeBuildFile(
+      """
+        constraints {
+          api('com.google.inject:guice') {
+            version {
+              strictly '[2.0]'
+            }
+          }
+        }
+      """,
+      'checkConstraints = true')
+
+    when:
+    run()
+
+    then: 'the pinned version, not the 3.1 the unbounded query finds'
+    def guice = report().outdated.dependencies.find { it.name == 'guice' }
+    guice != null
+    guice.available.milestone == '2.0'
+  }
+
   def 'rejectOutOfBoundVersions = false offers the version the build rejects'() {
     given:
     writeBuildFile(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -806,6 +806,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
       """,
       """
         checkConstraints = true
+        rejectOutOfBoundVersions = false
         rejectVersionIf {
           if (candidate.module == 'log4j-core' && currentVersion == '2.16.0') {
             println "PROBE \${candidate.module}@\${candidate.version} bound=\${satisfiesDeclaredBound}" +
@@ -1025,6 +1026,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
       """,
       """
         checkConstraints = true
+        rejectOutOfBoundVersions = false
         rejectVersionIf {
           if (candidate.module == 'guice' && currentVersion == '2.0') {
             println "PROBE guice@\${candidate.version} bound=\${satisfiesDeclaredBound}"

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -164,6 +164,51 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().outdated.dependencies[0].available.milestone == '3.0'
   }
 
+  def 'a rule reading satisfiesDeclaredBound is warned once per build that it is deprecated'() {
+    given: 'two modules, so the rule is evaluated for more than one candidate'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '3.1'
+          }
+        }
+        api 'com.google.guava:guava:15.0'
+      """,
+      """
+        rejectVersionIf {
+          !satisfiesDeclaredBound
+        }
+      """)
+
+    when:
+    def result = run()
+
+    then: 'one warning, not one per candidate'
+    result.output.count('satisfiesDeclaredBound is deprecated') == 1
+  }
+
+  def 'the default bound filter reads no deprecated member, so nothing is warned'() {
+    given:
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '3.1'
+          }
+        }
+      """,
+      '')
+
+    when:
+    def result = run()
+
+    then:
+    !result.output.contains('is deprecated')
+  }
+
   def 'a constraint stating a range still bounds the report, though its version reads as a range'() {
     given: 'a constraint with no declaration beside it, so the row reports the range as its version'
     writeBuildFile(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -326,7 +326,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().outdated.dependencies[0].available.milestone == '3.1'
   }
 
-  def 'the README recipe compiles and applies under the Kotlin DSL'() {
+  def 'the README snippet compiles and applies under the Kotlin DSL'() {
     given:
     testProjectDir.newFile('build.gradle.kts') <<
       """
@@ -353,18 +353,16 @@ final class DeclaredVersionConstraintSpec extends Specification {
         tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
           outputFormatter = "json"
           checkForGradleUpdate = false
-          rejectVersionIf {
-            !satisfiesDeclaredBound
-          }
+          rejectOutOfBoundVersions = false
         }
       """.stripIndent()
 
     when:
     run()
 
-    then:
+    then: 'the property is settable from a Kotlin script, and off lists the rejected version'
     report().outdated.dependencies*.name == ['guice']
-    report().outdated.dependencies[0].available.milestone == '3.0'
+    report().outdated.dependencies[0].available.milestone == '3.1'
   }
 
   def 'a declared range bounds the report, and an in-range upgrade is still offered'() {
@@ -416,6 +414,41 @@ final class DeclaredVersionConstraintSpec extends Specification {
     then: 'a required version is a floor resolution may rise above, a range included'
     report().outdated.dependencies*.name == ['guice']
     report().outdated.dependencies[0].available.milestone == '3.1'
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+  def 'a dynamic classpath bound is applied with no rule written for it'() {
+    given: 'a classpath range nothing pushes past, and no rejectVersionIf rule'
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          configurations.create('probeClasspath')
+          dependencies {
+            probeClasspath 'com.google.inject:guice:[2.0, 3.0['
+          }
+        }
+
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run()
+
+    then: 'the newest version inside the range, with 3.0 and 3.1 left out by default'
+    result.output.contains(' - com.google.inject:guice:2.2')
+    !result.output.contains('com.google.inject:guice [2.2 -> ')
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -65,10 +65,10 @@ final class DeclaredVersionConstraintSpec extends Specification {
       """.stripIndent()
   }
 
-  private def run() {
+  private def run(String... options) {
     def result = GradleRunner.create()
       .withProjectDir(testProjectDir.root)
-      .withArguments('dependencyUpdates')
+      .withArguments(['dependencyUpdates'] + options.toList())
       .withPluginClasspath()
       .build()
     assert result.task(':dependencyUpdates').outcome == SUCCESS
@@ -143,8 +143,8 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().unresolved.dependencies.isEmpty()
   }
 
-  def 'without the rule the rejected version is offered, so the rule is what changes it'() {
-    given:
+  def 'the declared bound is respected without a rule, as the task property is on by default'() {
+    given: 'a guice declaration rejecting its own newest version, with no rule beside it'
     writeBuildFile(
       """
         api('com.google.inject:guice') {
@@ -159,7 +159,72 @@ final class DeclaredVersionConstraintSpec extends Specification {
     when:
     run()
 
+    then: 'guice stops below the rejected version, which the README recipe used to be needed for'
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.0'
+  }
+
+  def 'a constraint stating a range still bounds the report, though its version reads as a range'() {
+    given: 'a constraint with no declaration beside it, so the row reports the range as its version'
+    writeBuildFile(
+      """
+        constraints {
+          api('com.google.inject:guice') {
+            version {
+              strictly '[2.0, 3.0['
+            }
+          }
+        }
+      """,
+      'checkConstraints = true')
+
+    when:
+    run()
+
+    then: 'the top of the declared range, not the 3.1 the unbounded query finds'
+    def guice = report().outdated.dependencies.find { it.name == 'guice' }
+    guice != null
+    guice.available.milestone == '2.2'
+  }
+
+  def 'rejectOutOfBoundVersions = false offers the version the build rejects'() {
+    given:
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '3.1'
+          }
+        }
+      """,
+      'rejectOutOfBoundVersions = false')
+
+    when:
+    run()
+
     then: 'the unbounded query offers the very version the build rejects'
+    report().outdated.dependencies*.name == ['guice']
+    report().outdated.dependencies[0].available.milestone == '3.1'
+  }
+
+  def 'the command line option shows what the bound withholds for a single run'() {
+    given: 'the build leaves the property at its default'
+    writeBuildFile(
+      """
+        api('com.google.inject:guice') {
+          version {
+            require '2.0'
+            reject '3.1'
+          }
+        }
+      """,
+      '')
+
+    when:
+    run('--no-reject-out-of-bound-versions')
+
+    then: 'the version the bound withholds is offered'
     report().outdated.dependencies*.name == ['guice']
     report().outdated.dependencies[0].available.milestone == '3.1'
   }
@@ -300,6 +365,45 @@ final class DeclaredVersionConstraintSpec extends Specification {
     then: 'the selected version is in bound even where the interval alone would exclude it'
     !result.output.contains('com.google.inject:guice [3.0 <- ')
     result.output.contains(' - com.google.inject:guice:3.0')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/755')
+  def 'a dynamic classpath bound the resolved version already exceeds does not hold the report'() {
+    given: 'the same classpath range resolution rose above, with no rule to reject with'
+    testProjectDir.newFile('build.gradle') <<
+      """
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          configurations.create('probeClasspath')
+          dependencies {
+            constraints {
+              probeClasspath 'com.google.guava:guava:15.0'
+            }
+            probeClasspath 'com.google.guava:guava'
+            probeClasspath 'com.google.inject:guice:[2.0, 3.0['
+            probeClasspath 'com.example:guice-consumer:1.0'
+          }
+        }
+
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+
+    when:
+    def result = run()
+
+    then: 'a bound the resolved version already sits above holds nothing, so the upgrade stands'
+    result.output.contains('com.google.inject:guice [3.0 -> 7.0.0]')
   }
 
   def 'a module with no declared bound is not bounded'() {
@@ -458,8 +562,8 @@ final class DeclaredVersionConstraintSpec extends Specification {
     then: 'the mutation is refused, and the reported current version is the resolved one'
     result.output.contains('PROBE-REFUSED')
     !result.output.contains('PROBE-MUTATED')
-    report().outdated.dependencies*.name == ['guice']
-    report().outdated.dependencies[0].version == '3.0'
+    report().current.dependencies*.name == ['guice']
+    report().current.dependencies[0].version == '3.0'
   }
 
   def 'a substituted module has no declared constraint, and the recipe tolerates it'() {
@@ -523,14 +627,14 @@ final class DeclaredVersionConstraintSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/402')
-  def 'without the rule the platform-supplied module is offered every upgrade, so the rule is what changes it'() {
-    given: 'the bounded shape above, with no rule installed'
+  def 'with the bound turned off the platform-supplied module is offered every upgrade'() {
+    given: 'the bounded declarations above, with the property turned off'
     writeBuildFile(
       """
         api platform('org.apache.logging.log4j:log4j:2.16.0')
         api 'org.apache.logging.log4j:log4j-core'
       """,
-      '')
+      'rejectOutOfBoundVersions = false')
 
     when:
     run()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -164,28 +164,57 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().outdated.dependencies[0].available.milestone == '3.0'
   }
 
-  def 'a rule reading satisfiesDeclaredBound is warned once per build that it is deprecated'() {
-    given: 'two modules, so the rule is evaluated for more than one candidate'
-    writeBuildFile(
+  def 'a rule reading satisfiesDeclaredBound is warned once per project that it is deprecated'() {
+    given: 'a script classpath and two modules, so the rule is evaluated by both resolutions'
+    testProjectDir.newFile('build.gradle') <<
       """
-        api('com.google.inject:guice') {
-          version {
-            require '2.0'
-            reject '3.1'
+        buildscript {
+          repositories {
+            maven {
+              url '${mavenRepoUrl}'
+            }
+          }
+          dependencies {
+            constraints {
+              classpath 'com.google.guava:guava:15.0'
+            }
           }
         }
-        api 'com.google.guava:guava:15.0'
-      """,
-      """
-        rejectVersionIf {
-          !satisfiesDeclaredBound
+
+        plugins {
+          id 'java-library'
+          id 'io.github.ben-manes.versions'
         }
-      """)
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          api('com.google.inject:guice') {
+            version {
+              require '2.0'
+              reject '3.1'
+            }
+          }
+          api 'com.google.guava:guava:15.0'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+          checkBuildEnvironmentConstraints = true
+          rejectVersionIf {
+            !satisfiesDeclaredBound
+          }
+        }
+      """.stripIndent()
 
     when:
     def result = run()
 
-    then: 'one warning, not one per candidate'
+    then: 'one warning, not one per candidate and not one per resolution'
     result.output.count('satisfiesDeclaredBound is deprecated') == 1
   }
 
@@ -206,7 +235,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     def result = run()
 
     then:
-    !result.output.contains('is deprecated')
+    !result.output.contains('satisfiesDeclaredBound is deprecated')
   }
 
   def 'a constraint stating a range still bounds the report, though its version reads as a range'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DeclaredVersionConstraintSpec.groovy
@@ -284,7 +284,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     guice.available.milestone == '2.0'
   }
 
-  def 'rejectOutOfBoundVersions = false offers the version the build rejects'() {
+  def 'with rejectOutOfBoundVersions = false the version the build rejects is listed'() {
     given:
     writeBuildFile(
       """
@@ -305,7 +305,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     report().outdated.dependencies[0].available.milestone == '3.1'
   }
 
-  def 'the command line option shows what the bound withholds for a single run'() {
+  def 'the command line option lists what the bound leaves out, for a single run'() {
     given: 'the build leaves the property at its default'
     writeBuildFile(
       """
@@ -321,7 +321,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     when:
     run('--no-reject-out-of-bound-versions')
 
-    then: 'the version the bound withholds is offered'
+    then: 'the version left out by the bound is listed'
     report().outdated.dependencies*.name == ['guice']
     report().outdated.dependencies[0].available.milestone == '3.1'
   }
@@ -499,7 +499,7 @@ final class DeclaredVersionConstraintSpec extends Specification {
     when:
     def result = run()
 
-    then: 'a bound the resolved version already sits above holds nothing, so the upgrade stands'
+    then: 'a bound the resolved version already lies outside is not applied, so the upgrade is listed'
     result.output.contains('com.google.inject:guice [3.0 -> 7.0.0]')
   }
 


### PR DESCRIPTION
This PR adds a `rejectOutOfBoundVersions` task property, on by default, so a candidate outside a bound declared in the build is left out of the report. It was listed before unless one used the `rejectVersionIf { !satisfiesDeclaredBound }` recipe in the README. As a task property, it is now configurable from the command line. The default can be overridden for a single run with `--no-reject-out-of-bound-versions` with no need to edit the build script. `satisfiesDeclaredBound` is deprecated for removal in a later release.

Given `api(platform("org.apache.logging.log4j:log4j-bom:2.16.0"))` and a versionless `api("org.apache.logging.log4j:log4j-core")`, on v0.61.0 an upgrade the build cannot take is listed:

```text
The following dependencies have later milestone versions:
 - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.26.1]
     https://logging.apache.org/log4j/2.x/
 - org.apache.logging.log4j:log4j-core [2.16.0 -> 2.26.1]
     https://logging.apache.org/log4j/2.x/
```

With this PR:

```text
The following dependencies are using the latest milestone version:
 - org.apache.logging.log4j:log4j-core:2.16.0
     constrained by the platform org.apache.logging.log4j:log4j-bom

The following dependencies have later milestone versions:
 - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.26.1]
     https://logging.apache.org/log4j/2.x/
```

With `--no-reject-out-of-bound-versions`:

```text
The following dependencies have later milestone versions:
 - org.apache.logging.log4j:log4j-bom [2.16.0 -> 2.26.1]
     https://logging.apache.org/log4j/2.x/
 - org.apache.logging.log4j:log4j-core [2.16.0 -> 2.26.1]
     https://logging.apache.org/log4j/2.x/
     constrained by the platform org.apache.logging.log4j:log4j-bom
```

The plugin's own row and the Gradle section are trimmed from each.
