### PR TITLE
Prepare the v0.62.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2492,15 +2492,14 @@ and *Note*s are things worth knowing that need no action.
 
 ### v0.61.0
 
-In the next release, a pre-release candidate is printed as a step after the
-newest release rather than in place of it, the report is restricted to the
-bounds written in the build without a rule to apply them, a coordinate with
-one declared version and different latest versions across the aggregated
-projects is printed on one entry per latest version, where the entries were
-merged into the newest of them before, the settings configured on an
-aggregating task are applied to the entries merged from an included build, and
-the platform behind a constrained module's version is printed on the entry for
-that module:
+In v0.62.0, a pre-release candidate is printed as a step after the newest
+release rather than in place of it, the report is restricted to the bounds
+written in the build without a rule to apply them, a coordinate with one
+declared version and different latest versions across the aggregated projects
+is printed on one entry per latest version, where the entries were merged into
+the newest of them before, the settings configured on an aggregating task are
+applied to the entries merged from an included build, and the platform behind
+a constrained module's version is printed on the entry for that module:
 
 > [!IMPORTANT]
 > - A row's `available` version is now the newest release, and a newer

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ben-manes
-VERSION_NAME=0.61.0
+VERSION_NAME=0.62.0
 
 POM_URL=https://github.com/ben-manes/gradle-versions-plugin
 POM_SCM_URL=https://github.com/ben-manes/gradle-versions-plugin


### PR DESCRIPTION
Bumps the version for the v0.62.0 release. I checked the public API against v0.61.0, and every constructor arity and `copy` that release shipped is still callable.

Draft release notes below. Let me know if there's anything more you want included in this release.

