### PR TITLE
State every cause of an aggregation coordinate left out of the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -2127,16 +2127,17 @@ dependencies {
 
 </details>
 
-Whether a coordinate is substituted at all rests on two Gradle rules. A build
-included only under `pluginManagement` is not substituted from the including
-build's dependency graph, so declare a plain `includeBuild` for it in the
-aggregating settings as well. An `includeBuild` that declares a
-`dependencySubstitution` block keeps only the rules declared in it, the
-automatic `group:name` rule included, so a rule for the aggregated coordinates
-has to be declared there too. A coordinate substituted onto no project stays an
-external module and none of its entries are merged; it is printed in a warning
-rather than failing the build, so an entry left over from a build that is no
-longer included does not break the build.
+Whether a coordinate is substituted at all rests on its spelling and on two
+Gradle rules. The coordinates have to match the `group`, `name` and `version`
+set in the included build. A build included only under `pluginManagement` is
+not substituted from the including build's dependency graph, so declare a plain
+`includeBuild` for it in the aggregating settings as well. An `includeBuild`
+that declares a `dependencySubstitution` block keeps only the rules declared in
+it, the automatic `group:name` rule included, so a rule for the aggregated
+coordinates has to be declared there too. A coordinate substituted onto no
+project is left out of the report and none of its entries are merged; it is
+printed in a warning rather than failing the build, so an entry left over from
+a build that is no longer included does not break the build.
 
 The task that writes the report applies its settings to every entry in it,
 including the entries an included build resolved and the entries its subprojects

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Aggregation.kt
@@ -620,9 +620,11 @@ internal fun registerAggregation(
     )
     // The artifact view above is lenient and keeps only the project components, so a coordinate
     // that Gradle substitutes onto no project is dropped without a word and the report is printed
-    // short. Read from the resolution result, which the lenient view does not filter, and mapped
-    // through a provider so that the graph is walked at execution and the configuration cache
-    // stores the provider rather than the result.
+    // short. A misspelled coordinate and one that resolves to a module in a repository are both
+    // collected here, as neither was substituted and the two differ in the resolution result only
+    // by which repositories are declared in the build. Read from the resolution result, which the
+    // lenient view does not filter, and mapped through a provider so that the graph is walked at
+    // execution and the configuration cache stores the provider rather than the result.
     task.unaggregatedCoordinates.set(
       results.incoming.resolutionResult.rootComponent.map { root ->
         root.dependencies

--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/DependencyUpdatesTask.kt
@@ -505,7 +505,8 @@ open class DependencyUpdatesTask : DefaultTask() { // tasks can't be final
     if (unaggregated.isNotEmpty()) {
       logger.warn(
         "Left out of the dependency updates report: ${unaggregated.joinToString(", ")}, " +
-          "which resolved to an external module rather than to a project. A build included only " +
+          "which no included build was substituted for. Check the coordinates against the group, " +
+          "name and version set in the included build. A build included only " +
           "under pluginManagement is not substituted from the including build's dependency graph, " +
           "so declare a plain includeBuild for these coordinates as well. An includeBuild that " +
           "declares a dependencySubstitution block keeps only the rules declared in it, so declare " +

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/CompositeBuildSpec.groovy
@@ -3056,8 +3056,74 @@ final class CompositeBuildSpec extends Specification {
     then: "the coordinate is named, and the child's row is absent"
     result.task(':dependencyUpdates').outcome == SUCCESS
     result.output.contains(
-      'Left out of the dependency updates report: com.example:child:1.0, which resolved to an ' +
-        'external module rather than to a project.')
+      'Left out of the dependency updates report: com.example:child:1.0, which no included ' +
+        'build was substituted for.')
+    !result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
+  }
+
+  def 'Warns of an aggregated coordinate that resolves to nothing'() {
+    given: 'the coordinate misnames the group of the build that is included'
+    testProjectDir.newFile('settings.gradle') << "includeBuild 'child'"
+    testProjectDir.newFile('build.gradle') <<
+      """
+        plugins {
+          id 'io.github.ben-manes.versions'
+        }
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          dependencyUpdatesAggregation 'com.exampl:child:1.0'
+        }
+
+        tasks.named('dependencyUpdates').configure {
+          checkForGradleUpdate = false
+        }
+      """.stripIndent()
+    includedBuild(
+      'child',
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'io.github.ben-manes.versions'
+
+        group = 'com.example'
+        version = '1.0'
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        configurations.create('tool') {
+          canBeResolved = true
+          canBeConsumed = false
+        }
+
+        dependencies {
+          tool 'com.example:jvm-library:1.0'
+        }
+      """.stripIndent(),
+    )
+
+    when:
+    def result = run('dependencyUpdates')
+
+    then: "the coordinate is named, and the child's row is absent"
+    result.task(':dependencyUpdates').outcome == SUCCESS
+    result.output.contains(
+      'Left out of the dependency updates report: com.exampl:child:1.0, which no included build ' +
+        'was substituted for. Check the coordinates against the group, name and version set in ' +
+        'the included build.')
     !result.output.contains('com.example:jvm-library [1.0 -> 2.0]')
   }
 }


### PR DESCRIPTION
This PR corrects the warning added in #1094 for an aggregation coordinate that no included build was substituted for. A misspelled coordinate is left out the same way, and the cause given in the old text is wrong for it.

Before, for `dependencyUpdatesAggregation 'com.exampl:child:1.0'` against an included `child` at `com.example:child:1.0`:

> Left out of the dependency updates report: com.exampl:child:1.0, which resolved to an external module rather than to a project. A build included only under pluginManagement is not substituted from the including build's dependency graph, so declare a plain includeBuild for these coordinates as well. An includeBuild that declares a dependencySubstitution block keeps only the rules declared in it, so declare a rule for these coordinates there too.


After:

> Left out of the dependency updates report: com.exampl:child:1.0, which no included build was substituted for. Check the coordinates against the group, name and version set in the included build. A build included only under pluginManagement is not substituted from the including build's dependency graph, so declare a plain includeBuild for these coordinates as well. An includeBuild that declares a dependencySubstitution block keeps only the rules declared in it, so declare a rule for these coordinates there too.
