### PR TITLE
Report the latest pre-release after the latest release by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,14 +308,14 @@ tasks.named("dependencyUpdates").configure {
 - `checkConstraints` adds the versions a `constraints` block manages to the
   report (see [Constraints](#constraints)).
 
-Nothing else is needed. A pre-release candidate is left out by
-`rejectPreReleases`, and a candidate outside a `strictly` or `reject` bound
-written in the build, outside a dynamic version declared on the buildscript
-classpath, or outside the version fixed by a consumed platform is left out by
-`rejectOutOfBounds`. Both are on by default (see [Filtering unstable
+Nothing else is needed. A pre-release candidate is printed as a step of its own
+after the newest release rather than in place of it, and `rejectPreReleases`
+leaves that step out. A candidate outside a `strictly` or `reject` bound written
+in the build, outside a dynamic version declared on the buildscript classpath, or
+outside the version fixed by a consumed platform is left out by
+`rejectOutOfBounds`, which is on by default (see [Filtering unstable
 versions](#filtering-unstable-versions) and [Respecting declared
-bounds](#respecting-declared-bounds)); set either to `false` to see what it
-leaves out.
+bounds](#respecting-declared-bounds)).
 
 The [configuration filters](#configuration-filter) are absent only because
 their arguments are build-specific: the names to reject come from your own
@@ -337,7 +337,7 @@ command line option, since no command line can express the logic.
 | [`filterConfigurations`](#filterconfigurations) | a `Spec<Configuration>` | every configuration | |
 | [`filterDeclaredConfigurations`](#filterdeclaredconfigurations) | a `Spec<String>` | every name | |
 | [`rejectOutOfBounds`](#respecting-declared-bounds) | `true`, `false` | `true` | `--[no-]reject-out-of-bounds` |
-| [`rejectPreReleases`](#filtering-unstable-versions) | `true`, `false` | `true` | `--[no-]reject-pre-releases` |
+| [`rejectPreReleases`](#filtering-unstable-versions) | `true`, `false` | `false` | `--[no-]reject-pre-releases` |
 | [`preReleaseVersionIf`](#filtering-unstable-versions) | a predicate over a version string | nothing added | |
 | [`exemptFromBuiltInChecksIf`](#filtering-unstable-versions) | a predicate over the candidate | nothing exempt | |
 | [`rejectVersionIf`](#filtering-unstable-versions) | a predicate over the candidate | nothing rejected | |
@@ -707,14 +707,32 @@ hoc usage:
 
 Because Maven repositories do not mark pre-release versions, an alpha or release
 candidate reaches the query as the latest version under any revision. What keeps
-it out of the report under `release` and `milestone` is the version string
-rather than the revision (see [Filtering unstable
+it from displacing the newest release under `release` and `milestone` is the
+version string rather than the revision (see [Filtering unstable
 versions](#filtering-unstable-versions)).
 
 ##### Filtering unstable versions
 
-A pre-release candidate is left out of the report unless the current version
-is itself a pre-release, in which case newer pre-releases are still reported.
+A row shows the newest release the resolution accepted, then the newest
+pre-release above it as a second step, each printed only where it is newer than
+the step before it:
+
+```
+The following dependencies have later milestone versions:
+ - org.jetbrains.kotlin:kotlin-stdlib [2.4.0 -> 2.4.10 -> 2.4.20-beta1]
+ - com.google.guava:guava [15.0 -> 16.0-rc1]
+```
+
+The Gradle row is printed the same way, and `gradleReleaseChannel` defaults to
+`release-candidate` for the same reason. Setting `rejectPreReleases` to `true`
+leaves the pre-release step out, so the first row above reads `[2.4.0 ->
+2.4.10]` and the second is reported as up to date.
+
+The pre-release step is the newest candidate that fails the pre-release check
+alone: the bound check, the revision and any `rejectVersionIf` filter are
+applied to it first, so a candidate one of those rejects is not printed as a
+step. It is left out entirely when the current version is itself a pre-release,
+in which case newer pre-releases are the row's accepted version instead.
 The markers are `alpha`, `beta`, `canary`, `candidate`, `cr`, `dev`,
 `draft`, `ea`, `eap`, `experimental`, `m`, `milestone`, `nightly`, `pr`, `pre`,
 `preview`, `rc`, `snap`, `snapshot` and `unstable`, each matched
@@ -736,11 +754,6 @@ The check is for a pre-release marker rather than for a stable pattern, so a
 version with a qualifier not in the list, such as `10.2.0.jre11`, `1.1.17.SP2`
 or `0.4-groovy-1.6`, is passed through rather than hidden.
 
-Under the `integration` revision the filter is off by default, and
-`rejectPreReleases` reads `false`: that revision selects the newest version
-whatever its qualifier, snapshots included. Setting the property, or passing the
-option, turns it on there too.
-
 A candidate is left out by being rejected, so for a module with only
 pre-releases published, and the declared version no longer among them, no
 candidate is left to resolve. That entry is reported as unresolved, with the
@@ -752,8 +765,9 @@ builds, is added to the check with `preReleaseVersionIf`. A version it matches
 is a pre-release wherever the check reads one: it is left out under the same
 property and option, a build already on one is still shown a newer one, and
 `isPreRelease` in a rule is true for it. The convention is part of the built-in
-check, so it is off wherever that check is, under `rejectPreReleases = false`
-and by default under the `integration` revision. It is given the version with
+check, so a version it matches is printed as a step rather than as the row's
+accepted version, and `rejectPreReleases` leaves that step out as it does any
+other. It is given the version with
 any build metadata removed, as the markers are, and it is applied to the version
 in use as well as to the candidate. Called more than once on a task, the
 predicates accumulate; a subproject that calls it replaces the root's rather
@@ -788,18 +802,16 @@ than in place of it, and it is still applied when the option is passed, so a
 convention belongs in `preReleaseVersionIf` rather than in a filter, and an
 exception belongs in `exemptFromBuiltInChecksIf`, below. A filter is for a
 policy the checks cannot express, such as pinning a module. A candidate is left
-out if either rejects it, and neither can restore what the other rejected. To
-see every published candidate, including the pre-releases, turn the built-in
-filter off with `rejectPreReleases = false`, or with `--no-reject-pre-releases`
-for a single run (see [Command line options](#command-line-options)).
+out if either rejects it, and neither can restore what the other rejected. A
+candidate a filter rejects is not printed as a pre-release step either.
 
 A module can be exempted from both built-in checks, with the checks left on for
 the rest of the build. `exemptFromBuiltInChecksIf` takes the same predicate over
 the candidate as `rejectVersionIf`; a candidate it matches is not held to
 `rejectPreReleases` or to `rejectOutOfBounds`. The exemption is applied
 inside the checks, so the two properties and their options apply as they do
-without it: `--no-reject-pre-releases` still turns the check off for a single
-run, and the positive option turns it on with the exemption in place. Called
+without it: `--reject-pre-releases` still leaves the step out for a single run,
+and the negative option prints it with the exemption in place. Called
 more than once on a task, the predicates accumulate; a subproject that calls it
 replaces the root's rather than adding to it (see [Shared task
 settings](#shared-task-settings)). Here one module is allowed both its
@@ -2120,13 +2132,14 @@ longer included does not break the build.
 The task that writes the report applies its settings to every entry in it,
 including the entries an included build resolved and the entries its subprojects
 resolved. Its `rejectVersionIf` and `resolutionStrategy` rules are applied to
-those entries, `rejectPreReleases` checks them against the pre-release
-markers, the convention added with `preReleaseVersionIf` and the exception made
-with `exemptFromBuiltInChecksIf`, and `filterDeclaredConfigurations` leaves out
-the ones with a configuration name it rejects. An included build with nothing
-configured is reported under the aggregating build's rules, and an included
-build with `rejectPreReleases` switched off is still checked against it
-where its entries are merged.
+those entries, the convention added with `preReleaseVersionIf` and the exception
+made with `exemptFromBuiltInChecksIf` are read for them, and
+`filterDeclaredConfigurations` leaves out the ones with a configuration name it
+rejects. An included build with nothing configured is reported under the
+aggregating build's rules. `rejectPreReleases` is settled by the aggregating
+task alone, for every entry in the report: an included build's own setting
+governs the report that build writes rather than the one its entries are merged
+into.
 
 Within one build the pre-release check and a rule behave differently. The
 pre-release check reads the convention and the exemption inherited by the
@@ -2452,8 +2465,8 @@ and *Note*s are things worth knowing that need no action.
 
 ### v0.61.0
 
-In the next release, a pre-release candidate is left out of the report unless
-the current version is itself a pre-release, the report is held to the bounds
+In the next release, a pre-release candidate is reported as a step after the
+newest release rather than in place of it, the report is held to the bounds
 written in the build without a rule written for it, a coordinate with one
 declared version and different latest versions across the aggregated projects
 is shown on one entry per latest version, where the entries were merged into
@@ -2461,11 +2474,20 @@ the newest of them before, and an aggregating report applies its settings to
 the entries merged from an included build:
 
 > [!IMPORTANT]
-> - A dependency with no newer release, only a newer pre-release, is now
->   reported as up to date, where that pre-release was reported before. Set
->   `rejectPreReleases = false` to include pre-releases again, or pass
->   `--no-reject-pre-releases` for a single run (see [Filtering unstable
+> - A row's `available` version is now the newest release, and a newer
+>   pre-release is carried beside it in `available.preRelease`, where the
+>   pre-release was the `available` version before. A plain text row prints both,
+>   as `[2.4.0 -> 2.4.10 -> 2.4.20-beta1]`. A tool that reads `available.release`,
+>   `available.milestone` or `available.integration` gets the newest release
+>   rather than the pre-release, and for a dependency whose only newer candidate
+>   is a pre-release it gets the version in use. Set `rejectPreReleases = true`
+>   to leave the pre-release step out altogether, or pass
+>   `--reject-pre-releases` for a single run (see [Filtering unstable
 >   versions](#filtering-unstable-versions)).
+> - `VersionAvailable` takes a fourth `preRelease` argument. Every constructor
+>   arity the last release shipped is still callable, so Java and Groovy callers
+>   are unaffected, but Kotlin code that constructs one with named or default
+>   arguments has to be recompiled.
 > - A candidate outside a `strictly` or `reject` bound written in the build,
 >   outside a dynamic version declared on the buildscript classpath, or outside
 >   the version fixed by a consumed platform, is left out of the report, where

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ command line option, since no command line can express the logic.
 | Property | Values | Default | Option |
 | --- | --- | --- | --- |
 | [`revision`](#revisions) | `release`, `milestone`, `integration` | `milestone` | `--revision` |
-| [`gradleReleaseChannel`](#gradle-release-channel) | `current`, `release-candidate`, `nightly` | `release-candidate` | `--gradle-release-channel` |
+| [`gradleReleaseChannel`](#gradle-release-channel) | `current`, `release-candidate`, `nightly` | `release-candidate`, or `current` under `rejectPreReleases` | `--gradle-release-channel` |
 | [`checkForGradleUpdate`](#checkforgradleupdate) | `true`, `false` | `true` | `--[no-]check-for-gradle-update` |
 | [`checkConstraints`](#constraints) | `true`, `false` | `false` | `--[no-]check-constraints` |
 | [`checkBuildEnvironmentConstraints`](#constraints) | `true`, `false` | `false` | `--[no-]check-build-environment-constraints` |
@@ -723,10 +723,11 @@ The following dependencies have later milestone versions:
  - com.google.guava:guava [15.0 -> 16.0-rc1]
 ```
 
-The Gradle row is printed the same way, and `gradleReleaseChannel` defaults to
-`release-candidate` for the same reason. Setting `rejectPreReleases` to `true`
-leaves the pre-release step out, so the first row above reads `[2.4.0 ->
-2.4.10]` and the second is reported as up to date.
+The Gradle row is printed the same way, and `rejectPreReleases` governs it
+through [`gradleReleaseChannel`](#gradle-release-channel)'s default. Setting
+`rejectPreReleases` to `true` leaves the pre-release step out, so the first row
+above reads `[2.4.0 -> 2.4.10]`, the second is reported as up to date, and the
+Gradle row reports `current` alone.
 
 The pre-release step is the newest candidate that fails the pre-release check
 alone: the bound check, the revision and any `rejectVersionIf` filter are
@@ -1241,7 +1242,14 @@ Gradle project is used to check for available Gradle updates. Options are:
 * `release-candidate`
 * `nightly`
 
-The default is `release-candidate`. The value can be changed as shown below:
+The default follows [`rejectPreReleases`](#filtering-unstable-versions), so one
+setting answers for the Gradle row and the dependency rows alike: with the
+pre-release step printed, which it is by default, the default here is
+`release-candidate`, and a build that sets `rejectPreReleases = true` reports
+`current` alone. Stating the property, passing the option, or setting the system
+property is read ahead of that, so a build that leaves out every dependency's
+pre-release step and still wants the Gradle release candidate can say so. The
+value can be changed as shown below:
 
 <details open>
 <summary>Kotlin</summary>
@@ -2488,6 +2496,14 @@ the entries merged from an included build:
 >   arity the last release shipped is still callable, so Java and Groovy callers
 >   are unaffected, but Kotlin code that constructs one with named or default
 >   arguments has to be recompiled.
+
+> [!NOTE]
+> - `gradleReleaseChannel` now takes its default from `rejectPreReleases`, so a
+>   build that leaves out every dependency's pre-release step no longer reports
+>   the Gradle release candidate. The default is unchanged at
+>   `release-candidate` for a build that leaves `rejectPreReleases` alone, and
+>   stating the property or passing the option is still read ahead of it (see
+>   [Gradle release channel](#gradle-release-channel)).
 > - A candidate outside a `strictly` or `reject` bound written in the build,
 >   outside a dynamic version declared on the buildscript classpath, or outside
 >   the version fixed by a consumed platform, is left out of the report, where

--- a/README.md
+++ b/README.md
@@ -732,7 +732,8 @@ Gradle row reports `current` alone.
 The pre-release step is the newest candidate that fails the pre-release check
 alone: the bound check, the revision and any `rejectVersionIf` filter are
 applied to it first, so a candidate one of those rejects is not printed as a
-step. It is left out entirely when the current version is itself a pre-release,
+step. That ordering is also why a filter is called for pre-release candidates it
+was never called for before. It is left out entirely when the current version is itself a pre-release,
 in which case newer pre-releases are the row's accepted version instead.
 The markers are `alpha`, `beta`, `canary`, `candidate`, `cr`, `dev`,
 `draft`, `ea`, `eap`, `experimental`, `m`, `milestone`, `nightly`, `pr`, `pre`,
@@ -2498,6 +2499,11 @@ the entries merged from an included build:
 >   arguments has to be recompiled.
 
 > [!NOTE]
+> - A `rejectVersionIf` filter is now applied to a pre-release candidate before
+>   the built-in check leaves it out, where the built-in check ran first and the
+>   filter never saw one. A filter with a side effect runs it for those
+>   candidates too (see [Filtering unstable
+>   versions](#filtering-unstable-versions)).
 > - `gradleReleaseChannel` now takes its default from `rejectPreReleases`, so a
 >   build that leaves out every dependency's pre-release step no longer reports
 >   the Gradle release candidate. The default is unchanged at

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
@@ -265,7 +265,21 @@ class HtmlReporter(
     return rows
   }
 
+  /**
+   * Returns the version the Latest Version cell shows, which is the newest the resolution accepted,
+   * followed by the pre-release step where there is one and it is not the same version.
+   */
   private fun getDisplayableVersion(versionAvailable: VersionAvailable): String? {
+    val latest = latestOf(versionAvailable)
+    val preRelease = versionAvailable.preRelease
+    return when {
+      preRelease == null || preRelease == latest -> latest
+      latest.isNullOrEmpty() -> preRelease
+      else -> "$latest -> $preRelease"
+    }
+  }
+
+  private fun latestOf(versionAvailable: VersionAvailable): String? {
     if (revision.equals("milestone", ignoreCase = true)) {
       return versionAvailable.milestone
     } else if (revision.equals("release", ignoreCase = true)) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/HtmlReporter.kt
@@ -1,6 +1,7 @@
 package com.github.benmanes.gradle.versions.reporter
 
 import com.github.benmanes.gradle.versions.reporter.result.Dependency
+import com.github.benmanes.gradle.versions.reporter.result.DependencyOutdated
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.reporter.result.VersionAvailable
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
@@ -253,11 +254,7 @@ class HtmlReporter(
           getUrlString(dependency.projectUrl),
           getVersionString(dependency.group.orEmpty(), dependency.name.orEmpty(), dependency.version) +
             origin(dependency),
-          getVersionString(
-            dependency.group.orEmpty(),
-            dependency.name.orEmpty(),
-            getDisplayableVersion(dependency.available),
-          ),
+          latestVersionCell(dependency),
           dependency.userReason.orEmpty(),
         )
       rows.add(rowString)
@@ -266,20 +263,27 @@ class HtmlReporter(
   }
 
   /**
-   * Returns the version the Latest Version cell shows, which is the newest the resolution accepted,
-   * followed by the pre-release step where there is one and it is not the same version.
+   * Returns the Latest Version cell, the newest version the resolution accepted followed by the
+   * pre-release step where a row has one. Each version is linked on its own rather than the pair
+   * being formatted as one, since [getVersionString] puts what it is given into a Sonatype url.
    */
-  private fun getDisplayableVersion(versionAvailable: VersionAvailable): String? {
-    val latest = latestOf(versionAvailable)
-    val preRelease = versionAvailable.preRelease
-    return when {
-      preRelease == null || preRelease == latest -> latest
-      latest.isNullOrEmpty() -> preRelease
-      else -> "$latest -> $preRelease"
+  private fun latestVersionCell(dependency: DependencyOutdated): String {
+    val available = dependency.available
+    val group = dependency.group.orEmpty()
+    val name = dependency.name.orEmpty()
+    val latest = getDisplayableVersion(available)
+    val cell = getVersionString(group, name, latest)
+    val preRelease = available.preRelease
+    return if (preRelease == null || preRelease == latest) {
+      cell
+    } else if (latest.isNullOrEmpty()) {
+      getVersionString(group, name, preRelease)
+    } else {
+      cell + " -> " + getVersionString(group, name, preRelease)
     }
   }
 
-  private fun latestOf(versionAvailable: VersionAvailable): String? {
+  private fun getDisplayableVersion(versionAvailable: VersionAvailable): String? {
     if (revision.equals("milestone", ignoreCase = true)) {
       return versionAvailable.milestone
     } else if (revision.equals("release", ignoreCase = true)) {
@@ -287,7 +291,8 @@ class HtmlReporter(
     } else if (revision.equals("integration", ignoreCase = true)) {
       return versionAvailable.integration
     }
-    return ""
+    // Where the report filed the version it found for a revision outside the three levels.
+    return versionAvailable.release
   }
 
   override fun getFileExtension(): String {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions.reporter
 import com.github.benmanes.gradle.versions.reporter.result.Dependency
 import com.github.benmanes.gradle.versions.reporter.result.DependencyOutdated
 import com.github.benmanes.gradle.versions.reporter.result.Result
+import com.github.benmanes.gradle.versions.updates.VersionMapping
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.NIGHTLY
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
@@ -115,11 +116,21 @@ class PlainTextReporter
     /**
      * Returns the row's version steps joined by arrows, from the version in use through the newest
      * the resolution accepted to the pre-release step, each printed only where it is newer than the
-     * one before it, as the Gradle row's release candidate is.
+     * one before it, as the Gradle row's release candidate is. Compared rather than deduplicated:
+     * `available[revision]` is blank for a revision outside the three the report knows, and a step
+     * equal to the one before it is not the only one that has nothing to add.
      */
     private fun breadcrumb(dependency: DependencyOutdated): String {
       val steps = listOfNotNull(dependency.version, dependency.available[revision], dependency.available.preRelease)
-      return steps.distinct().joinToString(" -> ")
+      val newestFirst = VersionMapping.versionComparator()
+      val printed = mutableListOf<String>()
+      for (step in steps) {
+        if (step.isEmpty()) continue
+        if (printed.isEmpty() || newestFirst.compare(printed.last(), step) < 0) {
+          printed.add(step)
+        }
+      }
+      return printed.joinToString(" -> ")
     }
 
     private fun writeUpgrades(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/PlainTextReporter.kt
@@ -1,6 +1,7 @@
 package com.github.benmanes.gradle.versions.reporter
 
 import com.github.benmanes.gradle.versions.reporter.result.Dependency
+import com.github.benmanes.gradle.versions.reporter.result.DependencyOutdated
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.NIGHTLY
@@ -111,6 +112,16 @@ class PlainTextReporter
       }
     }
 
+    /**
+     * Returns the row's version steps joined by arrows, from the version in use through the newest
+     * the resolution accepted to the pre-release step, each printed only where it is newer than the
+     * one before it, as the Gradle row's release candidate is.
+     */
+    private fun breadcrumb(dependency: DependencyOutdated): String {
+      val steps = listOfNotNull(dependency.version, dependency.available[revision], dependency.available.preRelease)
+      return steps.distinct().joinToString(" -> ")
+    }
+
     private fun writeUpgrades(
       printStream: OutputStream,
       result: Result,
@@ -121,7 +132,7 @@ class PlainTextReporter
         printStream.println("The following dependencies have later $revision versions:")
         for (dependency in upgradeVersions) {
           val currentVersion = dependency.version
-          printStream.println(" - ${label(dependency)} [$currentVersion -> ${dependency.available[revision]}]")
+          printStream.println(" - ${label(dependency)} [${breadcrumb(dependency)}]")
           dependency.userReason?.let {
             printStream.println("     $it")
           }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/XmlReporter.kt
@@ -106,6 +106,7 @@ class XmlReporter(
     appendTextChild(document, available, "release", version.release)
     appendTextChild(document, available, "milestone", version.milestone)
     appendTextChild(document, available, "integration", version.integration)
+    appendTextChild(document, available, "preRelease", version.preRelease)
   }
 
   private fun writeExceededSection(

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/VersionAvailable.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/VersionAvailable.kt
@@ -6,6 +6,12 @@ class VersionAvailable
     val release: String? = null,
     val milestone: String? = null,
     val integration: String? = null,
+    /**
+     * The newest candidate the pre-release check left out, null when there is none or when the
+     * report's `rejectPreReleases` leaves the step out. Newer than the version the three fields
+     * above carry, which is the newest the resolution accepted.
+     */
+    val preRelease: String? = null,
   ) {
     operator fun get(revision: String): String? {
       return when (revision) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/VersionAvailable.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/reporter/result/VersionAvailable.kt
@@ -7,20 +7,22 @@ class VersionAvailable
     val milestone: String? = null,
     val integration: String? = null,
     /**
-     * The newest candidate the pre-release check left out, null when there is none or when the
-     * report's `rejectPreReleases` leaves the step out. Newer than the version the three fields
-     * above carry, which is the newest the resolution accepted.
+     * The newest candidate left out by the pre-release check, null when there is none or when
+     * `rejectPreReleases` is set on the report. Newer than the version in the three fields above,
+     * which is the newest the resolution accepted.
      */
     val preRelease: String? = null,
   ) {
+    /**
+     * Returns the version available at [revision], and the release-level one for a revision outside
+     * the three levels, which is where the report files the version it found for such a revision.
+     * Reading back an empty string there left every reporter printing a row with no version at all.
+     */
     operator fun get(revision: String): String? {
       return when (revision) {
-        "release" -> release
         "milestone" -> milestone
         "integration" -> integration
-        else -> {
-          ""
-        }
+        else -> release
       }
     }
   }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -143,9 +143,6 @@ internal fun <T : Any> settingOf(
 /** The revision level resolved against when neither the build nor an override states one. */
 internal const val DEFAULT_REVISION = "milestone"
 
-/** The revision that selects the newest version whatever its qualifier, snapshots included. */
-internal const val INTEGRATION_REVISION = "integration"
-
 /** The task settings that a project's producer reads while its input is realized; null is unset. */
 internal class DependencyUpdatesParameters {
   var revision: String? = null
@@ -453,13 +450,13 @@ internal abstract class DependencyUpdatesParametersService :
           fromCommandLine = chain.firstNotNullOfOrNull { it.rejectOutOfBoundsFromCommandLine },
           configured = chain.firstNotNullOfOrNull { it.rejectOutOfBounds } ?: true,
         ),
-      // Off by default under the integration revision, which selects the newest version whatever
-      // its qualifier, snapshots included. An explicit setting still applies there.
+      // Off by default, whatever the revision, so that a row whose repository lists a newer
+      // pre-release prints it as the step after the newest release. `gradleReleaseChannel` prints
+      // the Gradle row's release candidate the same way and defaults to the same answer.
       rejectPreReleases =
         settingOf(
           fromCommandLine = chain.firstNotNullOfOrNull { it.rejectPreReleasesFromCommandLine },
-          configured =
-            chain.firstNotNullOfOrNull { it.rejectPreReleases } ?: (revision != INTEGRATION_REVISION),
+          configured = chain.firstNotNullOfOrNull { it.rejectPreReleases } ?: false,
         ),
     )
   }
@@ -997,7 +994,6 @@ private fun statusesOf(
       parameters.resolutionStrategy,
       checkConstraints = checkConstraints,
       rejectOutOfBounds = parameters.rejectOutOfBounds,
-      rejectPreReleases = parameters.rejectPreReleases,
       preReleaseVersionIf = parameters.preReleaseVersionIf,
       exemptFromBuiltInChecksIf = parameters.exemptFromBuiltInChecksIf,
       settingsConfigurations = settingsConfigurations,

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -18,7 +18,7 @@ class DependencyStatus {
   val contributed: Boolean
   val configurations: List<String>
 
-  /** The newest candidate the pre-release check left out, null when it left none out. */
+  /** The newest candidate left out by the pre-release check, null when none was left out. */
   val preReleaseVersion: String?
 
   @JvmOverloads

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyStatus.kt
@@ -18,12 +18,17 @@ class DependencyStatus {
   val contributed: Boolean
   val configurations: List<String>
 
+  /** The newest candidate the pre-release check left out, null when it left none out. */
+  val preReleaseVersion: String?
+
+  @JvmOverloads
   constructor(
     coordinate: Coordinate,
     latestVersion: String,
     projectUrl: String?,
     contributed: Boolean = false,
     configurations: List<String> = emptyList(),
+    preReleaseVersion: String? = null,
   ) {
     this.coordinate = coordinate
     this.latestVersion = latestVersion
@@ -31,6 +36,7 @@ class DependencyStatus {
     this.unresolved = null
     this.contributed = contributed
     this.configurations = configurations
+    this.preReleaseVersion = preReleaseVersion
   }
 
   constructor(
@@ -45,6 +51,7 @@ class DependencyStatus {
     projectUrl = null
     this.contributed = contributed
     this.configurations = configurations
+    this.preReleaseVersion = null
   }
 
   fun getLatestCoordinate(): Coordinate {
@@ -91,6 +98,7 @@ class DependencyStatus {
       constraint = coordinate.versionConstraint?.toConstraintInfo(),
       platformConstraints = coordinate.platformVersionConstraints.map { it.toConstraintInfo() },
       onScriptClasspath = coordinate.onScriptClasspath,
+      preReleaseVersion = preReleaseVersion,
     )
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -334,7 +334,11 @@ class DependencyUpdatesReporter(
     coordinate: Coordinate,
     key: Map<String, String>,
   ): DependencyOutdated {
-    val laterVersion = latestFor(coordinate, key)
+    // Left null where no release is newer than the version in use, which a row reported for its
+    // pre-release step alone is. Reporting the version in use as the later one would read as an
+    // entry with nothing to upgrade to, and a consumer comparing the two would find no update in a
+    // row this report put among the outdated ones.
+    val laterVersion = latestFor(coordinate, key)?.takeIf { it != coordinate.version }
     val preRelease = preReleaseByCurrent[coordinate]
     val available =
       when (revision) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesReporter.kt
@@ -78,6 +78,8 @@ class DependencyUpdatesReporter(
   val skipped: List<SkippedConfiguration> = emptyList(),
   val platformProjectsByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
   val constrainedByCoordinate: Map<Coordinate, List<String>> = emptyMap(),
+  /** The pre-release step of each row, absent where the pre-release check left nothing out. */
+  val preReleaseByCurrent: Map<Coordinate, String> = emptyMap(),
 ) {
   @Deprecated("Use the constructor that includes the skipped configurations.")
   constructor(
@@ -333,11 +335,12 @@ class DependencyUpdatesReporter(
     key: Map<String, String>,
   ): DependencyOutdated {
     val laterVersion = latestFor(coordinate, key)
+    val preRelease = preReleaseByCurrent[coordinate]
     val available =
       when (revision) {
-        "milestone" -> VersionAvailable(milestone = laterVersion)
-        "integration" -> VersionAvailable(integration = laterVersion)
-        else -> VersionAvailable(release = laterVersion)
+        "milestone" -> VersionAvailable(milestone = laterVersion, preRelease = preRelease)
+        "integration" -> VersionAvailable(integration = laterVersion, preRelease = preRelease)
+        else -> VersionAvailable(release = laterVersion, preRelease = preRelease)
       }
     return DependencyOutdated(
       group = key["group"],
@@ -427,8 +430,17 @@ fun reporterFor(
   gradleVersionsApiBaseUrl: String,
   gradleReleaseChannel: String,
   skipped: List<SkippedConfiguration> = emptyList(),
+  rejectPreReleases: Boolean = false,
 ): DependencyUpdatesReporter {
-  val split = markDivergentlyResolved(statuses)
+  // Dropped here rather than checked at every read: the setting governs whether the step is
+  // printed, so a report that leaves it out is one whose rows never carried it.
+  val kept =
+    if (rejectPreReleases) {
+      statuses.map { if (it.preReleaseVersion == null) it else it.copy(preReleaseVersion = null) }
+    } else {
+      statuses
+    }
+  val split = markDivergentlyResolved(kept)
   val versions = VersionMapping(logger, split)
   val projectsByCoordinate = divergentProjects(split)
   val contributedCoordinates = contributedCoordinates(split, logger)
@@ -461,6 +473,7 @@ fun reporterFor(
     upgradeVersions, versions.undeclared, unresolved, projectUrls, gradleUpdateChecker,
     gradleReleaseChannel, versions.latestByCurrent, projectsByCoordinate, contributedCoordinates,
     configurationsByCoordinate, skipped, platformProjectsByCoordinate, constrainedByCoordinate,
+    versions.preReleaseByCurrent,
   )
 }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -4,6 +4,7 @@ import com.github.benmanes.gradle.versions.reporter.Reporter
 import com.github.benmanes.gradle.versions.reporter.result.Result
 import com.github.benmanes.gradle.versions.reporter.result.SkippedConfiguration
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel
+import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.CURRENT
 import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel.RELEASE_CANDIDATE
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentFilter
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
@@ -101,10 +102,31 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
 
   private var gradleReleaseChannelFromCommandLine: String? = null
 
-  /** Returns the resolution revision level. */
-  @Input
-  var gradleReleaseChannel: String = RELEASE_CANDIDATE.id
-    get() = settingOf(gradleReleaseChannelFromCommandLine, "gradleReleaseChannel", field)
+  private var gradleReleaseChannelSetting: String? = null
+
+  /**
+   * Returns the release channels the Gradle row reports, `release-candidate` unless the build leaves
+   * [rejectPreReleases] on, which reports `current` alone. Stating the channel in the build, passing
+   * the option, or setting the system property is read ahead of that, so a build that leaves out
+   * every dependency's pre-release step and still wants the Gradle release candidate can say so.
+   *
+   * Derived rather than fixed so that one setting governs both rows. The Gradle row prints the
+   * release candidate after the newest release, the same breadcrumb every dependency row prints, and
+   * a report that leaves the second step out of every dependency row while printing it for Gradle
+   * states two opposite policies in one file.
+   */
+  @get:Input
+  var gradleReleaseChannel: String
+    get() =
+      settingOf(
+        gradleReleaseChannelFromCommandLine,
+        "gradleReleaseChannel",
+        gradleReleaseChannelSetting
+          ?: if (rejectPreReleases) CURRENT.id else RELEASE_CANDIDATE.id,
+      )
+    set(value) {
+      gradleReleaseChannelSetting = value
+    }
 
   /** Sets the Gradle release channel for this invocation alone. */
   @Option(
@@ -298,11 +320,11 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   }
 
   /**
-   * Whether a pre-release candidate is left out of the report while the current version is not
-   * itself a pre-release, so that newer pre-releases are still reported to a build on one. A
-   * convention the built-in markers do not cover is added to the check with [preReleaseVersionIf].
-   * Off by default under the `integration` revision, which selects the newest version whatever its
-   * qualifier, and read back as `false` there unless set.
+   * Whether the pre-release step is left out of the report, the newest candidate the pre-release
+   * check rejects while the version in use is not itself a pre-release. A convention the built-in
+   * markers do not cover is added to the check with [preReleaseVersionIf]. Off by default, under
+   * every revision, so the step is printed after the newest release rather than in place of it. It
+   * governs [gradleReleaseChannel]'s default as well, so one setting answers for both rows.
    */
   @get:Input
   var rejectPreReleases: Boolean

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -105,15 +105,15 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
   private var gradleReleaseChannelSetting: String? = null
 
   /**
-   * Returns the release channels the Gradle row reports, `release-candidate` unless the build leaves
-   * [rejectPreReleases] on, which reports `current` alone. Stating the channel in the build, passing
-   * the option, or setting the system property is read ahead of that, so a build that leaves out
-   * every dependency's pre-release step and still wants the Gradle release candidate can say so.
+   * Returns which Gradle releases are printed: `release-candidate`, unless the build turns
+   * [rejectPreReleases] on, and then `current` alone. Stating this property in the build, passing the
+   * option, or setting the system property is read ahead of that, so a build that leaves out every
+   * dependency's pre-release step and still wants the Gradle release candidate can say so.
    *
-   * Derived rather than fixed so that one setting governs both rows. The Gradle row prints the
-   * release candidate after the newest release, the same breadcrumb every dependency row prints, and
-   * a report that leaves the second step out of every dependency row while printing it for Gradle
-   * states two opposite policies in one file.
+   * Derived rather than fixed so that one setting answers for both. The Gradle row is printed with
+   * the release candidate after the newest release, the same breadcrumb used for every dependency
+   * row, and a report with the second step left out of every dependency row while Gradle keeps it
+   * puts two opposite policies in one file.
    */
   @get:Input
   var gradleReleaseChannel: String

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -75,7 +75,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
           rejectPreReleases =
             settingOf(
               parameters.rejectPreReleasesFromCommandLine,
-              parameters.rejectPreReleases ?: (revision != INTEGRATION_REVISION),
+              parameters.rejectPreReleases ?: false,
             ),
         )
       },
@@ -499,14 +499,17 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     // resolved, which is the same condition that stores the convention and the exemption for the
     // report. Everywhere else the producers already applied the identical check, under the settings
     // they inherited, so applying it again would add nothing and would read the two predicates from
-    // properties that are gone from a restored cache entry.
+    // properties that are gone from a restored cache entry. It is applied whether or not
+    // `rejectPreReleases` is set, since that setting governs whether the step is printed: a merged
+    // row whose producer knew nothing of the convention configured here still has to be moved off
+    // the version this report counts as a pre-release.
     val mergesRowsResolvedElsewhere = parameters.mergesRowsResolvedElsewhere
     val reportRules =
       ReportRules(
         strategy,
         logger,
         revision,
-        mergesRowsResolvedElsewhere && rejectPreReleases,
+        mergesRowsResolvedElsewhere,
         parameters.preReleaseVersionIf ?: parameters.storedPreReleaseVersionIf,
         parameters.exemptFromBuiltInChecksIf ?: parameters.storedExemptFromBuiltInChecksIf,
       )
@@ -533,6 +536,7 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     reporterFor(
       statuses, projectPath, logger, revision, outputFormatter(), outputDirectory(), reportfileName,
       checkForGradleUpdate, gradleVersionsApiBaseUrl, gradleReleaseChannel, skipped,
+      rejectPreReleases,
     ).write()
   }
 

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -56,6 +56,11 @@ data class PartialStatus
      * https://github.com/ben-manes/gradle-versions-plugin/issues/755
      */
     val onScriptClasspath: Boolean = false,
+    /**
+     * The newest candidate the producer's pre-release check left out, null when it left none out.
+     * Trails for the same reason as [platformProjects].
+     */
+    val preReleaseVersion: String? = null,
   ) {
     val coordinate: Coordinate
       get() = Coordinate(group, name, declaredVersion, userReason, divergentLatest)

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/PartialResult.kt
@@ -57,8 +57,8 @@ data class PartialStatus
      */
     val onScriptClasspath: Boolean = false,
     /**
-     * The newest candidate the producer's pre-release check left out, null when it left none out.
-     * Trails for the same reason as [platformProjects].
+     * The newest candidate left out by the producer's pre-release check, null when none was left
+     * out. Trails for the same reason as [platformProjects].
      */
     val preReleaseVersion: String? = null,
   ) {
@@ -212,9 +212,14 @@ data class PartialResult
       /**
        * Bumped when the shape changes incompatibly; a field with a compatible default reads from an
        * older partial as that default. 2 records every candidate a dynamic query reaches rather
-       * than only the accepted one, plus the declared and platform-supplied constraints.
+       * than only the accepted one, plus the declared and platform-supplied constraints. 3 holds the
+       * newest release in `latestVersion` whatever `rejectPreReleases` is set to, with the newest
+       * pre-release beside it in `preReleaseVersion`, where 2 held whichever of the two that setting
+       * selected. The new field alone would read from a 2 as its default, but an older report
+       * reading a 3 would take `latestVersion` under the earlier meaning and drop the pre-release
+       * with nothing said, so the bump is what makes that combination fail instead.
        */
-      const val FORMAT_VERSION: Int = 2
+      const val FORMAT_VERSION: Int = 3
 
       private val adapter =
         Moshi.Builder()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/ReportRules.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/ReportRules.kt
@@ -124,16 +124,6 @@ internal class ReportRules(
     if (status.unresolved != null) {
       return status
     }
-    val moduleVersions =
-      status.projectPath
-        ?.let { versionsByProjectPath[it] }
-        ?.get("${status.group}:${status.name}")
-        .orEmpty()
-    val ceilingIndex = moduleVersions.indexOf(status.latestVersion)
-    if (ceilingIndex < 0) {
-      return status
-    }
-
     val rowKey = Coordinate.Key(status.group, status.name)
     val current =
       Coordinate(
@@ -151,17 +141,29 @@ internal class ReportRules(
     current.onScriptClasspath = status.onScriptClasspath
     currentHolder.clear()
     currentHolder[rowKey] = current
+    // Read after the holder is filled, since a rule reads the version in use through it.
     val rules = collector.rulesFor(status.group, status.name)
+
+    // The step a producer recorded sits above that producer's verdict, which the walk below starts
+    // at and never rises above, so this report's revision and its own rules are applied to it here.
+    // The producer answered under its own settings, which an including build may have set otherwise.
+    var preRelease: String? = status.preReleaseVersion?.takeIf { keptAsStep(status, it, rules) }
+
+    val moduleVersions =
+      status.projectPath
+        ?.let { versionsByProjectPath[it] }
+        ?.get("${status.group}:${status.name}")
+        .orEmpty()
+    val ceilingIndex = moduleVersions.indexOf(status.latestVersion)
+    if (ceilingIndex < 0) {
+      // Nothing to walk, so the row keeps its verdict; the step still answers to this report.
+      return if (preRelease == status.preReleaseVersion) status else status.copy(preReleaseVersion = preRelease)
+    }
 
     // Kept for the ceiling candidate alone (the first iterated below): `selectorVersion` in the
     // synthesized UnresolvedInfo is always the ceiling, so the reason reported has to be why that
     // version was rejected rather than why some older candidate further down the walk was.
     var ceilingReason: String? = null
-    // The newest candidate this report's pre-release check left out, which the producer's own check
-    // passed because the convention or the exemption configured here reaches further. Reported as
-    // the row's pre-release step, the same place a locally resolved row carries it, and only when
-    // the producer recorded none of its own.
-    var preRelease: String? = status.preReleaseVersion?.takeIf { keptAsStep(status, it, ceilingIndex, ceilingIndex, rules) }
     for (index in ceilingIndex until moduleVersions.size) {
       val version = moduleVersions[index]
       val shim = RecordedComponentSelection(status.group, status.name, version)
@@ -173,7 +175,7 @@ internal class ReportRules(
         if (index == ceilingIndex) {
           ceilingReason = PRE_RELEASE_REASON
         }
-        if (preRelease == null && keptAsStep(status, version, index, ceilingIndex, rules)) {
+        if (preRelease == null && keptAsStep(status, version, rules)) {
           preRelease = version
         }
         continue
@@ -236,21 +238,20 @@ internal class ReportRules(
 
   /**
    * Returns whether [version] is printed as this row's pre-release step, which it is when this
-   * report's revision and its own rules both accept it. The rules are applied here rather than in
-   * the walk above, which reaches a pre-release candidate only to skip it, and applied to a shim of
-   * their own so that the walk's verdict for the same candidate is not overwritten. A rule reading
-   * the metadata absent from the record leaves the step alone, as an undecided candidate is left
-   * alone everywhere else. The version the producer recorded sits above the verdict, where the walk
-   * never reaches, so it is checked here too.
+   * report's revision and its own rules both accept it. The revision is applied to every step, the
+   * producer's recorded one included: a producer resolving at the `integration` revision records a
+   * snapshot-grade step that a report at `release` or `milestone` leaves out. The rules are applied
+   * here rather than in the walk above, which reaches a pre-release candidate only to skip it, and
+   * applied to a shim of their own so that the walk's verdict for the same candidate is not
+   * overwritten. A rule reading the metadata absent from the record leaves the step alone, as an
+   * undecided candidate is left alone everywhere else.
    */
   private fun keptAsStep(
     status: PartialStatus,
     version: String,
-    index: Int,
-    ceilingIndex: Int,
     rules: List<Action<in ComponentSelection>>,
   ): Boolean {
-    if (index > ceilingIndex && !accepted(status, version)) {
+    if (!accepted(status, version)) {
       return false
     }
     if (rules.isEmpty()) {

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/ReportRules.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/ReportRules.kt
@@ -6,6 +6,7 @@ import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentS
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.RecordedComponentSelection
 import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ResolutionStrategyWithCurrent
 import org.gradle.api.Action
+import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.logging.Logger
@@ -33,7 +34,7 @@ internal class ReportRules(
   resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
   private val logger: Logger,
   private val revision: String,
-  private val rejectPreReleases: Boolean,
+  private val checksPreReleases: Boolean,
   preReleaseVersionIf: Spec<String>?,
   exemptFromBuiltInChecksIf: ComponentFilter?,
 ) {
@@ -100,7 +101,7 @@ internal class ReportRules(
     statuses: List<PartialStatus>,
     candidatesByProjectPath: Map<String, List<String>>,
   ): List<PartialStatus> {
-    if (!hasRules && !rejectPreReleases) {
+    if (!hasRules && !checksPreReleases) {
       return statuses
     }
     val versionsByProjectPath = candidatesByProjectPath.mapValues { (_, candidates) -> versionsByModule(candidates) }
@@ -156,6 +157,11 @@ internal class ReportRules(
     // synthesized UnresolvedInfo is always the ceiling, so the reason reported has to be why that
     // version was rejected rather than why some older candidate further down the walk was.
     var ceilingReason: String? = null
+    // The newest candidate this report's pre-release check left out, which the producer's own check
+    // passed because the convention or the exemption configured here reaches further. Reported as
+    // the row's pre-release step, the same place a locally resolved row carries it, and only when
+    // the producer recorded none of its own.
+    var preRelease: String? = status.preReleaseVersion?.takeIf { keptAsStep(status, it, ceilingIndex, ceilingIndex, rules) }
     for (index in ceilingIndex until moduleVersions.size) {
       val version = moduleVersions[index]
       val shim = RecordedComponentSelection(status.group, status.name, version)
@@ -166,6 +172,9 @@ internal class ReportRules(
       if (rejectsPreRelease(current, shim)) {
         if (index == ceilingIndex) {
           ceilingReason = PRE_RELEASE_REASON
+        }
+        if (preRelease == null && keptAsStep(status, version, index, ceilingIndex, rules)) {
+          preRelease = version
         }
         continue
       }
@@ -193,7 +202,11 @@ internal class ReportRules(
         return status
       }
       if (!shim.rejected) {
-        return if (version == status.latestVersion) status else status.copy(latestVersion = version)
+        return if (version == status.latestVersion && preRelease == status.preReleaseVersion) {
+          status
+        } else {
+          status.copy(latestVersion = version, preReleaseVersion = preRelease)
+        }
       }
       if (index == ceilingIndex) {
         ceilingReason = shim.reason
@@ -222,6 +235,36 @@ internal class ReportRules(
     )
 
   /**
+   * Returns whether [version] is printed as this row's pre-release step, which it is when this
+   * report's revision and its own rules both accept it. The rules are applied here rather than in
+   * the walk above, which reaches a pre-release candidate only to skip it, and applied to a shim of
+   * their own so that the walk's verdict for the same candidate is not overwritten. A rule reading
+   * the metadata absent from the record leaves the step alone, as an undecided candidate is left
+   * alone everywhere else. The version the producer recorded sits above the verdict, where the walk
+   * never reaches, so it is checked here too.
+   */
+  private fun keptAsStep(
+    status: PartialStatus,
+    version: String,
+    index: Int,
+    ceilingIndex: Int,
+    rules: List<Action<in ComponentSelection>>,
+  ): Boolean {
+    if (index > ceilingIndex && !accepted(status, version)) {
+      return false
+    }
+    if (rules.isEmpty()) {
+      return true
+    }
+    val shim = RecordedComponentSelection(status.group, status.name, version)
+    for (rule in rules) {
+      if (shim.rejected || shim.undecided) break
+      shim.applyRule(rule)
+    }
+    return !shim.rejected || shim.undecided
+  }
+
+  /**
    * Returns whether the report's `rejectPreReleases` leaves this candidate out, read
    * through the same wrapper a rule reads it through so that `isPreRelease` and an
    * `exemptFromBuiltInChecksIf` predicate answer here as they do at a producer.
@@ -230,7 +273,7 @@ internal class ReportRules(
     current: Coordinate,
     shim: RecordedComponentSelection,
   ): Boolean {
-    if (!rejectPreReleases) {
+    if (!checksPreReleases) {
       return false
     }
     val selection =

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -51,7 +51,6 @@ class Resolver internal constructor(
   private val resolutionStrategy: Action<in ResolutionStrategyWithCurrent>?,
   private val checkConstraints: Boolean,
   private val rejectOutOfBounds: Boolean,
-  private val rejectPreReleases: Boolean,
   /** The convention added to the pre-release check in the build, null when none is configured. */
   preReleaseVersionIf: Spec<String>?,
   /** The candidates exempted from both built-in checks in the build, null when none is configured. */
@@ -67,7 +66,7 @@ class Resolver internal constructor(
 ) {
   /**
    * Retained so the arity released before the bound and pre-release filters were added still links.
-   * Both filters are on.
+   * The bound filter is on, and the pre-release check is applied to every resolution.
    */
   constructor(
     project: Project,
@@ -78,7 +77,6 @@ class Resolver internal constructor(
     resolutionStrategy,
     checkConstraints,
     rejectOutOfBounds = true,
-    rejectPreReleases = true,
     preReleaseVersionIf = null,
     exemptFromBuiltInChecksIf = null,
     settingsConfigurations = null,
@@ -91,6 +89,9 @@ class Resolver internal constructor(
    * `isPreRelease` read one definition.
    */
   private val isPreRelease: (String) -> Boolean = VersionStability.withConvention(preReleaseVersionIf)
+
+  /** Orders two versions newest first, for picking the newest of the rejected pre-releases. */
+  private val newestFirst = VersionMapping.versionComparator().reversed()
 
   /** Whether a candidate is exempt from the built-in checks; nothing is exempt unless configured. */
   private val isExempt: (ComponentSelectionWithCurrent) -> Boolean =
@@ -158,7 +159,11 @@ class Resolver internal constructor(
     configuration.incoming.dependencies
 
     val current = getCurrentCoordinates(configuration, declaredKeys(), nameDeclaringConfiguration, scriptClasspath)
-    val latestConfiguration = createLatestConfiguration(configuration, revision, current)
+    // Filled by the pre-release filter as the first-accept walk reaches each rejected candidate,
+    // and read once the walk below has run. Local to the resolution rather than held on the
+    // resolver, which resolves the configurations of a project concurrently.
+    val preReleases = ConcurrentHashMap<Coordinate.Key, String>()
+    val latestConfiguration = createLatestConfiguration(configuration, revision, current, preReleases)
     val root = latestConfiguration.incoming.resolutionResult.root
     // The recording pass enriches the report rather than producing it, so a failure in it costs
     // the candidate lists alone. Letting it throw would discard every status the first-accept walk
@@ -167,13 +172,14 @@ class Resolver internal constructor(
       .onFailure { e ->
         project.logger.info("Skipping the recorded candidates of ${configuration.name}", e)
       }
-    return getStatus(current, root)
+    return getStatus(current, root, preReleases)
   }
 
   /** Returns the version status of the configuration's dependencies. */
   private fun getStatus(
     current: CurrentCoordinates,
     root: ResolvedComponentResult,
+    preReleases: Map<Coordinate.Key, String>,
   ): Set<DependencyStatus> {
     val coordinates = current.coordinates
     val result = hashSetOf<DependencyStatus>()
@@ -192,7 +198,14 @@ class Resolver internal constructor(
           val contributed = coord.key in current.contributedKeys
           val configurations = current.contributedConfigurations[coord.key].orEmpty()
           result.add(
-            DependencyStatus(coord, resolvedCoordinate.version, projectUrl, contributed, configurations),
+            DependencyStatus(
+              coord,
+              resolvedCoordinate.version,
+              projectUrl,
+              contributed,
+              configurations,
+              preReleases[coord.key],
+            ),
           )
         }
         is UnresolvedDependencyResult -> {
@@ -214,6 +227,7 @@ class Resolver internal constructor(
     configuration: Configuration,
     revision: String,
     current: CurrentCoordinates,
+    preReleases: MutableMap<Coordinate.Key, String>,
   ): Configuration {
     val latest = queryDependencies(configuration, current)
 
@@ -270,10 +284,10 @@ class Resolver internal constructor(
     copy.resolutionStrategy.disableDependencyVerification()
 
     addDeclaredBoundFilter(copy, current.coordinates)
-    addPreReleaseFilter(copy, current.coordinates)
     addRevisionFilter(copy, revision, current.coordinates)
     addAttributes(copy, configuration)
     addCustomResolutionStrategy(copy, current.coordinates)
+    addPreReleaseFilter(copy, current.coordinates, preReleases)
 
     disableAutoTargetJvm(copy)
     return copy
@@ -552,25 +566,42 @@ class Resolver internal constructor(
 
   /**
    * Adds the filter that leaves out a pre-release candidate while the current version is a release,
-   * as [ComponentSelectionWithCurrent.isPreRelease] reads both. Registered ahead of the revision
-   * filter for the reason given on [addDeclaredBoundFilter], and on the configuration
-   * rather than through [DependencyUpdatesTask.rejectVersionIf]: that setter marks the task's
-   * parameters as having a resolution strategy, and a project marked that way is resolved with its
-   * own strategy instead of its nearest ancestor's, so routing this filter through it would stop
-   * every subproject inheriting the root's `rejectVersionIf`.
+   * as [ComponentSelectionWithCurrent.isPreRelease] reads both, and records the newest candidate it
+   * rejects as the row's pre-release step. Registered on the configuration rather than through
+   * [DependencyUpdatesTask.rejectVersionIf]: that setter marks the task's parameters as having a
+   * resolution strategy, and a project marked that way is resolved with its own strategy instead of
+   * its nearest ancestor's, so routing this filter through it would stop every subproject
+   * inheriting the root's `rejectVersionIf`.
+   *
+   * Registered last, after the bound and revision filters and after the build's own rules, which
+   * is the opposite of what [addDeclaredBoundFilter] describes and is what makes the recorded
+   * version exact: a rejected candidate is not passed to the rules that follow, so a candidate
+   * reaching this filter is one every other filter accepted, and the first one rejected here is the
+   * newest that fails the pre-release check alone. The cost of the later position is the revision
+   * filter's metadata read on the pre-release candidates above the verdict, which is bounded by how
+   * many a repository lists there.
+   *
+   * The newest rejection is kept by the comparator rather than the first one reached. A module
+   * found in more than one repository is walked newest-first per repository rather than newest-first
+   * overall, so the first rejection is the newest of one repository alone.
+   *
+   * Installed whether or not `rejectPreReleases` is set, since that setting governs whether the
+   * recorded step is printed rather than how the configuration resolves.
    */
   private fun addPreReleaseFilter(
     configuration: Configuration,
     currentCoordinates: Map<Coordinate.Key, Coordinate>,
+    preReleases: MutableMap<Coordinate.Key, String>,
   ) {
-    if (!rejectPreReleases) {
-      return
-    }
     configuration.resolutionStrategy { inner ->
       ResolutionStrategyWithCurrent(inner, currentCoordinates, {}, isPreRelease).componentSelection { rules ->
         rules.all(
           Action<ComponentSelectionWithCurrent> { current ->
             if (current.isPreRelease() && !isExempt(current)) {
+              val candidate = Coordinate.from(current.candidate)
+              preReleases.merge(candidate.key, candidate.version) { seen, found ->
+                if (newestFirst.compare(seen, found) <= 0) seen else found
+              }
               current.reject("Pre-release rejected by rejectPreReleases")
             }
           },

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -90,9 +90,6 @@ class Resolver internal constructor(
    */
   private val isPreRelease: (String) -> Boolean = VersionStability.withConvention(preReleaseVersionIf)
 
-  /** Orders two versions newest first, for picking the newest of the rejected pre-releases. */
-  private val newestFirst = VersionMapping.versionComparator().reversed()
-
   /** Whether a candidate is exempt from the built-in checks; nothing is exempt unless configured. */
   private val isExempt: (ComponentSelectionWithCurrent) -> Boolean =
     if (exemptFromBuiltInChecksIf == null) {
@@ -575,11 +572,12 @@ class Resolver internal constructor(
    *
    * Registered last, after the bound and revision filters and after the build's own rules, which
    * is the opposite of what [addDeclaredBoundFilter] describes and is what makes the recorded
-   * version exact: a rejected candidate is not passed to the rules that follow, so a candidate
-   * reaching this filter is one every other filter accepted, and the first one rejected here is the
-   * newest that fails the pre-release check alone. The cost of the later position is the revision
-   * filter's metadata read on the pre-release candidates above the verdict, which is bounded by how
-   * many a repository lists there.
+   * version exact: a rejected candidate is not passed to the rules that follow, so a candidate that
+   * reaches this filter passed every other one, and the first rejection here is the newest version
+   * that fails the pre-release check alone. The cost of the later position is the revision filter's
+   * metadata read on the pre-release candidates above the verdict, bounded by how many of those a
+   * repository publishes. The build's own rules are now evaluated for those candidates, which the
+   * earlier position kept from them.
    *
    * The newest rejection is kept by the comparator rather than the first one reached. A module
    * found in more than one repository is walked newest-first per repository rather than newest-first
@@ -598,9 +596,13 @@ class Resolver internal constructor(
         rules.all(
           Action<ComponentSelectionWithCurrent> { current ->
             if (current.isPreRelease() && !isExempt(current)) {
-              val candidate = Coordinate.from(current.candidate)
-              preReleases.merge(candidate.key, candidate.version) { seen, found ->
-                if (newestFirst.compare(seen, found) <= 0) seen else found
+              val candidate = current.candidate
+              val key = Coordinate.Key(candidate.group, candidate.module)
+              preReleases.merge(key, candidate.version) { seen, found ->
+                // Built here rather than held on the resolver, which resolves the configurations of
+                // one project concurrently, and reached only where two candidates of one module
+                // compete rather than once per candidate.
+                if (VersionMapping.versionComparator().compare(seen, found) >= 0) seen else found
               }
               current.reject("Pre-release rejected by rejectPreReleases")
             }

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
@@ -18,9 +18,10 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
   val latestByCurrent = hashMapOf<Coordinate, Coordinate>()
 
   /**
-   * The newest candidate the pre-release check left out, per declared coordinate, absent where it
-   * left none out. Kept beside [latestByCurrent] rather than replacing its entry, so a row with
-   * both steps reports the newest the resolution accepted as well as the one it did not.
+   * The newest candidate left out by the pre-release check, per declared coordinate, absent where
+   * none was left out. Kept beside [latestByCurrent] rather than replacing its entry, so a row with
+   * both steps is reported with the newest version the resolution accepted as well as the one it
+   * did not.
    */
   val preReleaseByCurrent = hashMapOf<Coordinate, String>()
   private var comparator = makeVersionComparator()

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/VersionMapping.kt
@@ -16,6 +16,13 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
   val current = sortedSetOf<Coordinate>()
   val latest = sortedSetOf<Coordinate>()
   val latestByCurrent = hashMapOf<Coordinate, Coordinate>()
+
+  /**
+   * The newest candidate the pre-release check left out, per declared coordinate, absent where it
+   * left none out. Kept beside [latestByCurrent] rather than replacing its entry, so a row with
+   * both steps reports the newest the resolution accepted as well as the one it did not.
+   */
+  val preReleaseByCurrent = hashMapOf<Coordinate, String>()
   private var comparator = makeVersionComparator()
 
   init {
@@ -27,6 +34,12 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
         val previous = latestByCurrent[status.coordinate]
         if (previous == null || comparator.compare(previous.version, latestCoordinate.version) < 0) {
           latestByCurrent[status.coordinate] = latestCoordinate
+        }
+        status.preReleaseVersion?.let { preRelease ->
+          val seen = preReleaseByCurrent[status.coordinate]
+          if (seen == null || comparator.compare(seen, preRelease) < 0) {
+            preReleaseByCurrent[status.coordinate] = preRelease
+          }
         }
       } else {
         unresolved.add(status.coordinate)
@@ -56,7 +69,14 @@ class VersionMapping(private val logger: Logger, statuses: List<PartialStatus>) 
       if (result <= -1) {
         upgrade.add(coordinate)
       } else if (result == 0) {
-        upToDate.add(coordinate)
+        // A module whose only newer candidate is a pre-release resolves to the version already
+        // declared, so the row is an upgrade by the pre-release step alone and the breadcrumb
+        // prints that step in place of the middle one.
+        if (preReleaseByCurrent.containsKey(coordinate)) {
+          upgrade.add(coordinate)
+        } else {
+          upToDate.add(coordinate)
+        }
       } else {
         downgrade.add(coordinate)
       }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/AggregationConfigurationCacheSpec.groovy
@@ -237,7 +237,8 @@ final class AggregationConfigurationCacheSpec extends Specification {
       ['The following dependencies have later release versions:',
        'com.google.inject:guice [2.0 -> 3.1]'],
       ['com.google.inject:guice [2.0 -> 3.1]'],
-      ['com.google.inject:guice [2.0 -> 3.0]'],
+      // The convention marks 3.1 a pre-release, so it is the step after the release it holds back.
+      ['com.google.inject:guice [2.0 -> 3.0 -> 3.1]'],
       ['com.google.inject:guice [2.0 -> 3.1]'],
     ]
     absent << [
@@ -247,7 +248,7 @@ final class AggregationConfigurationCacheSpec extends Specification {
       [],
       ['The following dependencies have later milestone versions:'],
       ['org.apache.logging.log4j:log4j-core'],
-      ['com.google.inject:guice [2.0 -> 3.1]'],
+      ['com.google.inject:guice [2.0 -> 3.1]\n'],
       ['com.google.inject:guice [2.0 -> 3.0]'],
     ]
   }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CheckPreReleaseVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CheckPreReleaseVersionsSpec.groovy
@@ -112,19 +112,79 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     return new JsonSlurper().parseText(new File(reportFolder, 'report.json').text) as Map
   }
 
-  def 'a pre-release candidate is hidden by default'() {
+  def 'the newest stable and the newest pre-release are both reported'() {
+    given:
+    writeBuildFile('com.example:stepped-widget:1.0')
+
+    when:
+    def report = runReport()
+
+    then:
+    report.outdated.dependencies*.name == ['stepped-widget']
+    report.outdated.dependencies[0].available.milestone == '1.1'
+    report.outdated.dependencies[0].available.preRelease == '1.2-beta'
+  }
+
+  def 'rejectPreReleases leaves the pre-release step out and keeps the stable one'() {
+    given:
+    writeBuildFile('com.example:stepped-widget:1.0', 'rejectPreReleases = true')
+
+    when:
+    def report = runReport()
+
+    then:
+    report.outdated.dependencies*.name == ['stepped-widget']
+    report.outdated.dependencies[0].available.milestone == '1.1'
+    report.outdated.dependencies[0].available.preRelease == null
+  }
+
+  def 'the plain text row prints both steps'() {
+    given:
+    writeBuildFile('com.example:stepped-widget:1.0', "outputFormatter = 'text'")
+
+    when:
+    runUpdates()
+
+    then:
+    new File(reportFolder, 'report.txt').text
+      .contains(' - com.example:stepped-widget [1.0 -> 1.1 -> 1.2-beta]')
+  }
+
+  def 'the plain text row skips a step that is not newer'() {
+    given: 'the only candidate newer than the declared version is a pre-release'
+    writeBuildFile('com.example:prerelease-widget:1.0', "outputFormatter = 'text'")
+
+    when:
+    runUpdates()
+
+    then:
+    new File(reportFolder, 'report.txt').text
+      .contains(' - com.example:prerelease-widget [1.0 -> 1.2-beta]')
+  }
+
+  private void runUpdates(List<String> extraArguments = []) {
+    def result = GradleRunner.create()
+      .withProjectDir(testProjectDir.root)
+      .withArguments(['dependencyUpdates'] + extraArguments)
+      .withPluginClasspath()
+      .build()
+    assert result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'a pre-release candidate is the step after the version in use by default'() {
     given:
     writeBuildFile('com.example:prerelease-widget:1.0')
 
     when:
     def report = runReport()
 
-    then:
-    report.current.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies.isEmpty()
+    then: 'no release is newer, so the step the resolution accepted is the version in use'
+    report.outdated.dependencies*.name == ['prerelease-widget']
+    report.outdated.dependencies[0].available.milestone == '1.0'
+    report.outdated.dependencies[0].available.preRelease == '1.2-beta'
   }
 
-  def 'with rejectPreReleases false the pre-release candidate is reported'() {
+  def 'rejectPreReleases false is the default and spelling it out changes nothing'() {
     given:
     writeBuildFile('com.example:prerelease-widget:1.0', 'rejectPreReleases = false')
 
@@ -133,19 +193,19 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then:
     report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.milestone == '1.2-beta'
+    report.outdated.dependencies[0].available.preRelease == '1.2-beta'
   }
 
-  def 'the command line option turns the filter off for one run'() {
+  def 'the command line option leaves the step out for one run'() {
     given:
     writeBuildFile('com.example:prerelease-widget:1.0')
 
     when:
-    def report = runReport(['--no-reject-pre-releases'])
+    def report = runReport(['--reject-pre-releases'])
 
     then:
-    report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.milestone == '1.2-beta'
+    report.current.dependencies*.name == ['prerelease-widget']
+    report.outdated.dependencies.isEmpty()
   }
 
   def 'the command line option overrides the property set to false in the build'() {
@@ -214,9 +274,10 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     when:
     def report = runReport()
 
-    then: 'neither candidate survives, so the two compose rather than one replacing the other'
-    report.current.dependencies*.name == ['guava']
-    report.outdated.dependencies.isEmpty()
+    then: 'the rule rejects 16.0 outright, and the built-in check reports 16.0-rc1 as the step'
+    report.outdated.dependencies*.name == ['guava']
+    report.outdated.dependencies[0].available.milestone == '15.0'
+    report.outdated.dependencies[0].available.preRelease == '16.0-rc1'
   }
 
   def 'under the integration revision a snapshot is reported'() {
@@ -228,11 +289,12 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then:
     report.outdated.dependencies*.name == ['snapshot-mixed']
-    report.outdated.dependencies[0].available.integration == '2.0-SNAPSHOT'
+    report.outdated.dependencies[0].available.integration == '1.5'
+    report.outdated.dependencies[0].available.preRelease == '2.0-SNAPSHOT'
   }
 
-  def 'under the integration revision the filter is off, and the property reads false'() {
-    given: 'a beta rather than a snapshot, so the exemption covers the whole revision'
+  def 'the property reads false by default, and the pre-release is the second step'() {
+    given: 'a beta rather than a snapshot, so the revision filter leaves the candidate alone'
     writeBuildFile('com.example:prerelease-widget:1.0', '''
           revision = 'integration'
           doLast { println "rejectPreReleases=$rejectPreReleases" }
@@ -250,7 +312,8 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('rejectPreReleases=false')
     report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.integration == '1.2-beta'
+    report.outdated.dependencies[0].available.integration == '1.0'
+    report.outdated.dependencies[0].available.preRelease == '1.2-beta'
   }
 
   def 'under the integration revision an explicit setting still applies'() {
@@ -317,15 +380,15 @@ final class CheckPreReleaseVersionsSpec extends Specification {
   }
 
   def 'a subproject inherits rejectPreReleases from the root task'() {
-    given:
-    writeMultiProjectBuild('com.example:prerelease-widget:1.0', 'rejectPreReleases = false')
+    given: 'the root turns the step off, which the default would leave on'
+    writeMultiProjectBuild('com.example:prerelease-widget:1.0', 'rejectPreReleases = true')
 
     when:
     def report = runReport()
 
     then:
-    report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.milestone == '1.2-beta'
+    report.current.dependencies*.name == ['prerelease-widget']
+    report.outdated.dependencies.isEmpty()
   }
 
   def 'a Groovy rule reading isPreRelease leaves out what the property would, and no more'() {
@@ -458,19 +521,23 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     def report = runReport()
 
     then: 'the exemption reaches the version the widget both bounds out and marks pre-release'
-    report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.milestone == '1.2-beta'
+    def widget = report.outdated.dependencies.find { it.name == 'prerelease-widget' }
+    widget.available.milestone == '1.2-beta'
+    widget.available.preRelease == null
 
-    and: 'the added convention holds the flagged module and the bound check holds guava'
-    report.current.dependencies*.name.sort() == ['guava', 'prerelease-flagged']
+    and: 'the added convention holds the flagged module back to a second step'
+    report.outdated.dependencies.find { it.name == 'prerelease-flagged' }.available.preRelease == '3.0-flagged'
 
-    when: 'both options ask for what the two checks leave out'
-    def unfiltered = runReport(['--no-reject-pre-releases', '--no-reject-out-of-bounds'])
+    and: 'the bound check holds guava, which only the pre-release below the bound gets past'
+    report.outdated.dependencies.find { it.name == 'guava' }.available.preRelease == '16.0-rc1'
 
-    then: 'both checks are off for that run, and the exemption has nothing left to exempt'
+    when: 'the option asks for what the bound check leaves out'
+    def unfiltered = runReport(['--no-reject-out-of-bounds'])
+
+    then: 'the bound check is off for that run, and the exemption has nothing left to exempt there'
     unfiltered.outdated.dependencies*.name.sort() == ['guava', 'prerelease-flagged', 'prerelease-widget']
     unfiltered.outdated.dependencies.find { it.name == 'guava' }.available.milestone == '16.0'
-    unfiltered.outdated.dependencies.find { it.name == 'prerelease-flagged' }.available.milestone == '3.0-flagged'
+    unfiltered.outdated.dependencies.find { it.name == 'prerelease-flagged' }.available.preRelease == '3.0-flagged'
   }
 
   def 'a Groovy build exempting one module from both checks keeps the checks on for the rest'() {
@@ -500,9 +567,11 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     def report = runReport()
 
     then:
-    report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.milestone == '1.2-beta'
-    report.current.dependencies*.name.sort() == ['guava', 'prerelease-flagged']
+    def widget = report.outdated.dependencies.find { it.name == 'prerelease-widget' }
+    widget.available.milestone == '1.2-beta'
+    widget.available.preRelease == null
+    report.outdated.dependencies.find { it.name == 'prerelease-flagged' }.available.preRelease == '3.0-flagged'
+    report.outdated.dependencies.find { it.name == 'guava' }.available.preRelease == '16.0-rc1'
   }
 
   def 'an exemption reading a negated member is narrowed to the other check'() {
@@ -609,7 +678,7 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     report.outdated.dependencies.find { it.name == 'prerelease-widget' }.available.milestone == '1.2-beta'
   }
 
-  def 'under the integration revision the added convention is off with the built-in check'() {
+  def 'under the integration revision the added convention marks the second step'() {
     given:
     writeBuildFile('com.example:prerelease-flagged:1.0', '''
           revision = 'integration'
@@ -621,7 +690,8 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then:
     report.outdated.dependencies*.name == ['prerelease-flagged']
-    report.outdated.dependencies[0].available.integration == '3.0-flagged'
+    report.outdated.dependencies[0].available.integration == '1.0'
+    report.outdated.dependencies[0].available.preRelease == '3.0-flagged'
   }
 
   def 'a qualifier not in the built-in markers is passed through'() {
@@ -648,16 +718,16 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     report.outdated.dependencies[0].available.milestone == '3.0-flagged'
   }
 
-  def 'the command line option turns off the added convention with the built-in check'() {
+  def 'the command line option leaves out a step the added convention marked'() {
     given:
     writeBuildFile('com.example:prerelease-flagged:1.0', "preReleaseVersionIf { it.endsWith('-flagged') }")
 
     when:
-    def report = runReport(['--no-reject-pre-releases'])
+    def report = runReport(['--reject-pre-releases'])
 
     then:
-    report.outdated.dependencies*.name == ['prerelease-flagged']
-    report.outdated.dependencies[0].available.milestone == '3.0-flagged'
+    report.current.dependencies*.name == ['prerelease-flagged']
+    report.outdated.dependencies.isEmpty()
   }
 
   def 'a rule reading isPreRelease answers for the added convention'() {
@@ -685,9 +755,10 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     when:
     def report = runReport()
 
-    then:
-    report.current.dependencies*.name == ['prerelease-flagged']
-    report.outdated.dependencies.isEmpty()
+    then: 'the convention reached the subproject, so the flagged candidate is the second step'
+    report.outdated.dependencies*.name == ['prerelease-flagged']
+    report.outdated.dependencies[0].available.milestone == '1.0'
+    report.outdated.dependencies[0].available.preRelease == '3.0-flagged'
   }
 
   def 'preReleaseVersionIf compiles and applies under the Kotlin DSL'() {
@@ -700,8 +771,8 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     def report = runReport()
 
     then:
-    report.current.dependencies*.name == ['prerelease-flagged']
-    report.outdated.dependencies.isEmpty()
+    report.outdated.dependencies*.name == ['prerelease-flagged']
+    report.outdated.dependencies[0].available.preRelease == '3.0-flagged'
   }
 
   def 'conventions added in two calls both apply'() {
@@ -720,7 +791,8 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     def report = runReport()
 
     then:
-    report.current.dependencies*.name.sort() == ['guava', 'prerelease-flagged']
-    report.outdated.dependencies.isEmpty()
+    report.outdated.dependencies*.name.sort() == ['guava', 'prerelease-flagged']
+    report.outdated.dependencies.find { it.name == 'guava' }.available.preRelease == '16.0'
+    report.outdated.dependencies.find { it.name == 'prerelease-flagged' }.available.preRelease == '3.0-flagged'
   }
 }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CheckPreReleaseVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CheckPreReleaseVersionsSpec.groovy
@@ -3,6 +3,7 @@ package com.github.benmanes.gradle.versions
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 import groovy.json.JsonSlurper
+import groovy.xml.XmlSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -136,6 +137,62 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     report.outdated.dependencies*.name == ['stepped-widget']
     report.outdated.dependencies[0].available.milestone == '1.1'
     report.outdated.dependencies[0].available.preRelease == null
+  }
+
+  def 'the negative command line option restores the step a build leaves out'() {
+    given: 'the build leaves the step out, which the option asks for back'
+    writeBuildFile('com.example:stepped-widget:1.0', 'rejectPreReleases = true')
+
+    when:
+    def report = runReport(['--no-reject-pre-releases'])
+
+    then:
+    report.outdated.dependencies*.name == ['stepped-widget']
+    report.outdated.dependencies[0].available.milestone == '1.1'
+    report.outdated.dependencies[0].available.preRelease == '1.2-beta'
+  }
+
+  def 'the XML and JSON reports carry the step, and the HTML cell links both versions'() {
+    given:
+    writeBuildFile('com.example:stepped-widget:1.0', "outputFormatter = 'json,xml,html'")
+
+    when:
+    runUpdates()
+
+    then: 'the XML element trails the revision level the resolution filled'
+    def available = new XmlSlurper()
+      .parse(new File(reportFolder, 'report.xml'))
+      .outdated.dependencies.outdatedDependency[0].available
+    available.milestone.text() == '1.1'
+    available.preRelease.text() == '1.2-beta'
+    available.release.isEmpty()
+    available.integration.isEmpty()
+
+    and: 'the JSON field trails them too'
+    def json = new JsonSlurper()
+      .parseText(new File(reportFolder, 'report.json').text).outdated.dependencies[0]
+    json.available.milestone == '1.1'
+    json.available.preRelease == '1.2-beta'
+
+    and: 'each HTML version is linked on its own, so neither Sonatype url holds the pair'
+    def html = new File(reportFolder, 'report.html').text
+    html.contains('stepped-widget/1.1/bundle')
+    html.contains('stepped-widget/1.2-beta/bundle')
+    !html.contains('1.1 -&gt; 1.2-beta/bundle')
+    !html.contains('1.1 -> 1.2-beta/bundle')
+  }
+
+  def 'under the release revision the step trails the release the resolution accepted'() {
+    given:
+    writeBuildFile('com.example:stepped-widget:1.0', "revision = 'release'")
+
+    when:
+    def report = runReport()
+
+    then:
+    report.outdated.dependencies[0].available.release == '1.1'
+    report.outdated.dependencies[0].available.milestone == null
+    report.outdated.dependencies[0].available.preRelease == '1.2-beta'
   }
 
   def 'the plain text row prints both steps'() {

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CheckPreReleaseVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CheckPreReleaseVersionsSpec.groovy
@@ -178,9 +178,9 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     when:
     def report = runReport()
 
-    then: 'no release is newer, so the step the resolution accepted is the version in use'
+    then: 'no release is newer, so only the pre-release step is reported'
     report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.milestone == '1.0'
+    report.outdated.dependencies[0].available.milestone == null
     report.outdated.dependencies[0].available.preRelease == '1.2-beta'
   }
 
@@ -276,7 +276,7 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then: 'the rule rejects 16.0 outright, and the built-in check reports 16.0-rc1 as the step'
     report.outdated.dependencies*.name == ['guava']
-    report.outdated.dependencies[0].available.milestone == '15.0'
+    report.outdated.dependencies[0].available.milestone == null
     report.outdated.dependencies[0].available.preRelease == '16.0-rc1'
   }
 
@@ -289,7 +289,7 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then:
     report.outdated.dependencies*.name == ['snapshot-mixed']
-    report.outdated.dependencies[0].available.integration == '1.5'
+    report.outdated.dependencies[0].available.integration == null
     report.outdated.dependencies[0].available.preRelease == '2.0-SNAPSHOT'
   }
 
@@ -312,7 +312,7 @@ final class CheckPreReleaseVersionsSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains('rejectPreReleases=false')
     report.outdated.dependencies*.name == ['prerelease-widget']
-    report.outdated.dependencies[0].available.integration == '1.0'
+    report.outdated.dependencies[0].available.integration == null
     report.outdated.dependencies[0].available.preRelease == '1.2-beta'
   }
 
@@ -690,7 +690,7 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then:
     report.outdated.dependencies*.name == ['prerelease-flagged']
-    report.outdated.dependencies[0].available.integration == '1.0'
+    report.outdated.dependencies[0].available.integration == null
     report.outdated.dependencies[0].available.preRelease == '3.0-flagged'
   }
 
@@ -757,7 +757,7 @@ final class CheckPreReleaseVersionsSpec extends Specification {
 
     then: 'the convention reached the subproject, so the flagged candidate is the second step'
     report.outdated.dependencies*.name == ['prerelease-flagged']
-    report.outdated.dependencies[0].available.milestone == '1.0'
+    report.outdated.dependencies[0].available.milestone == null
     report.outdated.dependencies[0].available.preRelease == '3.0-flagged'
   }
 

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -2733,6 +2733,51 @@ final class CompositeBuildSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
+  def "A merged row keeps the step its child recorded where the outer configures nothing"() {
+    given: 'neither build states a setting, so both are at the defaults'
+    unstableCeilingComposite()
+
+    when:
+    def result = run('dependencyUpdates', ':child:dependencyUpdates', '-DoutputFormatter=plain,json')
+    def included = report('child/')
+    def json = report('')
+
+    then: 'both reports read alike, since nothing in the outer moves the row'
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.milestone == '2.0'
+    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.preRelease ==
+      '3.0-Beta1'
+    json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.milestone == '2.0'
+    json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.preRelease ==
+      '3.0-Beta1'
+    result.output.contains('com.probe:unstable-ceiling [1.0 -> 2.0 -> 3.0-Beta1]')
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
+  def "The report's revision leaves out a merged step its child resolved under another"() {
+    given: 'a child at the integration revision, over an outer at the default milestone'
+    unstableCeilingComposite(
+      "tool 'com.example:snapshot-mixed:1.5'",
+      "revision = 'integration'",
+      '',
+    )
+
+    when:
+    def result = run('dependencyUpdates', ':child:dependencyUpdates', '-DoutputFormatter=plain,json')
+    def included = report('child/')
+    def json = report('')
+
+    then: "the child reports the snapshot it resolved for"
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    included.outdated.dependencies.find { it.name == 'snapshot-mixed' }?.available?.preRelease ==
+      '2.0-SNAPSHOT'
+
+    and: "the report it is merged into is not at a revision that accepts one"
+    json.outdated.dependencies.every { it.name != 'snapshot-mixed' }
+    json.current.dependencies.find { it.name == 'snapshot-mixed' }?.version == '1.5'
+  }
+
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
   def "The report's preReleaseVersionIf convention moves a merged row to its step"() {
     given: "an outer with a convention neither build's markers cover, and a child with none"
     unstableCeilingComposite(

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -2636,8 +2636,8 @@ final class CompositeBuildSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/550')
-  def "An aggregator's rule tightens a merged row where the child baked an unstable ceiling"() {
-    given: "the child bakes the pre-release ceiling with the built-in check off, and no rule of its own"
+  def "An aggregator's rule drops the pre-release step of a merged row"() {
+    given: "the child reports the step, having no rule of its own to drop it"
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
     testProjectDir.newFile('build.gradle') <<
       """
@@ -2696,32 +2696,44 @@ final class CompositeBuildSpec extends Specification {
     def included = report('child/')
     def json = report('')
 
-    then: "the child's own report bakes the pre-release ceiling, but the merged row is tightened by the outer's rule"
+    then: "the child's own report prints the step, and the outer's rule rejects it where they merge"
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.task(':child:dependencyUpdates').outcome == SUCCESS
-    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.release == '3.0-Beta1'
+    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.release == '2.0'
+    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.preRelease == '3.0-Beta1'
     json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.release == '2.0'
+    json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.preRelease == null
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
-  def "The report's pre-release check rejects a merged row its child let through"() {
-    given: 'a child with the built-in check off, and an outer with no rule of its own'
-    unstableCeilingComposite()
+  def "The report's rejectPreReleases drops the step from a merged row its child prints"() {
+    given: 'an outer that leaves the step out, over a child that keeps it'
+    unstableCeilingComposite(
+      "tool 'com.probe:unstable-ceiling:1.0'",
+      '',
+      """
+        tasks.named('dependencyUpdates').configure {
+          rejectPreReleases = true
+        }
+      """.stripIndent(),
+    )
 
     when:
     def result = run('dependencyUpdates', ':child:dependencyUpdates', '-DoutputFormatter=plain,json')
     def included = report('child/')
     def json = report('')
 
-    then: "the child keeps the pre-release it resolved, and the report it is merged into does not"
+    then: "the child prints the pre-release step, and the report it is merged into leaves it out"
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.task(':child:dependencyUpdates').outcome == SUCCESS
-    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.milestone == '3.0-Beta1'
+    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.milestone == '2.0'
+    included.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.preRelease == '3.0-Beta1'
     json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.milestone == '2.0'
+    json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.preRelease == null
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
-  def "The report's preReleaseVersionIf convention rejects a merged row"() {
+  def "The report's preReleaseVersionIf convention moves a merged row to its step"() {
     given: "an outer with a convention neither build's markers cover, and a child with none"
     unstableCeilingComposite(
       "tool 'com.example:prerelease-flagged:1.0'",
@@ -2738,22 +2750,24 @@ final class CompositeBuildSpec extends Specification {
     def included = report('child/')
     def json = report('')
 
-    then: "the convention reaches the row the child resolved without it, so the row is up to date"
+    then: "the convention reaches the row the child resolved without it, so the flagged version moves"
     result.task(':dependencyUpdates').outcome == SUCCESS
     included.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.milestone == '3.0-flagged'
-    json.outdated.dependencies.every { it.name != 'prerelease-flagged' }
-    json.current.dependencies.find { it.name == 'prerelease-flagged' }?.version == '1.0'
+    included.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.preRelease == null
+    json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.milestone == '1.0'
+    json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.preRelease == '3.0-flagged'
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
-  def "The report's exemption keeps a merged pre-release row the check would reject"() {
-    given: 'an outer exempting the one module from its built-in checks'
+  def "The report's exemption keeps a merged row its own convention would move"() {
+    given: 'an outer adding a convention and exempting the one module it would match'
     unstableCeilingComposite(
-      "tool 'com.probe:unstable-ceiling:1.0'",
-      'rejectPreReleases = false',
+      "tool 'com.example:prerelease-flagged:1.0'",
+      '',
       """
         tasks.named('dependencyUpdates').configure {
-          exemptFromBuiltInChecksIf { candidate.module == 'unstable-ceiling' }
+          preReleaseVersionIf { it.endsWith('-flagged') }
+          exemptFromBuiltInChecksIf { candidate.module == 'prerelease-flagged' }
         }
       """.stripIndent(),
     )
@@ -2762,9 +2776,10 @@ final class CompositeBuildSpec extends Specification {
     def result = run('dependencyUpdates', '-DoutputFormatter=plain,json')
     def json = report('')
 
-    then: 'the exemption is read at the report, so the merged row keeps the ceiling the child baked'
+    then: 'the exemption is read at the report, so the merged row keeps the version the child baked'
     result.task(':dependencyUpdates').outcome == SUCCESS
-    json.outdated.dependencies.find { it.name == 'unstable-ceiling' }?.available?.milestone == '3.0-Beta1'
+    json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.milestone == '3.0-flagged'
+    json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.preRelease == null
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
@@ -2775,7 +2790,7 @@ final class CompositeBuildSpec extends Specification {
         tool 'com.probe:unstable-ceiling:1.0'
         tool 'com.example:prerelease-flagged:1.0'
       """.stripIndent(),
-      'rejectPreReleases = false',
+      '',
       """
         tasks.named('dependencyUpdates').configure {
           preReleaseVersionIf { it.endsWith('-flagged') }
@@ -2791,17 +2806,18 @@ final class CompositeBuildSpec extends Specification {
     then: 'both are read from the slots that survive the cache, so the hit reports what the store did'
     store.task(':dependencyUpdates').outcome == SUCCESS
     hit.output.contains('Configuration cache entry reused.')
-    [store, hit].every { it.output.contains('com.probe:unstable-ceiling [1.0 -> 3.0-Beta1]') }
-    [store, hit].every { !it.output.contains('com.example:prerelease-flagged [1.0 ->') }
+    [store, hit].every { it.output.contains('com.probe:unstable-ceiling [1.0 -> 2.0 -> 3.0-Beta1]') }
+    [store, hit].every { it.output.contains('com.example:prerelease-flagged [1.0 -> 3.0-flagged]') }
   }
 
   /**
-   * Writes an outer that aggregates a child with its pre-release check off, so the child bakes a
-   * ceiling its own build accepts and the outer's report is the only place the check can apply.
+   * Writes an outer that aggregates a child with no settings of its own, so a merged row carries
+   * what the child's defaults produced and the outer's report is the only place its own convention,
+   * exemption and rules can apply.
    */
   private void unstableCeilingComposite(
       String childDependency = "tool 'com.probe:unstable-ceiling:1.0'",
-      String childConfig = 'rejectPreReleases = false',
+      String childConfig = '',
       String outerConfig = '') {
     testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
     testProjectDir.newFile('build.gradle') <<

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -2754,7 +2754,7 @@ final class CompositeBuildSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
     included.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.milestone == '3.0-flagged'
     included.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.preRelease == null
-    json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.milestone == '1.0'
+    json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.milestone == null
     json.outdated.dependencies.find { it.name == 'prerelease-flagged' }?.available?.preRelease == '3.0-flagged'
   }
 
@@ -2783,8 +2783,8 @@ final class CompositeBuildSpec extends Specification {
   }
 
   @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/440')
-  def "The report's own convention and exemption reach a merged row on the cache hit"() {
-    given: 'an outer that adds a convention and exempts one module, over a child with neither'
+  def "The report's own convention reaches a merged row on the cache hit"() {
+    given: 'an outer that adds a convention neither build\'s markers cover, over a child with none'
     unstableCeilingComposite(
       """
         tool 'com.probe:unstable-ceiling:1.0'
@@ -2794,7 +2794,6 @@ final class CompositeBuildSpec extends Specification {
       """
         tasks.named('dependencyUpdates').configure {
           preReleaseVersionIf { it.endsWith('-flagged') }
-          exemptFromBuiltInChecksIf { candidate.module == 'unstable-ceiling' }
         }
       """.stripIndent(),
     )
@@ -2803,7 +2802,7 @@ final class CompositeBuildSpec extends Specification {
     def store = run('dependencyUpdates', '--configuration-cache')
     def hit = run('dependencyUpdates', '--configuration-cache')
 
-    then: 'both are read from the slots that survive the cache, so the hit reports what the store did'
+    then: 'the convention is read from the copy that survives the cache, so the hit matches the store'
     store.task(':dependencyUpdates').outcome == SUCCESS
     hit.output.contains('Configuration cache entry reused.')
     [store, hit].every { it.output.contains('com.probe:unstable-ceiling [1.0 -> 2.0 -> 3.0-Beta1]') }

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/OutputFormatterSpec.groovy
@@ -303,7 +303,8 @@ final class OutputFormatterSpec extends Specification {
                     "available": {
                         "release": null,
                         "milestone": "3.1",
-                        "integration": null
+                        "integration": null,
+                        "preRelease": null
                     },
                     "userReason": null,
                     "version": "2.0",

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolverCandidatesSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/ResolverCandidatesSpec.groovy
@@ -181,7 +181,7 @@ final class ResolverCandidatesSpec extends Specification {
     }
     other.buildscript.dependencies.add('classpath', 'com.example:someplugin:1.0')
     def configuration = other.buildscript.configurations.getByName('classpath')
-    def resolver = new Resolver(app, null, false, true, true, null, null,
+    def resolver = new Resolver(app, null, false, true, null, null,
       other.buildscript.configurations, {})
 
     when:

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
@@ -213,6 +213,64 @@ final class TaskOptionSpec extends Specification {
     result.task(':dependencyUpdates').outcome == SUCCESS
   }
 
+  @Unroll
+  def 'Reports the Gradle releases of #expected when rejectPreReleases is #configured'() {
+    given: 'nothing states a release channel, so it follows the pre-release setting'
+    declaringBuildFile("tasks.dependencyUpdates { rejectPreReleases = $configured }")
+
+    when: 'the api is unreachable, so an error is printed for each release channel consulted'
+    def result = run(
+      'dependencyUpdates',
+      '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains("Gradle $expected updates:")
+    result.output.contains('[release channel: release-candidate]') == candidateConsulted
+    result.task(':dependencyUpdates').outcome == SUCCESS
+
+    where:
+    configured | expected            | candidateConsulted
+    'false'    | 'release-candidate' | true
+    'true'     | 'current'           | false
+  }
+
+  def 'A release channel stated in the build is read ahead of the pre-release setting'() {
+    given:
+    declaringBuildFile(
+      '''
+        tasks.dependencyUpdates {
+          rejectPreReleases = true
+          gradleReleaseChannel = 'nightly'
+        }
+      ''')
+
+    when:
+    def result = run(
+      'dependencyUpdates',
+      '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('Gradle nightly updates:')
+    result.output.contains('[release channel: nightly]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'The release channel option is read ahead of the pre-release setting'() {
+    given:
+    declaringBuildFile("tasks.dependencyUpdates { rejectPreReleases = true }")
+
+    when:
+    def result = run(
+      'dependencyUpdates',
+      '--gradle-release-channel', 'release-candidate',
+      '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('Gradle release-candidate updates:')
+    result.output.contains('[release channel: release-candidate]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def 'Writes the report to the directory given on the command line, ahead of the system property'() {
     given:
     declaringBuildFile()

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/TaskOptionSpec.groovy
@@ -234,6 +234,38 @@ final class TaskOptionSpec extends Specification {
     'true'     | 'current'           | false
   }
 
+  def 'The negative release option restores the Gradle releases a build leaves out'() {
+    given: 'the build reports the release channel alone, which the option asks past'
+    declaringBuildFile("tasks.dependencyUpdates { rejectPreReleases = true }")
+
+    when: 'the api is unreachable, so an error is printed for each release channel consulted'
+    def result = run(
+      'dependencyUpdates',
+      '--no-reject-pre-releases',
+      '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('Gradle release-candidate updates:')
+    result.output.contains('[release channel: release-candidate]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
+  def 'The release channel system property is read ahead of the pre-release setting'() {
+    given:
+    declaringBuildFile("tasks.dependencyUpdates { rejectPreReleases = true }")
+
+    when: 'the api is unreachable, so an error is printed for each release channel consulted'
+    def result = run(
+      'dependencyUpdates',
+      '-DgradleReleaseChannel=nightly',
+      '--gradle-versions-api-base-url', 'http://127.0.0.1:1/versions/')
+
+    then:
+    result.output.contains('Gradle nightly updates:')
+    result.output.contains('[release channel: nightly]')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def 'A release channel stated in the build is read ahead of the pre-release setting'() {
     given:
     declaringBuildFile(
@@ -576,7 +608,7 @@ final class TaskOptionSpec extends Specification {
 
     then: 'the invoking build resolves against it and the included build keeps its own'
     !viaOption.output.contains('com.google.inject:guice [2.0 ->')
-    viaOption.output.contains('com.google.guava:guava [15.0 ->')
+    viaOption.output.contains('com.google.guava:guava [15.0 -> 16.0]')
 
     when: 'the same revision is given as a system property, which is set for the whole JVM'
     def viaSystemProperty = run('dependencyUpdates', '-Drevision=bogus')

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/1.0/stepped-widget-1.0.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/1.0/stepped-widget-1.0.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>stepped-widget</artifactId>
+  <version>1.0</version>
+  <name>Example Stepped Widget</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/1.1/stepped-widget-1.1.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/1.1/stepped-widget-1.1.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>stepped-widget</artifactId>
+  <version>1.1</version>
+  <name>Example Stepped Widget</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/1.2-beta/stepped-widget-1.2-beta.pom
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/1.2-beta/stepped-widget-1.2-beta.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>stepped-widget</artifactId>
+  <version>1.2-beta</version>
+  <name>Example Stepped Widget</name>
+</project>

--- a/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/maven-metadata.xml
+++ b/gradle-versions-plugin/src/test/resources/maven/com/example/stepped-widget/maven-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>stepped-widget</artifactId>
+  <versioning>
+    <latest>1.2-beta</latest>
+    <release>1.1</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.1</version>
+      <version>1.2-beta</version>
+    </versions>
+    <lastUpdated>20260910000000</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
I realized that with the new pre-release filtering logic from #1093 we can print
the same `[current -> stable -> pre-release]` breadcrumb for dependency updates
that we already print for Gradle updates. That also flipped my thinking on the
default value for `rejectPreReleases`. In this PR it defaults to `false` to align
with the released default of no pre-release filtering and `release-candidate` for
`gradleReleaseChannel`.

`rejectPreReleases` is now about what is printed rather than about which
candidate is resolved. At the new default, both the latest stable release and any
later pre-release are printed. Set it to `true` and only the latest stable
release is printed.

`preReleaseVersionIf` from #1093 is still available to add pre-release logic
covering versions such as graphql-java's `-nf-` builds. A version it
matches is printed as the later pre-release, rather than left out of the report.

The default for `gradleReleaseChannel` now follows `rejectPreReleases`. At the
new default it stays `release-candidate`, so the Gradle release candidate is
still printed. Set `rejectPreReleases = true` and it becomes `current`, so the
release candidate is not. Setting `gradleReleaseChannel` in the build, passing
`--gradle-release-channel`, or setting the system property is read ahead of that.
`--reject-pre-releases` and `--no-reject-pre-releases` apply to both for one run.

On `master` today, with the defaults, a release candidate is printed for Gradle
and left out for a dependency:

```
The following dependencies have later milestone versions:
 - com.google.guava:guava [32.0.0-jre -> 33.7.1-jre]
 - org.slf4j:slf4j-api [2.0.9 -> 2.0.19]

Gradle release-candidate updates:
 - Gradle: [8.4 -> 9.7.1 -> 9.8.0-rc-1]
```

On `master` today, with `rejectPreReleases = false`, the 2.0.19 release is lost:

```
 - org.slf4j:slf4j-api [2.0.9 -> 2.1.0-alpha1]
```

On this branch, with the defaults:

```
The following dependencies have later milestone versions:
 - com.google.guava:guava [32.0.0-jre -> 33.7.1-jre]
 - org.slf4j:slf4j-api [2.0.9 -> 2.0.19 -> 2.1.0-alpha1]

Gradle release-candidate updates:
 - Gradle: [8.4 -> 9.7.1 -> 9.8.0-rc-1]
```

On this branch, with `rejectPreReleases = true`:

```
 - org.slf4j:slf4j-api [2.0.9 -> 2.0.19]

Gradle current updates:
 - Gradle: [8.4 -> 9.7.1]
```

Each step is printed only where it is later than the one before it, so a module
with no later stable release is printed as `[2.0.9 -> 2.1.0-alpha1]`.

Details:

- The pre-release step is the latest candidate that fails the pre-release check
  alone. The bound check, the revision and any `rejectVersionIf` filter are
  applied first, so a candidate already rejected by one of those is not printed.
- The step is in `available.preRelease` in the JSON and XML reports. Where there
  is no later stable release, `available.release`, `available.milestone` and
  `available.integration` are all null.
- A `rejectVersionIf` filter is now called for pre-release candidates it was
  never called for before, since the built-in check is applied last. If your
  filter has a side effect, it now happens for those candidates too.
- I bumped the partial report format to 3. Read by an older release, a partial
  written by a later one would have its `latestVersion` taken under the earlier
  meaning, and the bump makes that combination fail instead.
- I added a fourth constructor argument to `VersionAvailable`. Every arity
  shipped in the last release is still callable, so Groovy and Java callers are
  unaffected, but Kotlin code constructing one with named arguments needs
  recompiling.
