### PR TITLE
Opt out of dependency verification only where the build verifies

### DIFF
--- a/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
+++ b/gradle-versions-plugin/src/main/kotlin/com/github/benmanes/gradle/versions/updates/Resolver.kt
@@ -98,6 +98,14 @@ class Resolver internal constructor(
       { current -> exemptFromBuiltInChecksIf.reject(current) }
     }
 
+  // https://github.com/ben-manes/gradle-versions-plugin/issues/1095
+  // Gradle prints a line at the default log level for every configuration that opts out of
+  // dependency verification, so a build that verifies nothing would be told hundreds of times
+  // about an opt out it has no use for. Verification runs from the metadata file alone, so where
+  // that file is absent no lookup can fail one.
+  private val verifiesDependencies: Boolean =
+    project.rootDir.resolve("gradle/verification-metadata.xml").exists()
+
   private var projectUrls = ConcurrentHashMap<ModuleVersionIdentifier, ProjectUrl>()
 
   // One comparator for the resolver, where the configurations of a project resolve concurrently:
@@ -118,6 +126,13 @@ class Resolver internal constructor(
 
   init {
     logRepositories()
+  }
+
+  /** Exempts a lookup from dependency verification, in a build that verifies at all. */
+  private fun exemptFromDependencyVerification(copy: Configuration) {
+    if (verifiesDependencies) {
+      copy.resolutionStrategy.disableDependencyVerification()
+    }
   }
 
   /** Returns the declared dependency keys of the configuration, before lazy actions contribute. */
@@ -283,7 +298,7 @@ class Resolver internal constructor(
     // https://github.com/ben-manes/gradle-versions-plugin/issues/1095
     // The candidate versions cannot be in the build's verification metadata, as they are the newer
     // versions being searched for.
-    copy.resolutionStrategy.disableDependencyVerification()
+    exemptFromDependencyVerification(copy)
 
     addDeclaredBoundFilter(copy, current.coordinates)
     addRevisionFilter(copy, revision, current.coordinates)
@@ -364,7 +379,7 @@ class Resolver internal constructor(
     // https://github.com/ben-manes/gradle-versions-plugin/issues/1095
     // As for the copy that resolves the latest versions: the candidates walked here are the newer
     // versions being searched for, so none of them can be in the build's verification metadata.
-    copy.resolutionStrategy.disableDependencyVerification()
+    exemptFromDependencyVerification(copy)
     recordCandidates(copy)
     copy.incoming.resolutionResult.root
   }
@@ -670,7 +685,7 @@ class Resolver internal constructor(
     copy.resolutionStrategy.deactivateDependencyLocking()
 
     // https://github.com/ben-manes/gradle-versions-plugin/issues/1095
-    copy.resolutionStrategy.disableDependencyVerification()
+    exemptFromDependencyVerification(copy)
 
     disableAutoTargetJvm(copy)
     val root = copy.incoming.resolutionResult.root
@@ -816,7 +831,7 @@ class Resolver internal constructor(
     copy.resolutionStrategy.deactivateDependencyLocking()
 
     // https://github.com/ben-manes/gradle-versions-plugin/issues/1095
-    copy.resolutionStrategy.disableDependencyVerification()
+    exemptFromDependencyVerification(copy)
     disableAutoTargetJvm(copy)
     copy.dependencies.clear()
     // Copied rather than shared, as copyRecursive does for the set cleared above: a withDependencies
@@ -1082,7 +1097,7 @@ class Resolver internal constructor(
             }
           }
       val copy = project.configurations.detachedConfiguration(pom).setTransitive(false)
-      copy.resolutionStrategy.disableDependencyVerification()
+      exemptFromDependencyVerification(copy)
 
       // Resolved leniently, so that a module published without a pom is not an error. The
       // failures are logged rather than dropped, as a repository that cannot be reached would

--- a/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
+++ b/gradle-versions-plugin/src/test/groovy/com/github/benmanes/gradle/versions/DifferentGradleVersionsSpec.groovy
@@ -279,6 +279,45 @@ final class DifferentGradleVersionsSpec extends Specification {
     GradleVersions.CURRENT | true
   }
 
+  @Issue('https://github.com/ben-manes/gradle-versions-plugin/issues/1095')
+  def 'dependencyUpdates task leaves the verification opt out alone where the build has no metadata'() {
+    given: 'a build with no verification metadata, which verifies nothing'
+    buildFile = testProjectDir.newFile('build.gradle')
+    buildFile <<
+      """
+        buildscript {
+          dependencies {
+            classpath files($classpathString)
+          }
+        }
+
+        apply plugin: 'java'
+        apply plugin: "io.github.ben-manes.versions"
+
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+
+        dependencies {
+          implementation 'com.google.inject:guice:3.0'
+        }
+        """.stripIndent()
+
+    when: 'the oldest release that needs the exemption runs it, so every JVM leg covers this'
+    def result = GradleRunner.create()
+      .withGradleVersion('8.14.4')
+      .withProjectDir(testProjectDir.root)
+      .withArguments('dependencyUpdates')
+      .build()
+
+    then: 'Gradle prints its opt out line for every configuration that opts out, so none opts out'
+    result.output.contains('com.google.inject:guice [3.0 -> 3.1]')
+    !result.output.contains('Dependency verification has been disabled')
+    result.task(':dependencyUpdates').outcome == SUCCESS
+  }
+
   def 'dependencyUpdates task completes without errors if configuration cache is enabled'() {
     given:
     buildFile = testProjectDir.newFile('build.gradle')


### PR DESCRIPTION
This PR opts out of dependency verification only where the build has verification metadata. Gradle prints a line at the default log level for every configuration that opts out, and the version lookups opt out on every resolution pass, so a build that verifies nothing is told about it hundreds of times. On a 22-project build with no `gradle/verification-metadata.xml`, `dependencyUpdates` printed this 730 times, where v0.61.0 printed it none:

```text
Dependency verification has been disabled.
```

Its console output went from 132 lines on v0.61.0 to 900 on master, and to 169 with this change, where the rest of the increase is the `satisfiesDeclaredBound` deprecation warning. The report is unchanged, and the exemption still applies wherever the metadata file exists, which is what #1096's own test covers.