---
* Print the newest pre-release as a step after the newest release, where the pre-release was printed in place of the release (#1097)
* Add a built-in pre-release check, and a `rejectPreReleases` property to leave the pre-release step out, in place of the `isNonStable` recipe in the README (#440, #1093)
* Restrict the report to the bounds declared in the build, with a `rejectOutOfBounds` property in place of the `rejectVersionIf { !satisfiesDeclaredBound }` recipe, and deprecate `satisfiesDeclaredBound` for removal (#1092)
* Apply the `rejectVersionIf`, `resolutionStrategy`, `rejectPreReleases`, `preReleaseVersionIf`, `exemptFromBuiltInChecksIf` and `filterDeclaredConfigurations` configured on the aggregating task to the entries merged from an included build, so a composite is configured in one place, as a multi-project build already is (#1094)
* Accept every task setting with a plain value as a command line option, so what is in the report can be changed for a single run without an edit to the build script (#1085)
* Print the platform behind a constrained module's version on the entry for that module, for a `java-platform` project in the build and for an imported BOM (#1080, #1081)
* Split an aggregated coordinate into one entry per latest version found, where the entries were merged into the newest version and that version was printed for the projects it is not available in (#1082, #1083)
* Exempt the plugin's version lookups from the build's dependency verification, where the task failed on Gradle 8.7 and later in a build with verification enabled (#1095, #1096)
* Read back `revision`, `checkConstraints` and `checkBuildEnvironmentConstraints` as the values inherited from an ancestor project, where the unconfigured default was read back and the report was resolved with the inherited value (#1086, #1087)
* Read a dynamic version declared on the buildscript classpath as a bound, so for a plugin versioned inline as a range in the `plugins` block, the presence of a version catalog no longer changes whether an upgrade past that range is printed (#1090, #1091)
* Correct the warning for an aggregation coordinate left out of the report, where the one cause printed for it was wrong for a misspelled coordinate (#1098)
* Document the `dependencyUpdatesAggregation` configuration for merging an included build, and drop the claim in the composite builds section that no merged report spans builds (#1079)
* Test against Gradle 9.7.1 from a single pin (#1088)
* Improve the README and code documentation phrasing (#1084, #1101)
* Correct the documentation, and fix the defects found reviewing the changes since v0.61.0 (#1099, #1100, #1103)

> [!IMPORTANT]
> * A row's `available` version is now the newest release, and a newer pre-release is printed beside it in `available.preRelease`, where the pre-release was the `available` version before. Both are printed in a plain text row, as `[2.4.0 -> 2.4.10 -> 2.4.20-beta1]`. Reading `available.release`, `available.milestone` or `available.integration` yields the newest release rather than the pre-release, and null where the only newer candidate is a pre-release, since no newer release was found. A tool that prints one version for the row falls back to `available.preRelease` after those three. Set `rejectPreReleases = true` to leave the pre-release step out altogether, or pass `--reject-pre-releases` for a single run.
> * An attribution line reading `constrained by the platform :platform`, with the platform project or BOM behind the version, can now be printed under an entry. It does not depend on `checkConstraints`, and it is printed under an up to date entry as well as an outdated one, so a tool that parses the plain text report line by line has to skip it, as it already does for the other attribution lines. The same names are printed in the JSON and XML reports, in `constrainedBy`.
>
> See [Migrating from prior versions](https://github.com/ben-manes/gradle-versions-plugin#v0610).

> [!TIP]
> * The `isNonStable` recipe formerly recommended in the README can be dropped, along with the `rejectVersionIf` clause that called it. The built-in check matches pre-release markers rather than a stable pattern, so a qualifier not in its list, such as `13.4.0.jre11`, stays in the report. A convention not in the marker list, such as graphql-java's `-nf-` builds, is added to the check with [`preReleaseVersionIf`](https://github.com/ben-manes/gradle-versions-plugin#filtering-unstable-versions), so the property and its option apply to it too, and it is off wherever the property is off.
> * Drop `!satisfiesDeclaredBound` from a `rejectVersionIf` rule, since the bound is now applied by [`rejectOutOfBounds`](https://github.com/ben-manes/gradle-versions-plugin#respecting-declared-bounds). A module that needs an exception from a bound is exempted with `exemptFromBuiltInChecksIf`. The member is deprecated and will be removed in a later release; a warning is printed once per project where a rule still reads `satisfiesDeclaredBound`, so the clause has to be dropped before upgrading a Kotlin DSL build configured to treat compiler warnings as errors. With the clause still in a rule, the same candidates are rejected under `--no-reject-out-of-bounds` as without it.

> [!NOTE]
> * A `rejectVersionIf` filter is now applied to a pre-release candidate before the built-in check leaves it out, where the built-in check ran first and no pre-release candidate reached the filter. A filter with a side effect now runs for those candidates too.
> * `gradleReleaseChannel`'s default is now read from `rejectPreReleases`, so the Gradle release candidate is no longer reported in a build where every dependency's pre-release step is left out. The default is unchanged at `release-candidate` where `rejectPreReleases` is left alone, and stating the property or passing the option is still read ahead of it.
> * A candidate outside a `strictly` or `reject` bound written in the build, outside a dynamic version declared on the buildscript classpath, or outside the version fixed by a consumed platform, is left out of the report, where it was listed before. Set `rejectOutOfBounds = false` to list it again, or pass `--no-reject-out-of-bounds` for a single run.
> * A coordinate's group and name can now appear on two entries of one report, and in two of its sections. The projects for each entry are included in `projects`, which is what distinguishes the entries. A tool that keys them by group and name alone has to key them by the projects as well.
> * Every project of the build declared in a `dependencyUpdatesAggregation` entry is now merged, where only the project the coordinates resolved to was merged before. In a composite where every project of an included build was declared, the build alone can be declared now.
> * The `rejectVersionIf`, `resolutionStrategy`, `rejectPreReleases`, `preReleaseVersionIf`, `exemptFromBuiltInChecksIf` and `filterDeclaredConfigurations` configured on the aggregating task are applied to every entry in the report, both the ones resolved in an included build and the ones resolved in its subprojects. Before, the version printed for a merged entry came from the settings configured in the included build or the subproject. Now an older version can be printed on such an entry, and an entry can be left out entirely. Where a version accepted in a subproject is rejected for the project the report is asked for, two entries a per-project rule would have split apart are printed as one.
> * The configuration cache entry is discarded for a report that merges an included build's entries, where a Kotlin rule calls a function declared in the same build script. Move the function into a compiled class, in `buildSrc` or an included build, to keep the entry. A Groovy build is unaffected.
> * Newer pre-releases are still reported when the current version is itself a pre-release.
> * A module with only pre-releases published, and the declared version no longer among them, is reported as unresolved rather than as up to date, since every candidate is rejected.
> * For a plugin versioned inline as a range in the `plugins` block, the presence of a version catalog no longer changes whether an upgrade past that range is printed. The upgrade was left out when an unused alias for the same plugin was present in the catalog, and printed when it was not.
> * A module that a platform bounds in one project and not in another is now up to date in the bounded project and outdated in the other, rather than outdated in both. An upgrade not available in the bounded project was printed on the merged entry.
> * A split entry can include an attribution line left out of the merged one. The line is left out where the module is declared in a project outside the platform's importers. Once the entries are split, that project appears on an entry of its own, so the line is printed again.
> * A version resolved in no build is printed on an entry moved to an older version by the aggregating build's rules. A version accepted in a build came through the full status-aware resolution there, and a version below it did not.
> * A fourth `preRelease` argument was added to `VersionAvailable`, and a further `constrainedBy` one to `Dependency`, `DependencyOutdated`, `DependencyLatest` and `DependencyUnresolved`. Every constructor arity and every `copy` the last release shipped is still callable, so Java and Groovy callers are unaffected. Kotlin code that constructs one of these while leaving an argument to its default has to be recompiled. A formatter that only reads the report, as the documented ones do, needs nothing.

